### PR TITLE
Fix bug in AssertQuantityEqual

### DIFF
--- a/pint/testsuite/__init__.py
+++ b/pint/testsuite/__init__.py
@@ -104,7 +104,7 @@ class QuantityTestCase(BaseTestCase):
         if isinstance(m1, ndarray) or isinstance(m2, ndarray):
             np.testing.assert_array_equal(m1, m2, err_msg=msg)
         else:
-            unittest.TestCase.assertEqual(self, m1, m2, msg)
+            self.assertEqual(m1, m2, msg)
 
     def assertQuantityAlmostEqual(self, first, second, rtol=1e-07, atol=0, msg=None):
         if msg is None:


### PR DESCRIPTION
I encountered an error in the testsuite, where test_issue252 in test_issues.py was failing with

`Traceback (most recent call last):
  File "/usr/grte/v4/k8-linux/lib/python2.7/unittest/case.py", line 331, in run
    testMethod()
  File "/build/work/5d4407ac26f58beba049f66c9c021865/google3/runfiles/google3/third_party/py/pint/testsuite/test_issues.py", line 509, in test_issue252
    self.assertQuantityEqual(q.to(ur.mF), u)
  File "/build/work/5d4407ac26f58beba049f66c9c021865/google3/runfiles/google3/third_party/py/pint/testsuite/__init__.py", line 107, in assertQuantityEqual
    unittest.TestCase.assertEqual(self, m1, m2, msg)
TypeError: unbound method assertEqual() must be called with TestCase instance as first argument (got TestIssuesNP instance instead)`

I believe the issue is related to the fact that TestIssuesNP has a class decorator. This issue could only be triggered by code in TestIssuesNP that used assertQuantityEqual with arguments that were not ndarrays, and test_issue252 is the only test case in TestIssuesNP that does that, as far as I can tell.

This PR fixes the issue.

(I also realize the issue could be fixed by moving test_issue252 to TestIssues, since it does not use Numpy, but I thought it was better to fix this bug while it was exposed and then rearrange code.)