### PR TITLE
UnitRegistry.convert now returns a Fraction if the user submits a Fra…

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -317,7 +317,7 @@ class _Quantity(SharedRegistryObject):
         >>> (1e-2*ureg('kg m/s^2')).to_compact('N')
         <Quantity(10.0, 'millinewton')>
         """
-        if self.unitless:
+        if self.unitless or self.magnitude==0:
             return self
 
         SI_prefixes = {}

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -507,3 +507,9 @@ class TestIssuesNP(QuantityTestCase):
         t = copy.deepcopy(q)
         u = t.to(ur.mF)
         self.assertQuantityEqual(q.to(ur.mF), u)
+
+    def test_issue323(self):
+        from fractions import Fraction as F
+        self.assertEqual((self.Q_(F(2,3), 's')).to('ms'), self.Q_(F(2000,3), 'ms'))
+        self.assertEqual((self.Q_(F(2,3), 'm')).to('km'), self.Q_(F(1,1500), 'km'))
+

--- a/pint/unit.py
+++ b/pint/unit.py
@@ -1111,7 +1111,7 @@ class UnitRegistry(object):
             factor = Decimal(str(factor))
 
         if isinstance(value, Fraction):
-            factor = Fraction(Decimal(str(factor)))
+            factor = Fraction(str(factor))
 
         if inplace:
             value *= factor

--- a/pint/unit.py
+++ b/pint/unit.py
@@ -18,6 +18,7 @@ import functools
 import operator
 import pkg_resources
 from decimal import Decimal
+from fractions import Fraction
 from contextlib import contextmanager, closing
 from io import open, StringIO
 from collections import defaultdict
@@ -1108,6 +1109,9 @@ class UnitRegistry(object):
         # must first convert to Decimal before we can '*' the values
         if isinstance(value, Decimal):
             factor = Decimal(str(factor))
+
+        if isinstance(value, Fraction):
+            factor = Fraction(Decimal(str(factor)))
 
         if inplace:
             value *= factor


### PR DESCRIPTION
According to what we figured out in the Issue https://github.com/hgrecco/pint/issues/323, in the case the user wants to convert a quantity with a Fraction magnitude, UnitRegistry.convert will return the result with a Fraction magnitude (and not a Float).