### PR TITLE
to_compact now returns self for NaN and infinite magnitudes

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -317,7 +317,8 @@ class _Quantity(SharedRegistryObject):
         >>> (1e-2*ureg('kg m/s^2')).to_compact('N')
         <Quantity(10.0, 'millinewton')>
         """
-        if self.unitless or self.magnitude==0:
+        if (self.unitless or self.magnitude==0 or 
+            math.isnan(self.magnitude) or math.isinf(self.magnitude)):
             return self
 
         SI_prefixes = {}


### PR DESCRIPTION
I think it makes sense for infinity. For NaN magnitudes this is discutable.