### PR TITLE
Fix for Issue #80: Integer Division with Arrays

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -323,10 +323,7 @@ class _Quantity(object):
 
     def __itruediv__(self, other):
         if _check(self, other):
-            # We use a = a / b instead of a /= b because a /= b causes
-            # inplace integer division if the first array is an
-            # integer array.
-            self._magnitude = self._magnitude / other._magnitude
+            self._magnitude /= other._magnitude
             self._units /= other._units
         else:
             self._magnitude /= _to_magnitude(other, self.force_ndarray)
@@ -335,7 +332,13 @@ class _Quantity(object):
 
     def __truediv__(self, other):
         ret = copy.copy(self)
-        ret /= other
+        if _check(ret, other):
+            ret._magnitude = ret._magnitude / other._magnitude
+            ret._units /= other._units
+        else:
+            ret._magnitude = (ret._magnitude /
+                              _to_magnitude(other, ret.force_ndarray))
+
         return ret
 
     def __rtruediv__(self, other):
@@ -354,7 +357,12 @@ class _Quantity(object):
 
     def __floordiv__(self, other):
         ret = copy.copy(self)
-        ret //= other
+        if _check(ret, other):
+            ret._magnitude = ret._magnitude // other._magnitude
+            ret._units /= other._units
+        else:
+            ret._magnitude = (ret._magnitude //
+                              _to_magnitude(other, ret.force_ndarray))
         return ret
 
     __div__ = __truediv__

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -163,8 +163,11 @@ class TestNumpyMethods(TestCase):
     def test_integer_div(self):
         a = [1] * self.ureg.m
         b = [2] * self.ureg.m
-        c = a/b
+        c = a/b  # Should be float division
         self.assertEqual(c.magnitude[0], 0.5)
+
+        a /= b  # Should be integer division
+        self.assertEqual(a.magnitude[0], 0)
 
     def test_conj(self):
         self.assertSequenceEqual((self.q*(1+1j)).conj(), self.q*(1-1j))


### PR DESCRIPTION
This fixes #80. Numpy has an issue with the /= operator for integers:

``` python
>>> a = np.array([1])

>>> b = np.array([2])

>>> a/b  # Correct
array([ 0.5])

>>> a/=b

>>> a  # Different from a/b
array([0])
```

This is a workaround. I will post this issue to the numpy repository.
