### PR TITLE
Fixed download links in documentation

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -7,8 +7,8 @@ You are currently looking at the documentation of version {{ version }}.
 </p>
 <ul>
   <li><a href="https://media.readthedocs.org/pdf/pint/latest/pint.pdf">as PDF</a>
-  <li><a href="https://media.readthedocs.org/htmlzip/pint/latest/pint.zip">as ePub</a>
-  <li><a href="https://media.readthedocs.org/epub/pint/latest/pint.epub">as zipped HTML</a>
+  <li><a href="https://media.readthedocs.org/htmlzip/pint/latest/pint.zip">as zipped HTML</a>
+  <li><a href="https://media.readthedocs.org/epub/pint/latest/pint.epub">as ePub</a>
 </ul>
 <h3>Useful Links</h3>
 <ul>

--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -11,8 +11,8 @@ You are currently looking at the documentation of version {{ version }}.
 </p>
 <ul>
   <li><a href="https://media.readthedocs.org/pdf/pint/latest/pint.pdf">as PDF</a>
-  <li><a href="https://media.readthedocs.org/htmlzip/pint/latest/pint.zip">as ePub</a>
-  <li><a href="https://media.readthedocs.org/epub/pint/latest/pint.epub">as zipped HTML</a>
+  <li><a href="https://media.readthedocs.org/htmlzip/pint/latest/pint.zip">as zipped HTML</a>
+  <li><a href="https://media.readthedocs.org/epub/pint/latest/pint.epub">as ePub</a>
 </ul>
 <h3>Useful Links</h3>
 <ul>


### PR DESCRIPTION
Download links for ePub and zipped HTML were switched around.
