### PR TITLE
Added [concentration] quantity, with molar units. Closes #526.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ MANIFEST
 
 # WebDAV file system cache files
 .DAV/
+
+# tags files (from ctags)
+tags

--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -72,6 +72,10 @@ cmil = 5.067075e-10 * m ** 2 = circular_mils
 darcy = 9.869233e-13 * m ** 2
 hectare = 100 * are = ha
 
+# Concentration
+[concentration] = [substance] / [volume]
+molar = mol / (1e-3 * m ** 3) = M
+
 # EM
 esu = 1 * erg**0.5 * centimeter**0.5 = statcoulombs = statC = franklin = Fr
 esu_per_second = 1 * esu / second = statampere

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -39,7 +39,6 @@ class TestIssues(QuantityTestCase):
 
     def test_issue29(self):
         ureg = UnitRegistry()
-        ureg.define('molar = mole / liter = M')
         t = 4 * ureg('mM')
         self.assertEqual(t.magnitude, 4)
         self.assertEqual(t._units, UnitsContainer(millimolar=1))


### PR DESCRIPTION
In addition I modified a test that had defined molar units locally, and added tags files to the .gitignore.

I think I ran all the tests but I wasn't quite sure how they were run, so it's possible I missed some, but in that case your CI should catch them. Additionally, I was unsure if the [concentration] def in line 76 will function properly, as [volume] is defined later in that file, but it didn't seem to cause any issues when I played with it. 

Happy to make any necessary changes, of course.