### PR TITLE
Fixed inconsistency in definition of rps.

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -134,8 +134,9 @@ kip = 1000*lbf
 
 # Frequency
 [frequency] = 1 / [time]
-hertz = 1 / second = Hz = rps
+hertz = 1 / second = Hz
 revolutions_per_minute = revolution / minute = rpm
+revolutions_per_second = revolution / second = rps
 counts_per_second = count / second = cps
 
 # Heat


### PR DESCRIPTION
Correct behaviour is 1 rpm = 60 rps = 2 * pi * 60 Hz.