### PR TITLE
Fix TypeError in formatter method

### DIFF
--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -182,7 +182,10 @@ def format_unit(unit, spec):
         return 'dimensionless'
 
     spec = _parse_spec(spec)
-    fmt = _FORMATS[spec]
+    fmt = {}
+    # Convert keys and values to str to avoid a bug in Python2.6
+    for k, v in _FORMATS[spec].items():
+        fmt[str(k)] = str(v)
 
     result = formatter(unit.items(), **fmt)
     if spec == 'L':


### PR DESCRIPTION
To reproduce the error the pull request #295 have to be applied.

In Python 2.6 format_unit method does not manage properly unicode
string and gives a TypeError: "formatter() keywords must be strings".

Fix the error, doing a cast of the _FORMATS[spec].items() to str.

You can reproduce:

<pre>
In [2]: UR = UnitRegistry()

In [3]: UR.parse_units('m')
Out[3]: ---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)

...
/pint/formatting.py in format_unit(unit, spec)
    183     spec = _parse_spec(spec)
    184     fmt = _FORMATS[spec].items()
--> 185     result = formatter(unit.items(), **fmt)
    186     if spec == 'L':
    187         result = result.replace('[', '{').replace(']', '}')

TypeError: formatter() argument after ** must be a mapping, not list

</pre>
