### PR TITLE
Stop raising AttributeError when wrapping funcs

### DIFF
--- a/pint/unit.py
+++ b/pint/unit.py
@@ -1071,7 +1071,9 @@ class UnitRegistry(object):
             ret = self.parse_units(ret)
 
         def decorator(func):
-            @functools.wraps(func)
+            assigned = tuple(attr for attr in functools.WRAPPER_ASSIGNMENTS if hasattr(func, attr))
+            updated = tuple(attr for attr in functools.WRAPPER_UPDATES if hasattr(func, attr))
+            @functools.wraps(func, assigned=assigned, updated=updated)
             def wrapper(*values, **kw):
                 new_args = []
                 for unit, value in zip(units, values):


### PR DESCRIPTION
Before Python 3.2, `functools.wraps` (used in `UnitRegistry.wraps`) raised an `AttributeError` when wrapping functions without all of the attributes in `functools.WRAPPER_ASSIGNMENTS` and `functools.WRAPPER_UPDATES`. In Python 3.2, this limitation was removed. This commit removes the limitation in older versions of Python, as well.

For example, `scipy.optimize.interp1d` creates functions without a `__name__` attribute. Trying to use `UnitRegistry.wraps` with them failed on Python 2.7; this commit fixes the issue.
