### PR TITLE
added wavenumber to the spectroscopy context

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -321,6 +321,7 @@ firkin = barrel / 4
     [length] <-> [frequency]: speed_of_light / n / value
     [frequency] -> [energy]: planck_constant * value
     [energy] -> [frequency]: value / planck_constant
+    [frequency] <-> 1/[length]: value * n / speed_of_light
 @end
 
 @context boltzmann


### PR DESCRIPTION
Wavenumber conversion is missing from the spectroscopy context. This request adds it to ```default_en.txt```.