### PR TITLE
Add if to handle np.array with ndim == 0 on latex repr.

### DIFF
--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -295,6 +295,9 @@ def ndarray_to_latex_parts(ndarr, fmtfun=lambda x: format(x, '.2f'), dim=()):
         fmt = fmtfun
         fmtfun = lambda x: format(x, fmt)
 
+    if ndarr.ndim == 0:
+        _ndarr = ndarr.reshape(1)
+        return [vector_to_latex(_ndarr, fmtfun)]
     if ndarr.ndim == 1:
         return [vector_to_latex(ndarr, fmtfun)]
     if ndarr.ndim == 2:


### PR DESCRIPTION
Closes #587.
This adds a check for the array dimension. If it is 0, a reshaped array is
used (with dim = 1). 
The purpose of this PR is that ```Q_([1], 'bar')```, ```Q_(np.array([1]), 'bar')``` and ```Q_(np.array(1), 'bar')``` will have the same latex output in the jupyter notebook.
Currently, we have the following behavior on the jupyter notebook:

```python
import pint
import numpy as np

ureg = pint.UnitRegistry()
Q_ = ureg.Quantity

Q_([1], 'bar')
output : (1)bar

Q_(np.array([1]), 'bar')
output : (1)bar

Q_(np.array(1), 'bar')
output : 
---------------------------------------------------------
TypeError               Traceback (most recent call last)
~/anaconda3/envs/prf/lib/python3.6/site-packages/IPython/core/formatters.py in __call__(self, obj)
    343             method = get_real_method(obj, self.print_method)
    344             if method is not None:
--> 345                 return method()
    346             return None
    347         else:

~/pint/pint/util.py in _repr_html_(self)
    634             return "{:~H}".format(self)
    635         else:
--> 636             return "{:H}".format(self)
    637 
    638     def _repr_latex_(self):

~/pint/pint/quantity.py in __format__(self, spec)
    187                 # this is required to have the magnitude and unit in the same line
    188                 allf = r'\[{} {}\]'
--> 189                 parts = ndarray_to_latex_parts(obj.magnitude, mspec)
    190 
    191                 if len(parts) > 1:

~/pint/pint/formatting.py in ndarray_to_latex_parts(ndarr, fmtfun, dim)
    310                 ret += [header % elno + ' = ' + matrix_to_latex(el, fmtfun)]
    311         else:
--> 312             for elno, el in enumerate(ndarr):
    313                 ret += ndarray_to_latex_parts(el, fmtfun, dim + (elno, ))
    314 

TypeError: iteration over a 0-d array

---------------------------------------------------------
TypeError               Traceback (most recent call last)
~/anaconda3/envs/prf/lib/python3.6/site-packages/IPython/core/formatters.py in __call__(self, obj)
    343             method = get_real_method(obj, self.print_method)
    344             if method is not None:
--> 345                 return method()
    346             return None
    347         else:

~/pint/pint/util.py in _repr_latex_(self)
    640             return "${:~L}$".format(self)
    641         else:
--> 642             return "${:L}$".format(self)
    643 
    644     def _repr_pretty_(self, p, cycle):

~/pint/pint/quantity.py in __format__(self, spec)
    183         if isinstance(self.magnitude, ndarray):
    184             if 'L' in spec:
--> 185                 mstr = ndarray_to_latex(obj.magnitude, mspec)
    186             elif 'H' in spec:
    187                 # this is required to have the magnitude and unit in the same line

~/pint/pint/formatting.py in ndarray_to_latex(ndarr, fmtfun, dim)
    317 
    318 def ndarray_to_latex(ndarr, fmtfun=lambda x: format(x, '.2f'), dim=()):
--> 319         return '\n'.join(ndarray_to_latex_parts(ndarr, fmtfun, dim))

~/pint/pint/formatting.py in ndarray_to_latex_parts(ndarr, fmtfun, dim)
    310                 ret += [header % elno + ' = ' + matrix_to_latex(el, fmtfun)]
    311         else:
--> 312             for elno, el in enumerate(ndarr):
    313                 ret += ndarray_to_latex_parts(el, fmtfun, dim + (elno, ))
    314 

TypeError: iteration over a 0-d array
```