### PR TITLE
Improve IPython pretty printers

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -238,6 +238,12 @@ class _Quantity(SharedRegistryObject):
         else:
             return "${:L}$".format(self)
 
+    def _repr_pretty_(self, p, cycle):
+        if "~" in self.default_format:
+            p.text("{:~P}".format(self))
+        else:
+            p.text("{:P}".format(self))
+
     @property
     def magnitude(self):
         """Quantity's magnitude. Long form for `m`

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -219,10 +219,16 @@ class _Quantity(SharedRegistryObject):
 
     # IPython related code
     def _repr_html_(self):
-        return self.__format__('H')
+        if "~" in self.default_format:
+            return "{:~H}".format(self)
+        else:
+            return "{:H}".format(self)
 
     def _repr_latex_(self):
-        return "$" + self.__format__('L') + "$"
+        if "~" in self.default_format:
+            return "${:~L}$".format(self)
+        else:
+            return "${:L}$".format(self)
 
     @property
     def magnitude(self):

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -25,7 +25,7 @@ from .errors import (DimensionalityError, OffsetUnitCalculusError,
                      UndefinedUnitError)
 from .definitions import UnitDefinition
 from .compat import string_types, ndarray, np, _to_magnitude, long_type
-from .util import (logger, UnitsContainer, SharedRegistryObject,
+from .util import (PrettyIPython, logger, UnitsContainer, SharedRegistryObject,
                    to_units_container, infer_base_unit,
                    fix_str_conversions)
 from pint.compat import Loc
@@ -66,7 +66,7 @@ def ireduce_dimensions(f):
 
 
 @fix_str_conversions
-class _Quantity(SharedRegistryObject):
+class _Quantity(PrettyIPython, SharedRegistryObject):
     """Implements a class to describe a physical quantity:
     the product of a numerical value and a unit of measurement.
 
@@ -224,25 +224,6 @@ class _Quantity(SharedRegistryObject):
         return '{} {}'.format(
             format(obj.magnitude, remove_custom_flags(spec)),
             obj.units.format_babel(spec, **kwspec)).replace('\n', '')
-
-    # IPython related code
-    def _repr_html_(self):
-        if "~" in self.default_format:
-            return "{:~H}".format(self)
-        else:
-            return "{:H}".format(self)
-
-    def _repr_latex_(self):
-        if "~" in self.default_format:
-            return "${:~L}$".format(self)
-        else:
-            return "${:L}$".format(self)
-
-    def _repr_pretty_(self, p, cycle):
-        if "~" in self.default_format:
-            p.text("{:~P}".format(self))
-        else:
-            p.text("{:P}".format(self))
 
     @property
     def magnitude(self):

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -207,6 +207,14 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
             ustr = ustr[2:]
         return allf.format(mstr, ustr).strip()
 
+    def _repr_pretty_(self, p, cycle):
+        if cycle:
+            super(_Quantity, self)._repr_pretty_(p, cycle)
+        else:
+            p.pretty(self.magnitude)
+            p.text(" ")
+            p.pretty(self.units)
+
     def format_babel(self, spec='', **kwspec):
         spec = spec or self.default_format
 

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -17,6 +17,7 @@ import functools
 import bisect
 import warnings
 import numbers
+import re
 
 from .formatting import (remove_custom_flags, siunitx_format_unit, ndarray_to_latex,
                          ndarray_to_latex_parts)
@@ -149,6 +150,8 @@ class _Quantity(SharedRegistryObject):
         else:
             return hash((self_base.__class__, self_base.magnitude, self_base.units))
 
+    _exp_pattern = re.compile(r"([0-9]\.?[0-9]*)e(-?)\+?0*([0-9]+)")
+
     def __format__(self, spec):
         spec = spec or self.default_format
 
@@ -193,6 +196,11 @@ class _Quantity(SharedRegistryObject):
                 mstr = format(obj.magnitude, mspec).replace('\n', '')
         else:
             mstr = format(obj.magnitude, mspec).replace('\n', '')
+
+        if 'L' in spec:
+            mstr = self._exp_pattern.sub(r"\1\\times 10^{\2\3}", mstr)
+        elif 'H' in spec:
+            mstr = self._exp_pattern.sub(r"\1×10<sup>\2\3</sup>", mstr)
 
         if allf == plain_allf and ustr.startswith('1 /'):
             # Write e.g. "3 / s" instead of "3 1 / s"

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -183,6 +183,13 @@ class TestQuantity(QuantityTestCase):
             def text(text):
                 alltext.append(text)
 
+            @classmethod
+            def pretty(cls, data):
+                try:
+                    data._repr_pretty_(cls, False)
+                except AttributeError:
+                    alltext.append(str(data))
+
         ureg = UnitRegistry()
         x = 3.5 * ureg.Unit(UnitsContainer(meter=2, kilogram=1, second=-1))
         self.assertEqual(x._repr_html_(),

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -166,6 +166,15 @@ class TestQuantity(QuantityTestCase):
             ureg.default_format = spec
             self.assertEqual('{0}'.format(x), result)
 
+    def test_exponent_formatting(self):
+        ureg = UnitRegistry()
+        x = ureg.Quantity(1e20, UnitsContainer(meter=1))
+        self.assertEqual("{:~H}".format(x), "1×10<sup>20</sup> m")
+        self.assertEqual("{:~L}".format(x), r"1\times 10^{20}\ \mathrm{m}")
+        x /= 1e40
+        self.assertEqual("{:~H}".format(x), "1×10<sup>-20</sup> m")
+        self.assertEqual("{:~L}".format(x), r"1\times 10^{-20}\ \mathrm{m}")
+
     def test_ipython(self):
         ureg = UnitRegistry()
         x = 3.5 * ureg.Unit(UnitsContainer(meter=2, kilogram=1, second=-1))

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -166,6 +166,15 @@ class TestQuantity(QuantityTestCase):
             ureg.default_format = spec
             self.assertEqual('{0}'.format(x), result)
 
+    def test_ipython(self):
+        ureg = UnitRegistry()
+        x = 3.5 * ureg.Unit(UnitsContainer(meter=2, kilogram=1, second=-1))
+        self.assertEqual(x._repr_html_(),
+                         "3.5 kilogram meter<sup>2</sup>/second")
+        self.assertEqual(x._repr_latex_(),
+                         r'$3.5\ \frac{\mathrm{kilogram} \cdot '
+                         r'\mathrm{meter}^{2}}{\mathrm{second}}$')
+
     def test_to_base_units(self):
         x = self.Q_('1*inch')
         self.assertQuantityAlmostEqual(x.to_base_units(), self.Q_(0.0254, 'meter'))

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -174,6 +174,11 @@ class TestQuantity(QuantityTestCase):
         self.assertEqual(x._repr_latex_(),
                          r'$3.5\ \frac{\mathrm{kilogram} \cdot '
                          r'\mathrm{meter}^{2}}{\mathrm{second}}$')
+        ureg.default_format = "~"
+        self.assertEqual(x._repr_html_(), "3.5 kg m<sup>2</sup>/s")
+        self.assertEqual(x._repr_latex_(),
+                         r'$3.5\ \frac{\mathrm{kg} \cdot '
+                         r'\mathrm{m}^{2}}{\mathrm{s}}$')
 
     def test_to_base_units(self):
         x = self.Q_('1*inch')

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -176,6 +176,13 @@ class TestQuantity(QuantityTestCase):
         self.assertEqual("{:~L}".format(x), r"1\times 10^{-20}\ \mathrm{m}")
 
     def test_ipython(self):
+        alltext = []
+
+        class Pretty(object):
+            @staticmethod
+            def text(text):
+                alltext.append(text)
+
         ureg = UnitRegistry()
         x = 3.5 * ureg.Unit(UnitsContainer(meter=2, kilogram=1, second=-1))
         self.assertEqual(x._repr_html_(),
@@ -183,11 +190,16 @@ class TestQuantity(QuantityTestCase):
         self.assertEqual(x._repr_latex_(),
                          r'$3.5\ \frac{\mathrm{kilogram} \cdot '
                          r'\mathrm{meter}^{2}}{\mathrm{second}}$')
+        x._repr_pretty_(Pretty, False)
+        self.assertEqual("".join(alltext), "3.5 kilogram·meter²/second")
         ureg.default_format = "~"
         self.assertEqual(x._repr_html_(), "3.5 kg m<sup>2</sup>/s")
         self.assertEqual(x._repr_latex_(),
                          r'$3.5\ \frac{\mathrm{kg} \cdot '
                          r'\mathrm{m}^{2}}{\mathrm{s}}$')
+        alltext = []
+        x._repr_pretty_(Pretty, False)
+        self.assertEqual("".join(alltext), "3.5 kg·m²/s")
 
     def test_to_base_units(self):
         x = self.Q_('1*inch')

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -63,6 +63,13 @@ class TestUnit(QuantityTestCase):
             self.assertEqual('{0}'.format(x), result,
                              'Failed for {0}, {1}'.format(spec, result))
 
+    def test_ipython(self):
+        ureg = UnitRegistry()
+        x = ureg.Unit(UnitsContainer(meter=2, kilogram=1, second=-1))
+        self.assertEqual(x._repr_html_(), "kilogram meter<sup>2</sup>/second")
+        self.assertEqual(x._repr_latex_(), r'$\frac{\mathrm{kilogram} \cdot '
+                                           r'\mathrm{meter}^{2}}{\mathrm{second}}$')
+
     def test_unit_mul(self):
         x = self.U_('m')
         self.assertEqual(x*1, self.Q_(1, 'm'))

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -69,6 +69,10 @@ class TestUnit(QuantityTestCase):
         self.assertEqual(x._repr_html_(), "kilogram meter<sup>2</sup>/second")
         self.assertEqual(x._repr_latex_(), r'$\frac{\mathrm{kilogram} \cdot '
                                            r'\mathrm{meter}^{2}}{\mathrm{second}}$')
+        ureg.default_format = "~"
+        self.assertEqual(x._repr_html_(), "kg m<sup>2</sup>/s")
+        self.assertEqual(x._repr_latex_(),
+                         r'$\frac{\mathrm{kg} \cdot \mathrm{m}^{2}}{\mathrm{s}}$')
 
     def test_unit_mul(self):
         x = self.U_('m')

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -64,15 +64,27 @@ class TestUnit(QuantityTestCase):
                              'Failed for {0}, {1}'.format(spec, result))
 
     def test_ipython(self):
+        alltext = []
+
+        class Pretty(object):
+            @staticmethod
+            def text(text):
+                alltext.append(text)
+
         ureg = UnitRegistry()
         x = ureg.Unit(UnitsContainer(meter=2, kilogram=1, second=-1))
         self.assertEqual(x._repr_html_(), "kilogram meter<sup>2</sup>/second")
         self.assertEqual(x._repr_latex_(), r'$\frac{\mathrm{kilogram} \cdot '
                                            r'\mathrm{meter}^{2}}{\mathrm{second}}$')
+        x._repr_pretty_(Pretty, False)
+        self.assertEqual("".join(alltext), "kilogram·meter²/second")
         ureg.default_format = "~"
         self.assertEqual(x._repr_html_(), "kg m<sup>2</sup>/s")
         self.assertEqual(x._repr_latex_(),
                          r'$\frac{\mathrm{kg} \cdot \mathrm{m}^{2}}{\mathrm{s}}$')
+        alltext = []
+        x._repr_pretty_(Pretty, False)
+        self.assertEqual("".join(alltext), "kg·m²/s")
 
     def test_unit_mul(self):
         x = self.U_('m')

--- a/pint/unit.py
+++ b/pint/unit.py
@@ -112,10 +112,16 @@ class _Unit(SharedRegistryObject):
 
     # IPython related code
     def _repr_html_(self):
-        return self.__format__('H')
+        if "~" in self.default_format:
+            return "{:~H}".format(self)
+        else:
+            return "{:H}".format(self)
 
     def _repr_latex_(self):
-        return "$" + self.__format__('L') + "$"
+        if "~" in self.default_format:
+            return "${:~L}$".format(self)
+        else:
+            return "${:L}$".format(self)
 
     @property
     def dimensionless(self):

--- a/pint/unit.py
+++ b/pint/unit.py
@@ -15,7 +15,8 @@ import copy
 import operator
 from numbers import Number
 
-from .util import UnitsContainer, SharedRegistryObject, fix_str_conversions
+from .util import (
+    PrettyIPython, UnitsContainer, SharedRegistryObject, fix_str_conversions)
 
 from .compat import string_types, NUMERIC_TYPES, long_type
 from .formatting import siunitx_format_unit
@@ -23,7 +24,7 @@ from .definitions import UnitDefinition
 
 
 @fix_str_conversions
-class _Unit(SharedRegistryObject):
+class _Unit(PrettyIPython, SharedRegistryObject):
     """Implements a class to describe a unit supporting math operations.
 
     :type units: UnitsContainer, str, Unit or Quantity.
@@ -109,19 +110,6 @@ class _Unit(SharedRegistryObject):
             units = self._units
 
         return '%s' % (units.format_babel(spec, **kwspec))
-
-    # IPython related code
-    def _repr_html_(self):
-        if "~" in self.default_format:
-            return "{:~H}".format(self)
-        else:
-            return "{:H}".format(self)
-
-    def _repr_latex_(self):
-        if "~" in self.default_format:
-            return "${:~L}$".format(self)
-        else:
-            return "${:L}$".format(self)
 
     @property
     def dimensionless(self):

--- a/pint/util.py
+++ b/pint/util.py
@@ -625,6 +625,29 @@ class SharedRegistryObject(object):
         else:
             return False
 
+
+class PrettyIPython(object):
+    """Mixin to add pretty-printers for IPython"""
+
+    def _repr_html_(self):
+        if "~" in self.default_format:
+            return "{:~H}".format(self)
+        else:
+            return "{:H}".format(self)
+
+    def _repr_latex_(self):
+        if "~" in self.default_format:
+            return "${:~L}$".format(self)
+        else:
+            return "${:L}$".format(self)
+
+    def _repr_pretty_(self, p, cycle):
+        if "~" in self.default_format:
+            p.text("{:~P}".format(self))
+        else:
+            p.text("{:P}".format(self))
+
+
 def to_units_container(unit_like, registry=None):
     """ Convert a unit compatible type to a UnitsContainer.
 


### PR DESCRIPTION
IPython has nice ways to make objects look nice. Pint already implements the `_repr_html_` and `_repr_latex_` methods. This pull request:

- adds a `_repr_pretty_` method. This does pretty printing on the IPython command line.
- lets all `_repr_` methods obey the `default_format`. If the `default_format` contains a `~` character, most likely the user always wants the short version of the units, in all versions of `_repr_`.
- writes numbers in exponential form as such, so `3.5e15` is formatted as 3.5×10<sup>15</sup>, in both L<sup>A</sup>T<sub>E</sub>X and HTML.