### PR TITLE
Fix sidebar URL to GitHub project

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -13,7 +13,7 @@ You are currently looking at the documentation of version {{ version }}.
 <h3>Useful Links</h3>
 <ul>
   <li><a href="https://pypi.python.org/pypi/Pint/">Pint @ PyPI</a></li>
-  <li><a href="https://github.com/hgrecco/lantz">Code in GitHub</a></li>
+  <li><a href="https://github.com/hgrecco/pint">Code in GitHub</a></li>
   <li><a href="https://github.com/hgrecco/pint/issues">Issue Tracker</a></li>
 </ul>
 


### PR DESCRIPTION
The sidebar on the project's webpage points to the wrong GitHub project.  This fixes it.

I just found this project while searching for a Python units library.  It looks really useful.  Thanks for your work and for making it freely available!
