### PR TITLE
Add "hectare" as a supported unit of area

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -138,6 +138,10 @@ counts_per_second = count / second = cps
 byte = 8 * bit = Bo = octet
 baud = bit / second = Bd = bps
 
+# Irradiance
+peak_sun_hour = 1000 * watt_hour / meter**2 = PSH
+langley = thermochemical_calorie / centimeter**2 = Langley
+
 # Length
 angstrom = 1e-10 * meter = ångström = Å
 inch = 2.54 * centimeter = in = international_inch = inches = international_inches 

--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -66,6 +66,7 @@ barn = 1e-28 * m ** 2 = b
 cmil = 5.067075e-10 * m ** 2 = circular_mils
 darcy = 9.869233e-13 * m ** 2
 acre = 4046.8564224 * m ** 2 = international_acre
+hectare = 100 * are
 US_survey_acre = 160 * rod ** 2
 
 # EM


### PR DESCRIPTION
The usual "hecto" prefix for 100* (hectopascal, hectometre, etc.) is
shortened to "hect" for "hectares". This seems to be a unique case:
https://en.wikipedia.org/wiki/Hecto-.

Adding "hectare" as an explicit unit of area therefore seems to be cleaner than
adding "hect" as a supported prefix for all units. Adding "hect" instead would
cause Pint to recognize many strange new Quantities such as ureg.hectsecond.