### PR TITLE
Change `UndefinedUnitError` to inherit from `AttributeError`

### DIFF
--- a/pint/errors.py
+++ b/pint/errors.py
@@ -19,7 +19,7 @@ class DefinitionSyntaxError(ValueError):
     """
 
     def __init__(self, msg, filename=None, lineno=None):
-        super(ValueError, self).__init__()
+        super(DefinitionSyntaxError, self).__init__()
         self.msg = msg
         self.filename = None
         self.lineno = None
@@ -34,7 +34,7 @@ class RedefinitionError(ValueError):
     """
 
     def __init__(self, name, definition_type):
-        super(ValueError, self).__init__()
+        super(RedefinitionError, self).__init__()
         self.name = name
         self.definition_type = definition_type
         self.filename = None

--- a/pint/errors.py
+++ b/pint/errors.py
@@ -49,12 +49,12 @@ class RedefinitionError(ValueError):
         return msg
 
 
-class UndefinedUnitError(ValueError):
+class UndefinedUnitError(AttributeError):
     """Raised when the units are not defined in the unit registry.
     """
 
     def __init__(self, unit_names):
-        super(ValueError, self).__init__()
+        super(UndefinedUnitError, self).__init__()
         self.unit_names = unit_names
 
     def __str__(self):

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -234,7 +234,7 @@ class TestIssues(QuantityTestCase):
 
         for func in (ureg.get_name, ureg.parse_expression):
             val = func('meter')
-            self.assertRaises(ValueError, func, 'METER')
+            self.assertRaises(AttributeError, func, 'METER')
             self.assertEqual(val, func('METER', False))
 
     def test_issue104(self):


### PR DESCRIPTION
Running doctests that use Pint fail because the unit registry raises the wrong error if an attribute is not found, in this case:

```
>>> from pint import UnitRegistry
>>> ur = UnitRegistry()
>>> hasattr(ur, '__wrapped__')
False
```

is the desired behaviour. In current master branch this little test will fail with a `UndefinedUnitError` exception. Changing the `UndefinedUnitError` to inherit from `AttributeError` fixes the issue.