### PR TITLE
ENH: Add support for wavenumber/kayser in spectroscopy context

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -267,6 +267,8 @@ stere = meter ** 3
     [length] <-> [frequency]: speed_of_light / n / value
     [frequency] -> [energy]: planck_constant * value
     [energy] -> [frequency]: value / planck_constant
+    # allow wavenumber / kayser
+    1 / [length] <-> [length]: 1 / value
 @end
 
 @context boltzmann

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -510,7 +510,7 @@ class TestCompatibleUnits(QuantityTestCase):
 
         # length, frequency, energy
         valid = [gd(self.ureg.meter), gd(self.ureg.hertz),
-                 gd(self.ureg.joule)]
+                 gd(self.ureg.joule), 1/gd(self.ureg.meter)]
 
         with self.ureg.context('sp'):
             equiv = self.ureg.get_compatible_units(self.ureg.meter)


### PR DESCRIPTION
In spectroscopy, it is (regrettably) common to express the wavelength in
units of wavenumber (a.k.a. kayser) or cm^{-1}.  This commit adds support
to the default spectroscopy context, so that users can convert from
frequency and wavelength directly to wavenumber units such as kayser.