### PR TITLE
Introduce 'u' to format only a Quantity's units

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -134,8 +134,11 @@ class _Quantity(object):
         else:
             units = self.units
 
-        return '%s %s' % (format(self.magnitude, remove_custom_flags(spec)),
-                          format(units, spec))
+        if 'u' in spec:
+            return format(units, spec.replace('u', ''))
+        else:
+            return '%s %s' % (format(self.magnitude, remove_custom_flags(spec)),
+                              format(units, spec))
 
     # IPython related code
     def _repr_html_(self):


### PR DESCRIPTION
It is currently not possible to correctly format units (UnitsContainer
objects) using the '~' format spec.

    >>> format(q, '~')
    '17.0 km / s ** 2'
    >>> format(q.units, '~')
    'kilometer / second ** 2'

Notice how the units are different when formatted on their own.

In order for units to be properly formatted with '~', the UnitsRegistry
must be available so that the long names in the units container can be
mapped to their short, symbolic names. I.e. 'kilo' -> 'k' and 'meter' ->
'm'. A key problem is that UnitsContainer objects do not have access to
the UnitRegistry. When quantities are formatted, we cheat (a little) and
use the quantity's UnitRegistry (_REGISTRY) to perform the _get_symbol()
mapping in the case of '~'.

So we introduce 'u' as a formatting spec for Quantity that causes only
the unit, and not the magnitude, to be returned from format().

    >>> format(q, '~u')
    'km / s ** 2'
    >>> format(q, '~Pu')
    'km/s²'

-----

I believe this is a viable fix for #160.