### PR TITLE
Fix ValueError in parse_units method

### DIFF
--- a/pint/unit.py
+++ b/pint/unit.py
@@ -1216,11 +1216,11 @@ class UnitRegistry(object):
         if as_delta and input_string in self._parse_unit_cache:
             return self._parse_unit_cache[input_string]
 
-        # Sanitize input_string with whitespaces.
-        input_string = input_string.strip()
-
         if not input_string:
             return UnitsContainer()
+
+        # Sanitize input_string with whitespaces.
+        input_string = input_string.strip()
 
         units = ParserHelper.from_string(input_string)
         if units.scale != 1:

--- a/pint/unit.py
+++ b/pint/unit.py
@@ -1216,6 +1216,9 @@ class UnitRegistry(object):
         if as_delta and input_string in self._parse_unit_cache:
             return self._parse_unit_cache[input_string]
 
+        # Sanitize input_string with whitespaces.
+        input_string = input_string.strip()
+
         if not input_string:
             return UnitsContainer()
 


### PR DESCRIPTION
parse_units raises an ValueError when the input is a string with only white spaces. 
e.g. 
' ', '\t', etc.

Fix the error striping the input_string before working with it.

You can reproduce the error with this code:
import pint
ur = pint.UnitRegistry()
ur.parse_units(' ')

PS: In my solution, I considered  that the behaviour of parse_units  for these cases should be return dimensionless unit, but  another solution can be implemented, e.g. raising an UndefinedUnitError exception in these cases. What do you thing?