### PR TITLE
Prevent crash when context is None

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1223,7 +1223,7 @@ class _Quantity(SharedRegistryObject):
     __array_priority__ = 17
 
     def __array_prepare__(self, obj, context=None):
-        # If this uf is handled by Pint, write it down in the handling dictionary.
+        # If we have no context, assume this is unhandled
         if context is None:
             return obj
 
@@ -1246,6 +1246,10 @@ class _Quantity(SharedRegistryObject):
         return obj
 
     def __array_wrap__(self, obj, context=None):
+        # If we have no context, assume this is unhandled
+        if context is None:
+            return self.magnitude.__array_wrap__(obj, context)
+
         uf, objs, huh = context
 
         # if this ufunc is not handled by Pint, pass it to the magnitude.

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1224,6 +1224,8 @@ class _Quantity(SharedRegistryObject):
 
     def __array_prepare__(self, obj, context=None):
         # If this uf is handled by Pint, write it down in the handling dictionary.
+        if context is None:
+            return obj
 
         # name of the ufunc, argument of the ufunc, domain of the ufunc
         # In ufuncs with multiple outputs, domain indicates which output

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -463,7 +463,6 @@ class TestNDArrayQuantityMath(QuantityTestCase):
         # TODO
         # self.assertEqual(x.units, ureg.m * ureg.s)
 
-    @unittest.expectedFailure
     def test_linalg_solve(self):
         ureg = self.ureg
         A = np.eye(2) * ureg.s

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -422,9 +422,8 @@ class TestBitTwiddlingUfuncs(TestUFuncs):
                     'same')
 
 
-class TestNDArrayQunatityMath(QuantityTestCase):
-
-    @helpers.requires_numpy()
+@helpers.requires_numpy()
+class TestNDArrayQuantityMath(QuantityTestCase):
     def test_exponentiation_array_exp(self):
         arr = np.array(range(3), dtype=np.float)
         q = self.Q_(arr, None)
@@ -441,7 +440,6 @@ class TestNDArrayQunatityMath(QuantityTestCase):
             self.assertRaises(DimensionalityError, op_, q_cp, q2_cp)
 
     @unittest.expectedFailure
-    @helpers.requires_numpy()
     def test_exponentiation_array_exp_2(self):
         arr = np.array(range(3), dtype=np.float)
         #q = self.Q_(copy.copy(arr), None)
@@ -456,3 +454,21 @@ class TestNDArrayQunatityMath(QuantityTestCase):
         arr_cp = copy.copy(arr)
         q_cp = copy.copy(q)
         self.assertRaises(DimensionalityError, op.ipow, arr_cp, q_cp)
+
+    def test_maximum(self):
+        a = np.arange(4) * self.ureg.m
+        b = 2 * np.ones(4) * self.ureg.m
+        # this line would previously throw an error
+        x = np.maximum(a, b)
+        # TODO
+        # self.assertEqual(x.units, ureg.m * ureg.s)
+
+    @unittest.expectedFailure
+    def test_linalg_solve(self):
+        ureg = self.ureg
+        A = np.eye(2) * ureg.s
+        b = np.ones(2) * ureg.m
+        # this line would previously throw an error
+        x = np.linalg.solve(A, b)
+        # TODO
+        # self.assertEqual(x.units, ureg.m * ureg.s)


### PR DESCRIPTION
Triggered by `linalg`, among other things
