### PR TITLE
support changing shapes of numpy arrays

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1042,6 +1042,14 @@ class _Quantity(SharedRegistryObject):
     def T(self):
         return self.__class__(self._magnitude.T, self._units)
 
+    @property
+    def shape(self):
+        return self._magnitude.shape
+
+    @shape.setter
+    def shape(self, value):
+        self._magnitude.shape = value
+
     def searchsorted(self, v, side='left'):
         if isinstance(v, self.__class__):
             v = v.to(self).magnitude

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -252,6 +252,11 @@ class TestNumpyMethods(QuantityTestCase):
         self.assertQuantityEqual(u == u, u.magnitude == u.magnitude)
         self.assertQuantityEqual(u == 1, u.magnitude == 1)
 
+    def test_shape(self):
+        u = self.Q_(np.arange(12))
+        u.shape = 4, 3
+        self.assertEqual(u.magnitude.shape, (4, 3))
+
 
 @helpers.requires_numpy()
 class TestNumpyNeedsSubclassing(TestUFuncs):


### PR DESCRIPTION
In numpy one can simply change the shape of an array by setting
the shape attribute. This patch allows the same for pint Quantities.