### PR TITLE
support the flat property of numpy

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1042,6 +1042,11 @@ class _Quantity(SharedRegistryObject):
     def T(self):
         return self.__class__(self._magnitude.T, self._units)
 
+    @property
+    def flat(self):
+        for v in self._magnitude.flat:
+            yield self.__class__(v, self._units)
+
     def searchsorted(self, v, side='left'):
         if isinstance(v, self.__class__):
             v = v.to(self).magnitude

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -50,6 +50,10 @@ class TestNumpyMethods(QuantityTestCase):
     def test_flatten(self):
         self.assertQuantityEqual(self.q.flatten(), [1, 2, 3, 4] * self.ureg.m)
 
+    def test_flat(self):
+        for q, v in zip(self.q.flat, [1, 2, 3, 4]):
+            self.assertEqual(q, v * self.ureg.m)
+
     def test_ravel(self):
         self.assertQuantityEqual(self.q.ravel(), [1, 2, 3, 4] * self.ureg.m)
 


### PR DESCRIPTION
In numpy one can simply iterate over a flattened array by iterating
over ndarray.flat. With this PR that's also possible with pint.