### PR TITLE
Added warning for unsupported ufunc

### DIFF
--- a/pint/__init__.py
+++ b/pint/__init__.py
@@ -18,7 +18,7 @@ import pkg_resources
 from .formatting import formatter
 from .registry import (UnitRegistry, LazyRegistry)
 from .errors import (DimensionalityError, OffsetUnitCalculusError,
-                   UndefinedUnitError)
+                   UndefinedUnitError, UnitStrippedWarning)
 from .util import pi_theorem, logger
 
 from .context import Context

--- a/pint/errors.py
+++ b/pint/errors.py
@@ -111,3 +111,7 @@ class OffsetUnitCalculusError(ValueError):
                ', '.join(['%s' % u for u in [self.units1, self.units2] if u])
                + self.extra_msg)
         return msg.format(self.units1, self.units2)
+
+
+class UnitStrippedWarning(UserWarning):
+    pass

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -22,7 +22,7 @@ import re
 from .formatting import (remove_custom_flags, siunitx_format_unit, ndarray_to_latex,
                          ndarray_to_latex_parts)
 from .errors import (DimensionalityError, OffsetUnitCalculusError,
-                     UndefinedUnitError)
+                     UndefinedUnitError, UnitStrippedWarning)
 from .definitions import UnitDefinition
 from .compat import string_types, ndarray, np, _to_magnitude, long_type
 from .util import (PrettyIPython, logger, UnitsContainer, SharedRegistryObject,
@@ -1308,6 +1308,7 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
         # Attributes starting with `__array_` are common attributes of NumPy ndarray.
         # They are requested by numpy functions.
         if item.startswith('__array_'):
+            warnings.warn("The unit of the quantity is stripped.", UnitStrippedWarning)
             if isinstance(self._magnitude, ndarray):
                 return getattr(self._magnitude, item)
             else:


### PR DESCRIPTION
This PR attempts to close #620.

A ```UnitStrippedWarning``` is raised when an unsupported numpy ufunc is performed on the quantity.

This warning can be muted or amplified using ```warnings.simplefilter()```, for example,

```python
import warnings
import numpy as np
from pint import UnitRegistry, UnitStrippedWarning
warnings.simplefilter('ignore', category=UnitStrippedWarning)

ureg=UnitRegistry()
dist=24*ureg.meter

print(np.power(dis,2))

```