### PR TITLE
Fixed short name on pressure units.

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -218,12 +218,12 @@ bar = 100000 * pascal
 atmosphere = 101325 * pascal = atm = standard_atmosphere
 technical_atmosphere = kilogram * gravity / centimeter ** 2 = at
 torr = atm / 760
-psi = pound * gravity / inch ** 2 = pound_force_per_square_inch
-ksi = kip / inch ** 2 = kip_per_square_inch
+pound_force_per_square_inch = pound * gravity / inch ** 2 = psi
+kip_per_square_inch = kip / inch ** 2 = ksi
 barye = 0.1 * newton / meter ** 2 = barie = barad = barrie = baryd = Ba
-mmHg = millimeter * Hg = mm_Hg = millimeter_Hg = millimeter_Hg_0C
-cmHg = centimeter * Hg = cm_Hg = centimeter_Hg
-inHg = inch * Hg = in_Hg = inch_Hg = inch_Hg_32F
+mm_Hg = millimeter * Hg = mmHg = millimeter_Hg = millimeter_Hg_0C
+cm_Hg = centimeter * Hg = cmHg = centimeter_Hg
+in_Hg = inch * Hg = inHg = inch_Hg = inch_Hg_32F
 inch_Hg_60F = inch * mercury_60F
 inch_H2O_39F = inch * water_39F
 inch_H2O_60F = inch * water_60F


### PR DESCRIPTION
Some of them I was unsure about so I didn't change them.
Changed:
    psi
    ksi
    mmHg
    cmHg

    >>> import pint
    >>> u = pint.UnitRegistry()
    >>> pressure = 1.11 * u.psi
    >>> pressure
    <Quantity(1.11, 'pound_force_per_square_inch')>
    >>> format(pressure)
    '1.11 pound_force_per_square_inch'
    >>> format(pressure, 'P')
    '1.11 pound_force_per_square_inch'
    >>> format(pressure, '~')
    '1.11 psi'


https://github.com/hgrecco/pint/issues/313