### PR TITLE
Fixed formatting of fractional exponentials between 0 and 1.

### DIFF
--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -120,3 +120,8 @@ class TestIssuesNP(TestCase):
         Q_ = ureg.Quantity
         self.assertEqual(Q_(100), 100 * ureg.dimensionless)
         self.assertEqual(Q_('100'), 100 * ureg.dimensionless)
+
+    def test_issue62(self):
+        ureg = UnitRegistry()
+        m = ureg['m**0.5']
+        self.assertEqual(str(m.units), 'meter ** 0.5')

--- a/pint/util.py
+++ b/pint/util.py
@@ -164,7 +164,7 @@ def formatter(items, as_ratio=True, single_denominator=False,
     for key, value in sorted(items):
         if value == 1:
             pos_terms.append(key)
-        elif value > 1:
+        elif value > 0:
             pos_terms.append(power_fmt.format(key, fun(value)))
         elif value == -1:
             neg_terms.append(key)


### PR DESCRIPTION
This is a proposed fix for Issue #62. I've never done a fork/pull request on Github, so tell me anything you want me to do differently. Also, I ran all of the tests, but please make sure nothing else breaks from this fix :)
