### PR TITLE
Remove redundant code from Quantity.__format__()

### DIFF
--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -158,7 +158,7 @@ def formatter(items, as_ratio=True, single_denominator=False,
 # http://docs.python.org/2/library/string.html#format-specification-mini-language
 # We also add uS for uncertainties.
 _BASIC_TYPES = frozenset('bcdeEfFgGnosxX%uS')
-_KNOWN_TYPES = frozenset(_FORMATS.keys())
+_KNOWN_TYPES = frozenset(list(_FORMATS.keys()) + ['~'])
 
 def _parse_spec(spec):
     result = ''
@@ -191,7 +191,7 @@ def format_unit(unit, spec):
 
 
 def remove_custom_flags(spec):
-    for flag in _FORMATS.keys():
+    for flag in _KNOWN_TYPES:
          if flag:
              spec = spec.replace(flag, '')
     return spec

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -109,16 +109,9 @@ class _Quantity(SharedRegistryObject):
 
     def __format__(self, spec):
         spec = spec or self.default_format
-
-        if '~' in spec:
-            units = UnitsContainer(dict((self._REGISTRY._get_symbol(key), value)
-                                   for key, value in self._units.items()))
-            spec = spec.replace('~', '')
-        else:
-            units = self._units
-
-        return '%s %s' % (format(self.magnitude, remove_custom_flags(spec)),
-                          format(units, spec))
+        return '{0} {1}'.format(
+            format(self.magnitude, remove_custom_flags(spec)),
+            format(self.units, spec))
 
     # IPython related code
     def _repr_html_(self):


### PR DESCRIPTION
The new _Unit class now has the capability of applying the '~' format
flag itself. This makes the long-to-symbolic unit name conversion in
Quantity.__format__() redundant and duplicate to _Unit.__format__().

As part of this change, we teach pint.formatting.remove_custom_flags()
to remove the '~' flag.