### PR TITLE
fix to_compact for negative magnitude 

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -403,9 +403,9 @@ class _Quantity(SharedRegistryObject):
         unit_power = list(q_base._units.items())[0][1]
 
         if unit_power > 0:
-            power = int(math.floor(math.log10(magnitude) / unit_power / 3)) * 3
+            power = int(math.floor(math.log10(abs(magnitude)) / unit_power / 3)) * 3
         else:
-            power = int(math.ceil(math.log10(magnitude) / unit_power / 3)) * 3
+            power = int(math.ceil(math.log10(abs(magnitude)) / unit_power / 3)) * 3
 
         prefix = SI_bases[bisect.bisect_left(SI_powers, power)]
 

--- a/pint/testsuite/test_infer_base_unit.py
+++ b/pint/testsuite/test_infer_base_unit.py
@@ -24,6 +24,17 @@ class TestInferBaseUnit(QuantityTestCase):
         r = (Q(1, 'm') * Q(1, 'mm') / Q(1, 'm') / Q(2, 'um') * Q(2, 's')).to_compact()
         self.assertQuantityAlmostEqual(r, Q(1000, 's'))
 
+    def test_negative_to_compact(self):
+        r = Q(-1000000000, 'm') * Q(1, 'mm') / Q(1, 's') / Q(1, 'ms')
+        compact_r = r.to_compact()
+        expected = Q(-1000., 'kilometer**2 / second**2')
+        self.assertQuantityAlmostEqual(compact_r, expected)
+
+        r = (Q(-1, 'm') * Q(1, 'mm') / Q(1, 'm') / Q(2, 'um') * Q(2, 's')).to_compact()
+        self.assertQuantityAlmostEqual(r, Q(-1000, 's'))
+
+        self.assertQuantityAlmostEqual(Q(-1000, 'Hz'), Q(-1, 'kHz'))
+
     def test_volts(self):
         from pint.util import infer_base_unit
         r = Q(1, 'V') * Q(1, 'mV') / Q(1, 'kV')


### PR DESCRIPTION
Q(-1000, 's').to_compact() did fail because it tried to compute the logarithm of the negative magnitude.
