### PR TITLE
Fixed issue with negative values in to_compact() method

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -403,9 +403,9 @@ class _Quantity(SharedRegistryObject):
         unit_power = list(q_base._units.items())[0][1]
 
         if unit_power > 0:
-            power = int(math.floor(math.log10(magnitude) / unit_power / 3)) * 3
+            power = int(math.floor(math.log10(abs(magnitude)) / unit_power / 3)) * 3
         else:
-            power = int(math.ceil(math.log10(magnitude) / unit_power / 3)) * 3
+            power = int(math.ceil(math.log10(abs(magnitude)) / unit_power / 3)) * 3
 
         prefix = SI_bases[bisect.bisect_left(SI_powers, power)]
 

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -123,8 +123,14 @@ class TestQuantity(QuantityTestCase):
         self.assertEqual(q2.magnitude, q2b.magnitude)
         self.assertEqual(q2.units, q2b.units)
 
+        q3 = (-1000.0 * self.ureg('meters')).to_compact()
+        q3b = self.Q_(-1., 'kilometer')
+        self.assertEqual(q3.magnitude, q3b.magnitude)
+        self.assertEqual(q3.units, q3b.units)
+
         self.assertEqual('{0:#.1f}'.format(q1), '{0}'.format(q1b))
         self.assertEqual('{0:#.1f}'.format(q2), '{0}'.format(q2b))
+        self.assertEqual('{0:#.1f}'.format(q3), '{0}'.format(q3b))
 
 
     def test_default_formatting(self):


### PR DESCRIPTION
An exception `MathError` was raised when trying to get the compact version of `-1.0 meter` because the log10 of a negative magnitude `-1.0`  cannot be computed. 
