### PR TITLE
Fix python2.6 incompatibility

### DIFF
--- a/pint/util.py
+++ b/pint/util.py
@@ -449,7 +449,10 @@ class ParserHelper(UnitsContainer):
                                  for key, value in ret.items()))
 
     def __copy__(self):
-        return ParserHelper(scale=self.scale, **self)
+        # workaround for python2.6 compatibility (cast kwarg keys to str)
+        # see http://bugs.python.org/issue2646
+        kwargs = dict([(str(k),v) for k,v in self.items()])
+        return ParserHelper(scale=self.scale, **kwargs)
 
     def copy(self):
         return self.__copy__()


### PR DESCRIPTION
pint fails to inititialize the UnitRegistry with python2.6:

~~~~
~/src/pint> python -c 'from pint import UnitRegistry; UR=UnitRegistry()'
(...)
ValueError: While opening default_en.txt
'yard' is not defined in the unit registry
~~~~

The problem is due to a known python2.6 bug triggered in `ParserHelper.__copy__()`. 
See: http://bugs.python.org/issue2646

This patch fixes at least one trigger of this bug (the unit registry can be initialized now) but I haven't checked for other similar triggers