### PR TITLE
fix bug in infer_base_unit. 

### DIFF
--- a/pint/testsuite/test_infer_base_unit.py
+++ b/pint/testsuite/test_infer_base_unit.py
@@ -1,0 +1,18 @@
+from pint import UnitRegistry, set_application_registry
+from pint.testsuite import QuantityTestCase
+
+ureg = UnitRegistry()
+set_application_registry(ureg)
+Q = ureg.Quantity
+
+class TestInferBaseUnit(QuantityTestCase):
+    def test_infer_base_unit(self):
+        from pint.util import infer_base_unit
+        self.assertEqual(infer_base_unit(Q(1, 'millimeter * nanometer')), Q(1, 'meter**2').units)
+
+    def test_to_compact(self):
+        r = Q(1000000000, 'm') * Q(1, 'mm') / Q(1, 's') / Q(1, 'ms')
+        compact_r = r.to_compact()
+        expected = Q(1000., 'kilometer**2 / second**2')
+        self.assertEqual(compact_r, expected)
+

--- a/pint/testsuite/test_infer_base_unit.py
+++ b/pint/testsuite/test_infer_base_unit.py
@@ -14,5 +14,5 @@ class TestInferBaseUnit(QuantityTestCase):
         r = Q(1000000000, 'm') * Q(1, 'mm') / Q(1, 's') / Q(1, 'ms')
         compact_r = r.to_compact()
         expected = Q(1000., 'kilometer**2 / second**2')
-        self.assertEqual(compact_r, expected)
+        self.assertQuantityAlmostEqual(compact_r, expected)
 

--- a/pint/testsuite/test_infer_base_unit.py
+++ b/pint/testsuite/test_infer_base_unit.py
@@ -1,5 +1,6 @@
 from pint import UnitRegistry, set_application_registry
 from pint.testsuite import QuantityTestCase
+from pint.util import infer_base_unit
 
 ureg = UnitRegistry()
 set_application_registry(ureg)
@@ -10,9 +11,14 @@ class TestInferBaseUnit(QuantityTestCase):
         from pint.util import infer_base_unit
         self.assertEqual(infer_base_unit(Q(1, 'millimeter * nanometer')), Q(1, 'meter**2').units)
 
+    def test_units_adding_to_zero(self):
+        self.assertEqual(infer_base_unit(Q(1, 'm * mm / m / um * s')), Q(1, 's').units)
+
     def test_to_compact(self):
         r = Q(1000000000, 'm') * Q(1, 'mm') / Q(1, 's') / Q(1, 'ms')
         compact_r = r.to_compact()
         expected = Q(1000., 'kilometer**2 / second**2')
         self.assertQuantityAlmostEqual(compact_r, expected)
 
+        r = (Q(1, 'm') * Q(1, 'mm') / Q(1, 'm') / Q(2, 'um') * Q(2, 's')).to_compact()
+        self.assertQuantityAlmostEqual(r, Q(1000, 's'))

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -5,7 +5,7 @@ from __future__ import division, unicode_literals, print_function, absolute_impo
 import copy
 import operator as op
 
-from pint import DimensionalityError
+from pint import DimensionalityError, set_application_registry
 from pint.compat import np, unittest
 from pint.testsuite import QuantityTestCase, helpers
 from pint.testsuite.test_umath import TestUFuncs
@@ -240,7 +240,7 @@ class TestNumpyMethods(QuantityTestCase):
 
     def test_pickle(self):
         import pickle
-
+        set_application_registry(self.ureg)
         def pickle_test(q):
             pq = pickle.loads(pickle.dumps(q))
             np.testing.assert_array_equal(q.magnitude, pq.magnitude)

--- a/pint/util.py
+++ b/pint/util.py
@@ -643,7 +643,7 @@ def infer_base_unit(q):
 
         _, base_unit, __ = completely_parsed_unit
         d[base_unit] += power
-    return UnitsContainer(d)
+    return UnitsContainer(dict((k, v) for k, v in d.items() if v != 0))  # remove values that added to a power of zero
 
 
 def fix_str_conversions(cls):

--- a/pint/util.py
+++ b/pint/util.py
@@ -18,7 +18,7 @@ import re
 import operator
 from numbers import Number
 from fractions import Fraction
-from collections import Mapping
+from collections import Mapping, defaultdict
 
 import logging
 from token import STRING, NAME, OP, NUMBER
@@ -636,13 +636,13 @@ def to_units_container(unit_like, registry=None):
 
 def infer_base_unit(q):
     """Return UnitsContainer of q with all prefixes stripped."""
-    d = {}
+    d = defaultdict(lambda:0)
     parse = q._REGISTRY.parse_unit_name
     for unit_name, power in q._units.items():
         completely_parsed_unit = list(parse(unit_name))[-1]
 
         _, base_unit, __ = completely_parsed_unit
-        d[base_unit] = power
+        d[base_unit] += power
     return UnitsContainer(d)
 
 


### PR DESCRIPTION
infer_base_unit failed on quantities that were generated by multiplying the same dimension with different prefixes such as 'meter * millimeter'. This also leads to problems using .to_compact() as the base_unit of a quantity is inferred incorrectly
An example can be found in the added testcase.