### PR TITLE
Fix ValueError in parse_units method

### DIFF
--- a/pint/registry.py
+++ b/pint/registry.py
@@ -764,6 +764,9 @@ class BaseRegistry(object):
         if not input_string:
             return UnitsContainer()
 
+        # Sanitize input_string with whitespaces.
+        input_string = input_string.strip()
+
         units = ParserHelper.from_string(input_string)
         if units.scale != 1:
             raise ValueError('Unit expression cannot have a scaling factor.')


### PR DESCRIPTION
Unit register parse_units method raises an ValueError
when the input is a string with only white spaces.

e.g. ' ', '\t', etc.

Fix the error striping the input_string before working with it.