### PR TITLE
remove inline comment, patch for #366

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -245,7 +245,7 @@ work_month = work_year / 12
 
 # Velocity
 [speed] = [length] / [time]
-nautical_mile = 1852 m = nmi # exact
+nautical_mile = 1852 m = nmi
 knot = nautical_mile / hour = kt = knot_international = international_knot = nautical_miles_per_hour
 mph = mile / hour = MPH
 kph = kilometer / hour = KPH


### PR DESCRIPTION
This is a simple patch for #366. Not sure if inline comments in unit definition files are intended to work -- if they are, a better fix should be implemented and tested.