### PR TITLE
add return to example in docs

### DIFF
--- a/docs/wrapping.rst
+++ b/docs/wrapping.rst
@@ -146,7 +146,7 @@ airmass::
 
     @UREG.wraps(('deg', 'deg'), ('deg', 'deg', 'millibar', 'degC')
     def solar_position(lat, lon, press, tamb, timestamp):
-        pass
+        return zenith, azimuth, airmass
 
 
 Specifying relations between arguments


### PR DESCRIPTION
* fixes #363
* amends #364
* improves wraps documentation when there are more returns than units in the wrapper, actually shows 3 returns in example, but only 2 units in wrapper

this is a minor change to the docs only:

```diff
diff --git a/docs/wrapping.rst b/docs/wrapping.rst
index f7ac662..19f4d3c 100644
--- a/docs/wrapping.rst
+++ b/docs/wrapping.rst
@@ -146,7 +146,7 @@ airmass::

     @UREG.wraps(('deg', 'deg'), ('deg', 'deg', 'millibar', 'degC')
     def solar_position(lat, lon, press, tamb, timestamp):
-        pass
+        return zenith, azimuth, airmass


 Specifying relations between arguments
```