### PR TITLE
Provide ``to_common`` method

### DIFF
--- a/pint/__init__.py
+++ b/pint/__init__.py
@@ -17,7 +17,7 @@ import subprocess
 import pkg_resources
 from .formatting import formatter
 from .unit import (UnitRegistry, DimensionalityError, OffsetUnitCalculusError,
-                   UndefinedUnitError, LazyRegistry)
+                   UndefinedUnitError, LazyRegistry, to_common)
 from .util import pi_theorem, logger
 
 from .context import Context

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -10,7 +10,7 @@ import operator as op
 from pint.unit import (ScaleConverter, OffsetConverter, UnitsContainer,
                        Definition, PrefixDefinition, UnitDefinition,
                        DimensionDefinition, _freeze, Converter, UnitRegistry,
-                       LazyRegistry, ParserHelper)
+                       LazyRegistry, ParserHelper, to_common)
 from pint import DimensionalityError, UndefinedUnitError
 from pint.compat import u, unittest, np, string_types
 from pint.testsuite import QuantityTestCase, helpers, BaseTestCase
@@ -550,6 +550,13 @@ class TestCompatibleUnits(QuantityTestCase):
         self.assertEqual(ureg.get_compatible_units(''), (1, UnitsContainer()))
         self.assertEqual(ureg.get_compatible_units('meter'), ureg.get_compatible_units(ParserHelper(meter=1)))
 
+    def test_to_common(self):
+        ureg = UnitRegistry()
+        data = [ ureg.parse_expression(q) for q in
+                ('3 cm', '2.4 in', '9.1 cm', '0.04 ft')]
+        result = to_common(data)
+        self.assertEqual(result, [ ureg.parse_expression(q) for q in
+                ('3 cm', '6.096 cm', '9.1 cm', '1.2192 cm')])
 
 class TestRegistryWithDefaultRegistry(TestRegistry):
 

--- a/pint/unit.py
+++ b/pint/unit.py
@@ -21,7 +21,7 @@ from decimal import Decimal
 from contextlib import contextmanager
 from io import open, StringIO
 from numbers import Number
-from collections import defaultdict
+from collections import defaultdict, Counter
 from tokenize import untokenize, NUMBER, STRING, NAME, OP
 
 from .context import Context, ContextChain, _freeze
@@ -1375,3 +1375,16 @@ class LazyRegistry(object):
     def __call__(self, *args, **kwargs):
         self.__init()
         return self(*args, **kwargs)
+
+
+def to_common(quantities):
+    """
+    Given: an iterable of Quantities
+    Return: the quantities converted to the unit most frequently
+            occuring
+    """
+    quants = list(quantities)
+    data = Counter(str(q.units) for q in quants)
+    most_common = data.most_common(1)[0][0]
+    return [q.to(most_common) for q in quants]
+


### PR DESCRIPTION
Feel free to ignore if this convenience function doesn't fit in your vision, but it's useful for me.

I wasn't sure where (or whether) it would fit into your docs structure, so I didn't write any.  At least it's got a docstring!