### PR TITLE
Fix bug where conversion would fail because of caching

### DIFF
--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -488,6 +488,11 @@ class TestRegistry(QuantityTestCase):
             np.testing.assert_allclose(r2, v * ac)
             self.assertIs(r2, a)
 
+    def test_repeated_convert(self):
+        # Because of caching, repeated conversions were failing.
+        self.ureg.convert(1, "m", "ft")
+        self.ureg.convert(1, "m", "ft")
+
     def test_parse_units(self):
         ureg = self.ureg
         self.assertEqual(ureg.parse_units(''), UnitsContainer())

--- a/pint/util.py
+++ b/pint/util.py
@@ -244,8 +244,12 @@ class ParserHelper(dict):
         return ret
 
     @classmethod
-    @lru_cache()
     def from_string(cls, input_string):
+        return cls._from_string(input_string).copy()
+
+    @classmethod
+    @lru_cache()
+    def _from_string(cls, input_string):
         """Parse linear expression mathematical units and return a quantity object.
         """
 
@@ -287,6 +291,9 @@ class ParserHelper(dict):
         return ParserHelper(ret.scale,
                             dict((key.replace('__obra__', '[').replace('__cbra__', ']'), value)
                                  for key, value in ret.items()))
+
+    def copy(self):
+        return ParserHelper(scale=self.scale, **self)
 
     def __missing__(self, key):
         return 0.0


### PR DESCRIPTION
I was experiencing an annoying error where repeated calls of `ureg.convert` would fail because the `lru_cache` on `ParserHelper.from_string` would return the already-modified object from the previous conversion:

``` python
>>> ureg.convert(1, "m", "ft")
3.280839895013123

>>> ureg.convert(1, "m", "ft")
---------------------------------------------------------------------------
DimensionalityError                       Traceback (most recent call last)
<ipython-input-3-20b4654f9b60> in <module>()
----> 1 ureg.convert(1, "m", "ft")

/home/david/Dropbox/.virtualenvs/frackoptima/lib/python3.4/site-packages/pint/unit.py in convert(self, value, src, 
dst, inplace)                                                                                                     
    995 
    996         if src_dim != dst_dim:
--> 997             raise DimensionalityError(src, dst, src_dim, dst_dim)
    998 
    999         if len(src) == 1:

DimensionalityError: Cannot convert from '1.0 {'ft': -1.0, 'm': 1.0}' (dimensionless) to '1 {'ft': 1.0}' ([length])
```

I tried making the `ParserHelper.from_string` function always return a copy by doing something like this:

``` python
@classmethod
def from_string(cls, input_string):
    return cls.cached_from_string(input_string).copy()
    # Note that pull request defined ParserHelper.copy()

@classmethod
@lru_cache()
def cached_from_string(cls, input_string):
    # Contents of old from_string function
    ...

```

However, this caused a recursion limit error when loading the definitions file. For a quick fix, I just slapped `copy()` calls on the `from_string` calls inside the convert function only.

I also added a test that reproduced the bug.
