### PR TITLE
Bug in the str(Quantity.units) when multiple units in the denominator

### DIFF
--- a/pint/pint.py
+++ b/pint/pint.py
@@ -264,7 +264,11 @@ class UnitsContainer(dict):
                 if single_denominator:
                    ret += ' / '.join(tmp_minus)
                 else:
+                   if len(tmp_minus) > 1:
+                       ret += '('
                    ret += product_sign.join(tmp_minus)
+                   if len(tmp_minus) > 1:
+                       ret += ')'
             else:
                 ret += product_sign.join(tmp_minus)
 

--- a/tests/test_pint.py
+++ b/tests/test_pint.py
@@ -374,6 +374,10 @@ class TestPint(TestCase):
         self.assertEqual(self.Q_(1, 'meter')/self.Q_(1, 'meter'), 1)
         self.assertEqual((self.Q_(1, 'meter')/self.Q_(1, 'mm')).to(''), 1000)
 
+    def test_multiple_denominators(self):
+        x = self.Q_(1, 'g/(m**2*s)')
+        self.assertEqual(x, self.Q_(x.magnitude, str(x.units)))
+
     @unittest.expectedFailure
     def test_offset(self):
         self.assertAlmostEqual(self.Q_(0, 'degK').to('degK'), self.Q_(0, 'degK'))


### PR DESCRIPTION
example of bug:
    q = Q_(1, 'g/(m*_2_s)')
    # gram / meter *\* 2 \* seconds
    # not gram / (meter **2 \* seconds)

Test is added.  Note tests/test_pint.py passes.  Others fail consistently
before and after this change.

I expect that I can save a Quantity as a tuple (q.magnitude, str(q.units) to a database and reconstruct the quantity by Quantity(\* (q.magnitude, str(q.units) ).

This fails when multiple units are in the denominator.  The denominator needs to be wrapped in parens to get the correct operator precedence when re-parsing the units. 
