### PR TITLE
support dimensionless values in wraps

### DIFF
--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -364,6 +364,7 @@ class TestRegistry(QuantityTestCase):
 
         g0 = ureg.wraps('=A', ['=A', '=A'])(gfunc)
         self.assertEqual(g0(3. * ureg.meter, 1. * ureg.centimeter), rst.to('meter'))
+        self.assertEqual(g0(3, 1), 4)
 
         g1 = ureg.wraps('=A', ['=A', '=A'])(gfunc)
         self.assertEqual(g1(3. * ureg.meter, 1. * ureg.centimeter), rst.to('centimeter'))
@@ -375,9 +376,12 @@ class TestRegistry(QuantityTestCase):
         a = 3. * ureg.meter
         b = (2. * ureg.centimeter) ** 2
         self.assertEqual(g3(a, b), gfunc2(a, b))
+        self.assertEqual(g3(3, 2), gfunc2(3, 2))
 
         g4 = ureg.wraps('=A**2 * B', ['=A', '=B'])(gfunc3)
         self.assertEqual(g4(3. * ureg.meter, 2. * ureg.second), ureg('(3*meter)**2 * 2 *second'))
+        self.assertEqual(g4(3. * ureg.meter, 2.), ureg('(3*meter)**2 * 2'))
+        self.assertEqual(g4(3., 2. * ureg.second), ureg('3**2 * 2 * second'))
 
 
     def test_check(self):


### PR DESCRIPTION
when wrapping a function with UnitRegistry.wraps, we enforce that
every argument that has a variable unit actually has a unit.
This means we cannot use the function in the way it was used before.

As an example:

    @ureg.wraps("=A", ("=A", "=A"))
    def f(x, y):
        return x + y

    f(3 * ureg.m, 4 * ureg.m)  # works fine
    f(3, 4)  # doesn't work, but should
    f(3, 4 * ureg.m)  # should (and does) raise an exception

This PR simply treats every non-pint-quantity as dimensionless.