### PR TITLE
Correct symbol translation for inches and feet

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -139,8 +139,8 @@ baud = bit / second = Bd = bps
 
 # Length
 angstrom = 1e-10 * meter
-inch = 2.54 * centimeter = international_inch = inches = international_inches = in
-foot = 12 * inch = international_foot = ft = feet = international_foot = international_feet
+inch = 2.54 * centimeter = in = international_inch = inches = international_inches 
+foot = 12 * inch = ft = international_foot = feet = international_feet
 mile = 5280 * foot = mi = international_mile
 yard = 3 * feet = yd = international_yard
 mil = inch / 1000 = thou

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -254,6 +254,14 @@ class TestRegistry(TestCase):
         self.assertEqual(self.ureg.get_symbol('megahertz'), 'MHz')
         self.assertEqual(self.ureg.get_symbol('millisecond'), 'ms')
 
+    def test_imperial_symbol(self):
+        self.assertEqual(self.ureg.get_symbol('inch'), 'in')
+        self.assertEqual(self.ureg.get_symbol('foot'), 'ft')
+        self.assertEqual(self.ureg.get_symbol('inches'), 'in')
+        self.assertEqual(self.ureg.get_symbol('feet'), 'ft')
+        self.assertEqual(self.ureg.get_symbol('international_foot'), 'ft')
+        self.assertEqual(self.ureg.get_symbol('international_inch'), 'in')
+
     @unittest.expectedFailure
     def test_delta_in_diff(self):
         """This might be supported in future versions


### PR DESCRIPTION
get_symbol('inch') should return 'in' not 'international_inch'.
This seems be a definition error.

This commit provides the updated definition and related test.
