### PR TITLE
prevent Travis from building bors tmp branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: python
 
+branches:
+  # prevent bors temporary branches to be built
+  except:
+  - staging.tmp
+  - trying.tmp
+
 env:
   - UNCERTAINTIES="N" PYTHON="3.3" NUMPY_VERSION=1.9.2
   - UNCERTAINTIES="N" PYTHON="3.4" NUMPY_VERSION=1.11.2


### PR DESCRIPTION
As noticed in https://github.com/hgrecco/pint/pull/630#issuecomment-381284930 , Travis should not build the staging.tmp and trying.tmp branches used internally by bors. So blocklist them in travis.yml