### PR TITLE
Image/scanning/printing related units

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -262,6 +262,12 @@ liter = 1e-3 * m ** 3 = l = L = litre
 cc = centimeter ** 3 = cubic_centimeter
 stere = meter ** 3
 
+# Image/printing
+pixel = dot = px = pel = picture_element
+pixels_per_centimeter = pixel / cm = PPCM
+pixels_per_inch = pixel / inch = dots_per_inch = PPI = ppi = DPI = dpi
+bits_per_pixel = bit / pixel = bpp
+
 @context(n=1) spectroscopy = sp
     # n index of refraction of the medium.
     [length] <-> [frequency]: speed_of_light / n / value


### PR DESCRIPTION
Hello,

I propose to add following units related to images, scanning and printing.

Base unit: pixel (px), dot, pel (picture element)
Resolution: PPCM (pixel per centimeter), ppi (pixels per inch), dpi (dots pet inch)
Color depth: bpp (bit per pixel)

A little thing I don't know how fix:
If I do `pixel * pixel`, I get result in `pixel**2`, but I want get result in "megapixel".

Another problem:
"dpi" conflict with US dry pint, I find no reference about US dry pint called as "dpi". Maybe removing it ?