### PR TITLE
Properly support deepcopy of Quantity objects.

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -118,6 +118,11 @@ class _Quantity(object):
         ret.__used = self.__used
         return ret
 
+    def __deepcopy__(self, memo):
+        ret = self.__class__(copy.deepcopy(self._magnitude, memo), copy.deepcopy(self._units, memo))
+        ret.__used = self.__used
+        return ret
+
     def __str__(self):
         return format(self)
 


### PR DESCRIPTION
deepcopy of quantities will currently drop the unit information (just returning the magnitude).