### PR TITLE
Use empty string for dimensionless abbreviated format

### DIFF
--- a/pint/unit.py
+++ b/pint/unit.py
@@ -101,6 +101,8 @@ class _Unit(SharedRegistryObject):
         spec = spec or self.default_format
 
         if '~' in spec:
+            if self.dimensionless:
+                return ''
             units = UnitsContainer(dict((self._REGISTRY._get_symbol(key),
                                          value)
                                    for key, value in self._units.items()))


### PR DESCRIPTION
Make pint use empty string when formatting dimensionless units
(instead of "dimensionless") if the abbreviation format spec ("~") 
is used.

See #300