### PR TITLE
Sort multiplicative units for deterministic conversion.

### DIFF
--- a/pint/unit.py
+++ b/pint/unit.py
@@ -944,7 +944,7 @@ class UnitRegistry(object):
         return base_factor, destination_units
 
     def _get_root_units_recurse(self, ref, exp, accumulators):
-        for key in ref:
+        for key in sorted(ref):
             exp2 = exp*ref[key]
             key = self.get_name(key)
             reg = self._units[key]


### PR DESCRIPTION
Solution for Issue #327 

This solution sorts the entries in the UnitContainer before accumulating them during multiplicative conversions so that the result can be deterministic.