### PR TITLE
Fix for issue #506

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -243,7 +243,7 @@ common_year = 365 * day
 leap_year = 366 * day
 julian_year = 365.25 * day
 gregorian_year = 365.2425 * day
-millenium = 1000 * year = millenia = milenia = milenium
+millennium = 1000 * year = millennia
 eon = 1e9 * year
 work_year = 2056 * hour
 work_month = work_year / 12

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -302,7 +302,7 @@ class TestIssues(QuantityTestCase):
 
     def test_issue506(self):
         ureg = UnitRegistry()
-        self.assertEqual(ureg['millennium'], ureg['millennia'])
+        self.assertEqual(ureg('millennium'), ureg('millennia'))
         self.assertRaises(UndefinedUnitError, ureg.parse_expression, 'millenium')
 
 

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -303,7 +303,7 @@ class TestIssues(QuantityTestCase):
     def test_issue506(self):
         ureg = UnitRegistry()
         self.assertEqual(ureg['millennium'], ureg['millennia'])
-        self.assertRaises(UndefinedUnitError, ureg.Quantity, 'millenium')
+        self.assertRaises(UndefinedUnitError, ureg.parse_expression, 'millenium')
 
 
 @helpers.requires_numpy()

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -300,6 +300,11 @@ class TestIssues(QuantityTestCase):
         except SyntaxError:
             self.fail('Quantity with µ prefix could not be created.')
 
+    def test_issue506(self):
+        ureg = UnitRegistry()
+        self.assertEqual(ureg['millennium'], ureg['millennia'])
+        self.assertRaises(UndefinedUnitError, ureg.Quanity, 'millenium')
+
 
 @helpers.requires_numpy()
 class TestIssuesNP(QuantityTestCase):

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -303,7 +303,7 @@ class TestIssues(QuantityTestCase):
     def test_issue506(self):
         ureg = UnitRegistry()
         self.assertEqual(ureg['millennium'], ureg['millennia'])
-        self.assertRaises(UndefinedUnitError, ureg.Quanity, 'millenium')
+        self.assertRaises(UndefinedUnitError, ureg.Quantity, 'millenium')
 
 
 @helpers.requires_numpy()


### PR DESCRIPTION
This changes the spelling of **millennium** in the default definition file, raised by issue #506 . It is a breaking change for anything that was defined with the misspelled version, as these versions of the unit were removed. To maintain backwards compatibility, these could be added back as aliases. It also has not been changed in the default_en_0.6 definition file. 