### PR TITLE
Wraps handles keywords (closes #625, closes #651)

### DIFF
--- a/docs/wrapping.rst
+++ b/docs/wrapping.rst
@@ -151,7 +151,7 @@ airmass::
 Optional arguments
 ------------------
 
-For a function with named keywords with optional values, use a tuple for all
+In Python 3, for a function with named keywords with optional values, use a tuple for all
 arguments:
 
 .. doctest::
@@ -202,7 +202,7 @@ You can use more than one label:
     ... def some_function(x, y, z):
     ...     pass
 
-With optional arguments:
+With optional arguments in Python 3:
 
 .. doctest::
 

--- a/docs/wrapping.rst
+++ b/docs/wrapping.rst
@@ -151,7 +151,7 @@ airmass::
 Optional arguments
 ------------------
 
-In Python 3, for a function with named keywords with optional values, use a tuple for all
+For a function with named keywords with optional values, use a tuple for all
 arguments:
 
 .. doctest::
@@ -202,7 +202,7 @@ You can use more than one label:
     ... def some_function(x, y, z):
     ...     pass
 
-With optional arguments in Python 3:
+With optional arguments
 
 .. doctest::
 

--- a/docs/wrapping.rst
+++ b/docs/wrapping.rst
@@ -148,6 +148,37 @@ airmass::
     def solar_position(lat, lon, press, tamb, timestamp):
         return zenith, azimuth, airmass
 
+Optional arguments
+------------------
+
+For a function with named keywords with optional values, use a tuple for all
+arguments:
+
+.. doctest::
+
+    >>> @ureg.wraps(ureg.second, (ureg.meters, ureg.meters/ureg.second**2))
+    ... def calculate_time_to_fall(height, gravity=Q_(9.8, 'm/s^2'), verbose=False):
+    ...     """Calculate time to fall from a height h.
+    ...
+    ...     By default, the gravity is assumed to be earth gravity,
+    ...     but it can be modified.
+    ...
+    ...     d = .5 * g * t**2
+    ...     t = sqrt(2 * d / g)
+    ...     """
+    ...     t = sqrt(2 * height / gravity)
+    ...     if verbose: print(str(t) + " seconds to fall")
+    ...     return t
+    ...
+    >>> lunar_module_height = Q_(22, 'feet') + Q_(11, 'inches')
+    >>> calculate_time_to_fall(lunar_module_height, verbose=True)
+    1.1939473204801092 seconds to fall
+    <Quantity(1.1939473204801092, 'second')>
+    >>>
+    >>> moon_gravity = Q_(1.625, 'm/s^2')
+    >>> tcalculate_time_to_fall(lunar_module_height, moon_gravity)
+    <Quantity(2.932051001760214, 'second')>
+
 
 Specifying relations between arguments
 --------------------------------------
@@ -170,6 +201,19 @@ You can use more than one label:
     >>> @ureg.wraps('=A**2*B', ('=A', '=A*B', '=B'))
     ... def some_function(x, y, z):
     ...     pass
+
+With optional arguments:
+
+.. doctest::
+
+    >>> @ureg.wraps('=A*B', ('=A', '=B'))
+    ... def get_displacement(time, rate=Q_(1, 'm/s')):
+    ...     return time * rate
+    ...
+    >>> get_displacement(Q_(2, 's'))
+    <Quantity(2, 'meter')>
+    >>> get_displacement(Q_(2, 's'), Q_(1, 'deg/s'))
+    <Quantity(2, 'degree')>
 
 
 Ignoring an argument or return value

--- a/pint/registry_helpers.py
+++ b/pint/registry_helpers.py
@@ -18,8 +18,8 @@ from .util import to_units_container, UnitsContainer
 try:
     from inspect import signature
 except ImportError:
-    # Python2 does not have the inspect library.
-    pass
+    # Python2 does not have the inspect library. Import the backport.
+    from funcsigs import signature
 
 # for detecting whether we can support the inspect library
 import sys 
@@ -174,18 +174,18 @@ def wraps(ureg, ret, args, strict=True):
         @functools.wraps(func, assigned=assigned, updated=updated)
         def wrapper(*values, **kw):
 
-            if sys.version_info >= (3, 0):
-                # Named keywords may have been left blank. Wherever the named keyword is blank,
-                # fill it in with the default value.
-                sig = signature(func)
-                bound_arguments = sig.bind(*values, **kw)
 
-                for param in sig.parameters.values():
-                    if param.name not in bound_arguments.arguments:
-                        bound_arguments.arguments[param.name] = param.default
+            # Named keywords may have been left blank. Wherever the named keyword is blank,
+            # fill it in with the default value.
+            sig = signature(func)
+            bound_arguments = sig.bind(*values, **kw)
 
-                values = [bound_arguments.arguments[key] for key in sig.parameters.keys()]
-                kw = {}
+            for param in sig.parameters.values():
+                if param.name not in bound_arguments.arguments:
+                    bound_arguments.arguments[param.name] = param.default
+
+            values = [bound_arguments.arguments[key] for key in sig.parameters.keys()]
+            kw = {}
                 
             # In principle, the values are used as is
             # When then extract the magnitudes when needed.

--- a/pint/registry_helpers.py
+++ b/pint/registry_helpers.py
@@ -21,9 +21,6 @@ except ImportError:
     # Python2 does not have the inspect library. Import the backport.
     from funcsigs import signature
 
-# for detecting whether we can support the inspect library
-import sys 
-
 
 def _replace_units(original_units, values_by_name):
     """Convert a unit compatible type to a UnitsContainer.

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -571,3 +571,49 @@ class TestIssuesNP(QuantityTestCase):
 
         self.assertEqual(f(ureg.Quantity(1, '')), 2)
         self.assertRaises(DimensionalityError, f, ureg.Quantity(1, 'm'))
+
+    @helpers.requires_python3()
+    def test_issue625a(self):
+        from inspect import signature
+        ureg = UnitRegistry()
+        Q_ = ureg.Quantity
+        from math import sqrt
+
+        @ureg.wraps(ureg.second, (ureg.meters, ureg.meters/ureg.second**2))
+        def calculate_time_to_fall(height, gravity=Q_(9.8, 'm/s^2')):
+            """Calculate time to fall from a height h with a default gravity.
+
+            By default, the gravity is assumed to be earth gravity,
+            but it can be modified.
+
+            d = .5 * g * t**2
+            t = sqrt(2 * d / g)
+            """
+            return sqrt(2 * height / gravity)
+
+        lunar_module_height = Q_(10, 'm')
+        t1 = calculate_time_to_fall(lunar_module_height)
+        print(t1)
+        self.assertAlmostEqual(t1, Q_(1.4285714285714286, 's'))
+
+        moon_gravity = Q_(1.625, 'm/s^2')
+        t2 = calculate_time_to_fall(lunar_module_height, moon_gravity)
+        self.assertAlmostEqual(t2, Q_(3.508232077228117, 's'))
+
+    @helpers.requires_python3()
+    def test_issue625b(self):
+        from inspect import signature
+        ureg = UnitRegistry()
+        Q_ = ureg.Quantity
+
+        @ureg.wraps('=A*B', ('=A', '=B'))
+        def get_displacement(time, rate=Q_(1, 'm/s')):
+            """Calculates displacement from a duration and default rate.
+            """
+            return time * rate
+
+        d1 = get_displacement(Q_(2, 's'))
+        self.assertAlmostEqual(d1, Q_(2, 'm'))
+
+        d2 = get_displacement(Q_(2, 's'), Q_(1, 'deg/s'))
+        self.assertAlmostEqual(d2, Q_(2,' deg'))

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -573,7 +573,12 @@ class TestIssuesNP(QuantityTestCase):
         self.assertRaises(DimensionalityError, f, ureg.Quantity(1, 'm'))
 
     def test_issue625a(self):
+    try:
         from inspect import signature
+    except ImportError:
+        # Python2 does not have the inspect library. Import the backport.
+        from funcsigs import signature
+
         ureg = UnitRegistry()
         Q_ = ureg.Quantity
         from math import sqrt
@@ -600,7 +605,12 @@ class TestIssuesNP(QuantityTestCase):
         self.assertAlmostEqual(t2, Q_(3.508232077228117, 's'))
 
     def test_issue625b(self):
+    try:
         from inspect import signature
+    except ImportError:
+        # Python2 does not have the inspect library. Import the backport.
+        from funcsigs import signature
+
         ureg = UnitRegistry()
         Q_ = ureg.Quantity
 

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -572,7 +572,6 @@ class TestIssuesNP(QuantityTestCase):
         self.assertEqual(f(ureg.Quantity(1, '')), 2)
         self.assertRaises(DimensionalityError, f, ureg.Quantity(1, 'm'))
 
-    @helpers.requires_python3()
     def test_issue625a(self):
         from inspect import signature
         ureg = UnitRegistry()
@@ -600,7 +599,6 @@ class TestIssuesNP(QuantityTestCase):
         t2 = calculate_time_to_fall(lunar_module_height, moon_gravity)
         self.assertAlmostEqual(t2, Q_(3.508232077228117, 's'))
 
-    @helpers.requires_python3()
     def test_issue625b(self):
         from inspect import signature
         ureg = UnitRegistry()

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -573,11 +573,11 @@ class TestIssuesNP(QuantityTestCase):
         self.assertRaises(DimensionalityError, f, ureg.Quantity(1, 'm'))
 
     def test_issue625a(self):
-    try:
-        from inspect import signature
-    except ImportError:
-        # Python2 does not have the inspect library. Import the backport.
-        from funcsigs import signature
+        try:
+            from inspect import signature
+        except ImportError:
+            # Python2 does not have the inspect library. Import the backport.
+            from funcsigs import signature
 
         ureg = UnitRegistry()
         Q_ = ureg.Quantity
@@ -605,11 +605,11 @@ class TestIssuesNP(QuantityTestCase):
         self.assertAlmostEqual(t2, Q_(3.508232077228117, 's'))
 
     def test_issue625b(self):
-    try:
-        from inspect import signature
-    except ImportError:
-        # Python2 does not have the inspect library. Import the backport.
-        from funcsigs import signature
+        try:
+            from inspect import signature
+        except ImportError:
+            # Python2 does not have the inspect library. Import the backport.
+            from funcsigs import signature
 
         ureg = UnitRegistry()
         Q_ = ureg.Quantity

--- a/setup.py
+++ b/setup.py
@@ -60,4 +60,10 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
-    ])
+    ],
+    extras_require={
+        ':python_version == "2.7"': [
+            'funcsigs',
+        ],
+    },
+    )


### PR DESCRIPTION
This passed the test that I wrote, and didn't break anything else when I tested it on my Python 3 install.

I import `inspect`, which is only available in Python3. I'm not sure how to cleanly support Python2 at the same time...