### PR TITLE
symbol accessor optimization for string formatting

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -126,7 +126,7 @@ class _Quantity(object):
         spec = spec or self.default_format
 
         if '~' in spec:
-            units = UnitsContainer(dict((self._REGISTRY.get_symbol(key), value)
+            units = UnitsContainer(dict((self._REGISTRY._get_symbol(key), value)
                                    for key, value in self.units.items()))
             spec = spec.replace('~', '')
         else:

--- a/pint/unit.py
+++ b/pint/unit.py
@@ -880,6 +880,9 @@ class UnitRegistry(object):
 
         return self._prefixes[prefix].symbol + self._units[unit_name].symbol
 
+    def _get_symbol(self, name):
+        return self._units[name].symbol
+
     def get_dimensionality(self, input_units):
         """Convert unit or dict of units or dimensions to a dict of base dimensions
 


### PR DESCRIPTION
The get_symbol registry method goes through string parsing and various lookups which seem oriented towards accepting unsanitized user input.  I would expect that the units in a UnitsContainer are all known to be valid and so we can short-circuit that process.  This patch implements that idea by directly looking up the name in the _units dict.  This results in 2x-3x speed increase for `{:~}.format(thing)` calls.

Here is an example script and improved performance.

```
#  This script illustrates the performance of the string formatters.
from __future__ import print_function

import pint
import timeit
ureg = pint.UnitRegistry()

q = 34.*ureg.cm
print("{:~}".format(q))
t = timeit.timeit('"{:~}".format(q)', setup='from __main__ import q', number=100)
print(t)

q = 34.*ureg.cm**3*ureg.g
print("{:~}".format(q))
t = timeit.timeit('"{:~}".format(q)', setup='from __main__ import q', number=100)
print(t)

q = 34.*ureg.V
print("{:~}".format(q))
t = timeit.timeit('"{:~}".format(q)', setup='from __main__ import q', number=100)
print(t)
```

```
# ORIGINAL OUTPUT
34.0 cm
0.00538087748031
34.0 cm ** 3 * g
0.0091122678241
34.0 V
0.00510761454672
```

```
#  NEW OUTPUT
34.0 cm
0.00193115816038
34.0 cm ** 3 * g
0.0030094957368
34.0 V
0.00205457691391
```
