### PR TITLE
ENH/TST: Make ndarray-quantity swapaxes-proof and add several tests

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -984,7 +984,7 @@ class _Quantity(SharedRegistryObject):
     #: original.
     __copy_units = 'compress conj conjugate copy cumsum diagonal flatten ' \
                    'max mean min ptp ravel repeat reshape round ' \
-                   'squeeze std sum take trace transpose ' \
+                   'squeeze std sum swapaxes take trace transpose ' \
                    'ceil floor hypot rint ' \
                    'add subtract ' \
                    'copysign nextafter trunc ' \

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -178,6 +178,17 @@ class TestQuantity(QuantityTestCase):
             self.assertIsNot(r, q)
             self.assertIsNot(r._magnitude, a)
 
+    @helpers.requires_numpy()
+    def test_retain_unit(self):
+        # Test that methods correctly retain units and do not degrade into
+        # ordinary ndarrays.  List contained in __copy_units.
+        a = np.ones((3, 2))
+        q = self.Q_(a, "km")
+        self.assertEqual(q.u, q.reshape(2, 3).u)
+        self.assertEqual(q.u, q.swapaxes(0, 1).u)
+        self.assertEqual(q.u, q.mean().u)
+        self.assertEqual(q.u, np.compress((q==q[0,0]).any(0), q).u)
+
     def test_context_attr(self):
         self.assertEqual(self.ureg.meter, self.Q_(1, 'meter'))
 


### PR DESCRIPTION
Make a numpy array quantity retain its unit when swapaxes is called.
Previously it would turn into a regular ndarray.  Add a test suite to test
unit retainment for this and other ufuncs in __copy_units.

I also tried to add functionality for others, such as median, average,
percentile, expand_dims, atleast_1d, atleast_2d, atleast_3d, tile, rot90.
However, this doesn't work because those ndarrays start with `asarray` or
`asndarray`.  Onother solution is needed.  See also issue #396.