### PR TITLE
Matplotlib support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,6 +32,7 @@ Other contributors, listed alphabetically, are:
 * Richard Barnes <rbarnes@umn.edu>
 * Ryan Dwyer <ryanpdwyer@gmail.com>
 * Ryan Kingsbury <RyanSKingsbury@alumni.unc.edu>
+* Ryan May
 * Sundar Raman <cybertoast@gmail.com>
 * Tiago Coutinho <coutinho@esrf.fr>
 * Thomas Kluyver <takowl@gmail.com>

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,8 @@ Pint Changelog
 0.9 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add support for registering with matplotlib's unit handling
+  (Issue #317, thanks dopplershift)
 
 
 0.8.1 (2017-06-05)
@@ -34,7 +35,7 @@ Pint Changelog
   (Issue #95)
 - Implemented a function decorator to ensure that a context is active (with_context)
   (Issue #465)
-- Add warning when a System contains an unknown Group. 
+- Add warning when a System contains an unknown Group.
   (Issue #472)
 - Add conda-forge installation snippet.
   (Issue #485, thanks stadelmanma)
@@ -57,7 +58,7 @@ Pint Changelog
   (Issues #448, thanks gdonval)
 - Improved Parser to support capital "E" on scientific notation.
   (Issue #390, thanks javenoneal)
-- Make sure that prefixed units are defined on the registry when unplicking.
+- Make sure that prefixed units are defined on the registry when unpickling.
   (Issue #405)
 - Automatic unit names translation through babel.
   (Issue #338, thanks alexbodn)
@@ -234,7 +235,7 @@ Pint Changelog
   (Issue #107, thanks rec)
 - Added UnitRegistry () operator to parse expression replacing [].
   (Issue #106, thanks rec)
-- Optional case insensitive unit parsing. 
+- Optional case insensitive unit parsing.
   (Issue #105, thanks rec, jeremyfreeman, dbrnz)
 - Change the Quantity mutability depending on magnitude type.
   (Issue #104, thanks rec)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ import datetime
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.coverage', 'sphinx.ext.viewcode', 'sphinx.ext.mathjax']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.coverage', 'sphinx.ext.viewcode', 'sphinx.ext.mathjax', 'matplotlib.sphinxext.plot_directive']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -115,6 +115,7 @@ User Guide
     numpy
     nonmult
     wrapping
+    plotting
     serialization
     pitheorem
     contexts

--- a/docs/plotting.rst
+++ b/docs/plotting.rst
@@ -1,0 +1,75 @@
+.. _plotting:
+
+
+Plotting with Matplotlib
+========================
+
+Matplotlib_ is a Python plotting library that produces a wide range of plot types
+with publication-quality images and support for typesetting mathematical formulas.
+Starting with Matplotlib 2.0, **Quantity** instances can be used with matplotlib's
+support for units when plotting. To do so, the support must be manually enabled on
+a **UnitRegistry**:
+
+.. testsetup:: *
+
+   import pint
+   ureg = pint.UnitRegistry()
+
+.. doctest::
+
+   >>> import pint
+   >>> ureg = pint.UnitRegistry()
+   >>> ureg.setup_matplotlib()
+
+This support can also be disabled with:
+
+.. doctest::
+
+   >>> ureg.setup_matplotlib(False)
+
+This allows then plotting quantities with different units:
+
+.. plot::
+   :include-source: true
+
+   import matplotlib.pyplot as plt
+   import numpy as np
+   import pint
+
+   ureg = pint.UnitRegistry()
+   ureg.setup_matplotlib(True)
+
+   y = np.linspace(0, 30) * ureg.miles
+   x = np.linspace(0, 5) * ureg.hours
+
+   fig, ax = plt.subplots()
+   ax.plot(x, y, 'tab:blue')
+   ax.axhline(26400 * ureg.feet, color='tab:red')
+   ax.axvline(120 * ureg.minutes, color='tab:green')
+
+This also allows controlling the actual plotting units for the x and y axes:
+
+.. plot::
+   :include-source: true
+
+   import matplotlib.pyplot as plt
+   import numpy as np
+   import pint
+
+   ureg = pint.UnitRegistry()
+   ureg.setup_matplotlib(True)
+
+   y = np.linspace(0, 30) * ureg.miles
+   x = np.linspace(0, 5) * ureg.hours
+
+   fig, ax = plt.subplots()
+   ax.yaxis.set_units(ureg.inches)
+   ax.xaxis.set_units(ureg.seconds)
+
+   ax.plot(x, y, 'tab:blue')
+   ax.axhline(26400 * ureg.feet, color='tab:red')
+   ax.axvline(120 * ureg.minutes, color='tab:green')
+
+For more information, visit the Matplotlib_ home page.
+
+.. _Matplotlib: https://matplotlib.org

--- a/pint/matplotlib.py
+++ b/pint/matplotlib.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""
+    pint.matplotlib
+    ~~~~~~~~~
+
+    Functions and classes related to working with Matplotlib's support
+    for plotting with units.
+
+    :copyright: 2017 by Pint Authors, see AUTHORS for more details.
+    :license: BSD, see LICENSE for more details.
+"""
+import matplotlib.units
+
+
+class PintAxisInfo(matplotlib.units.AxisInfo):
+    """Support default axis and tick labeling and default limits."""
+
+    def __init__(self, units):
+        """Set the default label to the pretty-print of the unit."""
+        super(PintAxisInfo, self).__init__(label='{:P}'.format(units))
+
+
+class PintConverter(matplotlib.units.ConversionInterface):
+    """Implement support for pint within matplotlib's unit conversion framework."""
+
+    def __init__(self, registry):
+        super(PintConverter, self).__init__()
+        self._reg = registry
+
+    def convert(self, value, unit, axis):
+        """Convert :`Quantity` instances for matplotlib to use."""
+        if isinstance(value, (tuple, list)):
+            return [self._convert_value(v, unit, axis) for v in value]
+        else:
+            return self._convert_value(value, unit, axis)
+
+    def _convert_value(self, value, unit, axis):
+        """Handle converting using attached unit or falling back to axis units."""
+        if hasattr(value, 'units'):
+            return value.to(unit).magnitude
+        else:
+            return self._reg.Quantity(value, axis.get_units()).to(unit).magnitude
+
+    @staticmethod
+    def axisinfo(unit, axis):
+        """Return axis information for this particular unit."""
+        return PintAxisInfo(unit)
+
+    @staticmethod
+    def default_units(x, axis):
+        """Get the default unit to use for the given combination of unit and axis."""
+        return getattr(x, 'units', None)
+
+
+def setup_matplotlib_handlers(registry, enable):
+    """Set up matplotlib's unit support to handle units from a registry.
+       :param registry: the registry that will be used
+       :type registry: UnitRegistry
+       :param enable: whether support should be enabled or disabled
+       :type enable: bool
+    """
+    if matplotlib.__version__ < '2.0':
+        raise RuntimeError('Matplotlib >= 2.0 required to work with pint.')
+
+    if enable:
+        matplotlib.units.registry[registry.Quantity] = PintConverter(registry)
+    else:
+        matplotlib.units.registry.pop(registry.Quantity, None)

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -557,14 +557,14 @@ class BaseRegistry(meta.with_metaclass(_Meta)):
                 reg = self._units[self.get_name(key)]
                 if reg.reference is not None:
                     self._get_dimensionality_recurse(reg.reference, exp2, accumulator)
-                    
+
     def _get_dimensionality_ratio(self, unit1, unit2):
-        """ Get the exponential ratio between two units, i.e. solve unit2 = unit1**x for x. 
+        """ Get the exponential ratio between two units, i.e. solve unit2 = unit1**x for x.
         :param unit1: first unit
         :type unit1: UnitsContainer compatible (str, Unit, UnitsContainer, dict)
         :param unit2: second unit
         :type unit2: UnitsContainer compatible (str, Unit, UnitsContainer, dict)
-        :returns: exponential proportionality or None if the units cannot be converted 
+        :returns: exponential proportionality or None if the units cannot be converted
         """
         #shortcut in case of equal units
         if unit1 == unit2:
@@ -573,13 +573,13 @@ class BaseRegistry(meta.with_metaclass(_Meta)):
         dim1, dim2 = (self.get_dimensionality(unit) for unit in (unit1, unit2))
         if not dim1 or not dim2 or dim1.keys() != dim2.keys(): #not comparable
             return None
-        
+
         ratios = (dim2[key]/val for key, val in dim1.items())
         first = next(ratios)
         if all(r == first for r in ratios): #all are same, we're good
             return first
         return None
-            
+
     def get_root_units(self, input_units, check_nonmult=True):
         """Convert unit or dict of units to the root units.
 
@@ -1489,6 +1489,15 @@ class UnitRegistry(SystemRegistry, ContextRegistry, NonMultiplicativeRegistry):
         :return: a list of dimensionless quantities expressed as dicts
         """
         return pi_theorem(quantities, self)
+
+    def setup_matplotlib(self, enable=True):
+        """Set up handlers for matplotlib's unit support.
+        :param enable: whether support should be enabled or disabled
+        :type enable: bool
+        """
+        # Delays importing matplotlib until it's actually requested
+        from .matplotlib import setup_matplotlib_handlers
+        setup_matplotlib_handlers(self, enable)
 
     wraps = registry_helpers.wraps
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,0 +1,2 @@
+matplotlib
+numpy


### PR DESCRIPTION
This adds a method to `UnitRegistry` that hooks up handlers for `Quantity` instances within matplotlib's unit machinery:
```python
import pint
ureg = pint.UnitRegistry()
ureg.setup_matplotlib()
```
This support can also be disabled with:
```python
ureg.setup_matplotlib(False)
```

Closes #317.