### PR TITLE
Fix error with package setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except:
     pass
 
 try:
-    from setuptools import setup
+    from setuptools import setup, find_packages
 except ImportError:
     from distutils.core import setup
 
@@ -36,7 +36,7 @@ setup(
     url='https://github.com/hgrecco/pint',
     test_suite='pint.testsuite.testsuite',
     zip_safe=True,
-    packages=['pint'],
+    packages=find_packages(),
     package_data={
         'pint': ['default_en.txt',
                  'constants_en.txt']


### PR DESCRIPTION
When `setup.py install` is called, subpackages are not installed and `pint`
fails to import in Python. Using the `find_packages()` method solves that
by looking for all packages and subpackages and adding them to the install procedure. I have tested it and it seems to work. Now I can use `pint` on my machine (Windows 7).

This should also solve the error I got when trying to install the package using `pip install pint`: the subpackages were missing.
