### PR TITLE
Fix `test_nonnumeric_magnitudes`

### DIFF
--- a/pint/__init__.py
+++ b/pint/__init__.py
@@ -26,7 +26,7 @@ from .context import Context
 
 try:                # pragma: no cover
     __version__ = pkg_resources.get_distribution('pint').version
-except:             # pragma: no cover
+except TypeError:  # pragma: no cover
     # we seem to have a local copy not installed without setuptools
     # so the reported version will be unknown
     __version__ = "unknown"

--- a/pint/compat/tokenize.py
+++ b/pint/compat/tokenize.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Tokenization help for Python programs.
 
 tokenize(readline) is a generator that breaks a stream of bytes into

--- a/pint/compat/tokenize.py
+++ b/pint/compat/tokenize.py
@@ -36,7 +36,7 @@ from token import *
 
 try:
     reASCII = re.ASCII
-except:
+except AttributeError:
     reASCII = 0
 
 

--- a/pint/compat/tokenize.py
+++ b/pint/compat/tokenize.py
@@ -235,7 +235,7 @@ class TokenError(Exception): pass
 class StopTokenizing(Exception): pass
 
 
-class Untokenizer:
+class Untokenizer(object):
 
     def __init__(self):
         self.tokens = []

--- a/pint/compat/tokenize.py
+++ b/pint/compat/tokenize.py
@@ -509,7 +509,7 @@ def _tokenize(readline, encoding):
         if encoding is not None:
             line = line.decode(encoding)
         lnum += 1
-        pos, max = 0, len(line)
+        pos, maximum = 0, len(line)
 
         if contstr:                            # continued string
             if not line:
@@ -535,7 +535,7 @@ def _tokenize(readline, encoding):
         elif parenlev == 0 and not continued:  # new statement
             if not line: break
             column = 0
-            while pos < max:                   # measure leading whitespace
+            while pos < maximum:                   # measure leading whitespace
                 if line[pos] == ' ':
                     column += 1
                 elif line[pos] == '\t':
@@ -545,7 +545,7 @@ def _tokenize(readline, encoding):
                 else:
                     break
                 pos += 1
-            if pos == max:
+            if pos == maximum:
                 break
 
             if line[pos] in '#\r\n':           # skip comments or blank lines
@@ -577,7 +577,7 @@ def _tokenize(readline, encoding):
                 raise TokenError("EOF in multi-line statement", (lnum, 0))
             continued = 0
 
-        while pos < max:
+        while pos < maximum:
             pseudomatch = _compile(PseudoToken).match(line, pos)
             if pseudomatch:                                # scan for tokens
                 start, end = pseudomatch.span(1)

--- a/pint/context.py
+++ b/pint/context.py
@@ -108,7 +108,7 @@ class Context(object):
             else:
                 aliases = ()
             defaults = r.groupdict()['defaults']
-        except:
+        except Exception:
             raise DefinitionSyntaxError("Could not parse the Context header '%s'" % header,
                                         lineno=lineno)
 
@@ -157,7 +157,7 @@ class Context(object):
                     ctx.add_transformation(src, dst, func)
                 else:
                     raise Exception
-            except:
+            except Exception:
                 raise DefinitionSyntaxError("Could not parse Context %s relation '%s'" % (name, line),
                                             lineno=lineno)
 

--- a/pint/pint_eval.py
+++ b/pint/pint_eval.py
@@ -111,7 +111,7 @@ def build_eval_tree(tokens, op_priority=_OP_PRIORITY, index=0, depth=0, prev_op=
     6) Go back to step #2
     """
 
-    if depth == 0 and prev_op == None:
+    if depth == 0 and prev_op is None:
         # ensure tokens is list so we can access by index
         tokens = list(tokens)
         

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1227,13 +1227,13 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
 
     def clip(self, first=None, second=None, out=None, **kwargs):
         minimum = kwargs.get('min', first)
-        max = kwargs.get('max', second)
+        maximum = kwargs.get('max', second)
 
-        if minimum is None and max is None:
+        if minimum is None and maximum is None:
             raise TypeError('clip() takes at least 3 arguments (2 given)')
 
-        if max is None and 'min' not in kwargs:
-            minimum, max = max, minimum
+        if maximum is None and 'min' not in kwargs:
+            minimum, maximum = maximum, minimum
 
         kwargs = {'out': out}
 
@@ -1245,11 +1245,11 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
             else:
                 raise DimensionalityError('dimensionless', self._units)
 
-        if max is not None:
-            if isinstance(max, self.__class__):
-                kwargs['max'] = max.to(self).magnitude
+        if maximum is not None:
+            if isinstance(maximum, self.__class__):
+                kwargs['max'] = maximum.to(self).magnitude
             elif self.dimensionless:
-                kwargs['max'] = max
+                kwargs['max'] = maximum
             else:
                 raise DimensionalityError('dimensionless', self._units)
 

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1226,22 +1226,22 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
                 tuple(__copy_units) + tuple(__skip_other_args)
 
     def clip(self, first=None, second=None, out=None, **kwargs):
-        min = kwargs.get('min', first)
+        minimum = kwargs.get('min', first)
         max = kwargs.get('max', second)
 
-        if min is None and max is None:
+        if minimum is None and max is None:
             raise TypeError('clip() takes at least 3 arguments (2 given)')
 
         if max is None and 'min' not in kwargs:
-            min, max = max, min
+            minimum, max = max, minimum
 
         kwargs = {'out': out}
 
-        if min is not None:
-            if isinstance(min, self.__class__):
-                kwargs['min'] = min.to(self).magnitude
+        if minimum is not None:
+            if isinstance(minimum, self.__class__):
+                kwargs['min'] = minimum.to(self).magnitude
             elif self.dimensionless:
-                kwargs['min'] = min
+                kwargs['min'] = minimum
             else:
                 raise DimensionalityError('dimensionless', self._units)
 

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -462,7 +462,7 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
                 log10_scale = int(math.log10(scale))
                 if log10_scale == math.log10(scale):
                     SI_prefixes[log10_scale] = prefix.name
-            except:
+            except Exception:
                 SI_prefixes[0] = ''
 
         SI_prefixes = sorted(SI_prefixes.items())
@@ -1502,12 +1502,12 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
             if ufname in self.__set_units:
                 try:
                     out = self.__class__(out, self.__set_units[ufname])
-                except:
+                except Exception:
                     raise _Exception(ValueError)
             elif ufname in self.__copy_units:
                 try:
                     out = self.__class__(out, self._units)
-                except:
+                except Exception:
                     raise _Exception(ValueError)
             elif ufname in self.__prod_units:
                 tmp = self.__prod_units[ufname]

--- a/pint/testsuite/helpers.py
+++ b/pint/testsuite/helpers.py
@@ -71,7 +71,7 @@ class PintOutputChecker(doctest.OutputChecker):
         try:
             if eval(want) == eval(got):
                 return True
-        except:
+        except Exception:
             pass
 
         for regex in (_q_re, _sq_re):
@@ -89,7 +89,7 @@ class PintOutputChecker(doctest.OutputChecker):
                     return False
 
                 return True
-            except:
+            except Exception:
                 pass
 
         cnt = 0
@@ -102,8 +102,7 @@ class PintOutputChecker(doctest.OutputChecker):
 
                 if parsed_got == parsed_want:
                     return True
-
-            except:
+            except Exception:
                 pass
 
         if cnt:

--- a/pint/testsuite/test_infer_base_unit.py
+++ b/pint/testsuite/test_infer_base_unit.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from pint import UnitRegistry, set_application_registry
 from pint.testsuite import QuantityTestCase
 from pint.util import infer_base_unit

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -553,7 +553,7 @@ class TestIssuesNP(QuantityTestCase):
         x = ureg.Quantity(1., 'meter')
         y = f(x)
         z = x * y
-        self.assertEquals(z, ureg.Quantity(1., 'meter * kilogram'))
+        self.assertEqual(z, ureg.Quantity(1., 'meter * kilogram'))
 
     def test_issue483(self):
         ureg = self.ureg

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -123,7 +123,7 @@ class TestIssues(QuantityTestCase):
 
         try:
             va.to_base_units()
-        except:
+        except Exception:
             self.assertTrue(False, 'Error while trying to get base units for {}'.format(va))
 
         boltmk = 1.3806488e-23*ureg.J/ureg.K
@@ -216,7 +216,7 @@ class TestIssues(QuantityTestCase):
         ureg = UnitRegistry()
         try:
             ureg.convert(1, ureg.degC, ureg.kelvin * ureg.meter / ureg.nanometer)
-        except:
+        except Exception:
             self.assertTrue(False,
                             'Error while trying to convert {} to {}'.format(ureg.degC, ureg.kelvin * ureg.meter / ureg.nanometer))
 

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -430,7 +430,7 @@ class TestQuantityBasicMath(QuantityTestCase):
         if isinstance(expected_result, string_types):
             expected_result = self.Q_(expected_result)
 
-        if not unit is None:
+        if unit is not None:
             value1 = value1 * unit
             value2 = value2 * unit
             expected_result = expected_result * unit
@@ -454,7 +454,7 @@ class TestQuantityBasicMath(QuantityTestCase):
         if isinstance(expected_result, string_types):
             expected_result = self.Q_(expected_result)
 
-        if not unit is None:
+        if unit is not None:
             value1 = value1 * unit
             value2 = value2 * unit
             expected_result = expected_result * unit

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -482,7 +482,7 @@ class TestRegistry(QuantityTestCase):
         src_dst1 = UnitsContainer(meter=1), UnitsContainer(inch=1)
         src_dst2 = UnitsContainer(meter=1, second=-1), UnitsContainer(inch=1, minute=-1)
         for src, dst in (src_dst1, src_dst2):
-            v = ureg.convert(1, src, dst),
+            v = ureg.convert(1, src, dst)
 
             a = np.ones((3, 1))
             ac = np.ones((3, 1))

--- a/pint/util.py
+++ b/pint/util.py
@@ -205,7 +205,7 @@ def find_shortest_path(graph, start, end, path=None):
     path = (path or []) + [start]
     if start == end:
         return path
-    if not start in graph:
+    if start not in graph:
         return None
     shortest = None
     for node in graph[start]:
@@ -218,7 +218,7 @@ def find_shortest_path(graph, start, end, path=None):
 
 
 def find_connected_nodes(graph, start, visited=None):
-    if not start in graph:
+    if start not in graph:
         return None
 
     visited = (visited or set())

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@
 import sys
 
 try:
-    reload(sys).setdefaultencoding("UTF-8")
-except:
+    reload(sys).setdefaultencoding('UTF-8')
+except NameError:
     pass
 
 try:


### PR DESCRIPTION
The test for non-numeric magnitudes was using `assertRaises` incorrectly.  While the context-manager form should be preferred, with the given style it should be passed the function to test, not the result of the function.

```python
# Wrong
self.assertRaises(RuntimeError, self.compareQuantity_compact(x,x))

# Better
self.assertRaises(RuntimeError, self.compareQuantity_compact, x, x)

# Best
with self.assertRaises(RuntimeError):
    self.compareQuantity_compact(x,x)
```

While fixing this I found that `RuntimeError` was not being raised, instead a `RuntimeWarning` was being issued.  Since `unittest.TestCase.assertWarns` was not added until Python 3.2 (see [docs](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertWarns)), I'm testing for the warning as recommended in the [Python 2.7 docs](https://docs.python.org/2/library/warnings.html#testing-warnings).

Fixes hgrecco/pint#659