### PR TITLE
Add Unit.from_ and Unit.m_from

### DIFF
--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -247,6 +247,26 @@ class TestQuantity(QuantityTestCase):
             self.assertIsNot(r, q)
             self.assertIsNot(r._magnitude, a)
 
+    def test_convert_from(self):
+        x = self.Q_('2*inch')
+        meter = self.ureg.meter
+
+        # from quantity
+        self.assertQuantityAlmostEqual(meter.from_(x), self.Q_(2. * 0.0254, 'meter'))
+        self.assertQuantityAlmostEqual(meter.m_from(x), 2. * 0.0254)
+
+        # from unit
+        self.assertQuantityAlmostEqual(meter.from_(self.ureg.inch), self.Q_(0.0254, 'meter'))
+        self.assertQuantityAlmostEqual(meter.m_from(self.ureg.inch), 0.0254)
+
+        # from number
+        self.assertQuantityAlmostEqual(meter.from_(2, strict=False), self.Q_(2., 'meter'))
+        self.assertQuantityAlmostEqual(meter.m_from(2, strict=False), 2.)
+
+        # from number (strict mode)
+        self.assertRaises(ValueError, meter.from_, 2)
+        self.assertRaises(ValueError, meter.m_from, 2)
+
     @helpers.requires_numpy()
     def test_retain_unit(self):
         # Test that methods correctly retain units and do not degrade into

--- a/pint/unit.py
+++ b/pint/unit.py
@@ -256,6 +256,37 @@ class _Unit(PrettyIPython, SharedRegistryObject):
                     out.add(sname)
         return frozenset(out)
 
+    def from_(self, value, strict=True, name='value'):
+        """Converts a numerical value or quantity to this unit
+
+        :param value: a Quantity (or numerical value if strict=False) to convert
+        :param strict: boolean to indicate that only quanities are accepted
+        :param name: descriptive name to use if an exception occurs
+        :return: The converted value as this unit
+        :raises:
+            :class:`ValueError` if strict and one of the arguments is not a Quantity.
+        """
+        if self._check(value):
+            if not isinstance(value, self._REGISTRY.Quantity):
+                value = self._REGISTRY.Quantity(1, value)
+            return value.to(self)
+        elif strict:
+            raise ValueError("%s must be a Quantity" % value)
+        else:
+            return value * self
+
+    def m_from(self, value, strict=True, name='value'):
+        """Converts a numerical value or quantity to this unit, then returns
+        the magnitude of the converted value
+
+        :param value: a Quantity (or numerical value if strict=False) to convert
+        :param strict: boolean to indicate that only quanities are accepted
+        :param name: descriptive name to use if an exception occurs
+        :return: The magnitude of the converted value
+        :raises:
+            :class:`ValueError` if strict and one of the arguments is not a Quantity.
+        """
+        return self.from_(value, strict=strict, name=name).magnitude
 
 def build_unit_class(registry):
 


### PR DESCRIPTION
Converts from a number or quantity to the unit (or the magnitude). This is most useful for when you aren't sure if the input is a Quantity.

While you could technically use `ureg.check()` for this, it's syntactically cleaner (and I suspect more performant) to use this:

```
ureg.inch.from_(1*foot)
ureg.inch.from_(1, strict=False)
```

Added tests and docstrings. I'm not quite sure where in the docs this should go, but I'm willing to add a blurb in there if you'll point me to the right place.