### PR TITLE
Ascii formatting

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -122,7 +122,7 @@ class _Quantity(SharedRegistryObject):
     def __format__(self, spec):
         spec = spec or self.default_format
 
-        allf = '{0} {1}'
+        allf = plain_allf = '{0} {1}'
         mstr, ustr = None, None
 
         # If Compact is selected, do it at the beginning
@@ -160,6 +160,9 @@ class _Quantity(SharedRegistryObject):
         else:
             mstr = format(obj.magnitude, mspec).replace('\n', '')
 
+        if allf == plain_allf and ustr.startswith('1 /'):
+            # Write e.g. "3 / s" instead of "3 1 / s"
+            ustr = ustr[2:]
         return allf.format(mstr, ustr).strip()
 
     # IPython related code

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -107,6 +107,9 @@ class TestQuantity(QuantityTestCase):
                              ('{0:Lx}', r'\SI[]{4.12345678}{\kilo\gram\meter\squared\per\second}'),
                              ):
             self.assertEqual(spec.format(x), result)
+        # Check the special case that prevents e.g. '3 1 / second'
+        x = self.Q_(3, UnitsContainer(second=-1))
+        self.assertEqual('{}'.format(x), '3 / second')
 
     def test_format_compact(self):
         q1 = (200e-9 * self.ureg.s).to_compact()

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -109,7 +109,7 @@ class TestQuantity(QuantityTestCase):
             self.assertEqual(spec.format(x), result)
         # Check the special case that prevents e.g. '3 1 / second'
         x = self.Q_(3, UnitsContainer(second=-1))
-        self.assertEqual('{}'.format(x), '3 / second')
+        self.assertEqual('{0}'.format(x), '3 / second')
 
     def test_format_compact(self):
         q1 = (200e-9 * self.ureg.s).to_compact()


### PR DESCRIPTION
Possibly I'm the only one bothered by this, but this formatting seems weird to me:

```python
>>> str(3/ureg.s)
'3 1 / second'
```
This PR checks for the specific case where you would write `<mag> 1 / <units>` and returns `<mag> / <units>` instead, e.g.
```python
>>> str(3/ureg.s)
'3 / second'
```