### PR TITLE
Use µ as default abbreviation for micro.

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -15,7 +15,7 @@ atto- =  1e-18 = a-
 femto- = 1e-15 = f-
 pico- =  1e-12 = p-
 nano- =  1e-9  = n-
-micro- = 1e-6  = u- = µ-
+micro- = 1e-6  = µ- = u-
 milli- = 1e-3  = m-
 centi- = 1e-2  = c-
 deci- =  1e-1  = d-

--- a/pint/definitions.py
+++ b/pint/definitions.py
@@ -11,6 +11,7 @@
 
 from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
+import sys
 
 from .converters import ScaleConverter, OffsetConverter
 from .util import UnitsContainer, _is_dim, ParserHelper
@@ -44,6 +45,13 @@ class Definition(object):
         name = name.strip()
 
         result = [res.strip() for res in definition.split('=')]
+        # For python 2.7, remove unsupported unicode character
+        if (sys.version_info < (3, 0)):
+            for value in result:
+                try:
+                    value.decode('utf-8')
+                except UnicodeEncodeError:
+                    result.remove(value)
         value, aliases = result[0], tuple(result[1:])
         symbol, aliases = (aliases[0], aliases[1:]) if aliases else (None,
                                                                      aliases)

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -282,21 +282,36 @@ class TestIssues(QuantityTestCase):
 
     def test_angstrom_creation(self):
         ureg = UnitRegistry()
-        if (sys.version_info < (3, 0)):
+        try:
+            # Check if the install supports unicode, travis python27 seems to
+            # support it...
+            if (sys.version_info < (3, 0)):
+                'Å'.decode('utf-8')
+        except UnicodeEncodeError:
             self.assertRaises(UndefinedUnitError, ureg.Quantity, 2, 'Å')
         else:
             ureg.Quantity(2, 'Å')
 
     def test_alternative_angstrom_definition(self):
         ureg = UnitRegistry()
-        if (sys.version_info < (3, 0)):
+        try:
+            # Check if the install supports unicode, travis python27 seems to
+            # support it...
+            if (sys.version_info < (3, 0)):
+                'Å'.decode('utf-8')
+        except UnicodeEncodeError:
             self.assertRaises(UndefinedUnitError, ureg.Quantity, 2, '\u212B')
         else:
             ureg.Quantity(2, '\u212B')
 
     def test_micro_creation(self):
         ureg = UnitRegistry()
-        if (sys.version_info < (3, 0)):
+        try:
+            # Check if the install supports unicode, travis python27 seems to
+            # support it...
+            if (sys.version_info < (3, 0)):
+                'µ'.decode('utf-8')
+        except UnicodeEncodeError:
             self.assertRaises(UndefinedUnitError, ureg.Quantity, 2, 'µm')
         else:
             ureg.Quantity(2, 'µm')

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -5,6 +5,7 @@ from __future__ import division, unicode_literals, print_function, absolute_impo
 import math
 import copy
 import unittest
+import sys
 
 from pint import UnitRegistry
 from pint.unit import UnitsContainer
@@ -281,25 +282,24 @@ class TestIssues(QuantityTestCase):
 
     def test_angstrom_creation(self):
         ureg = UnitRegistry()
-        try:
+        if (sys.version_info < (3, 0)):
+            self.assertRaises(UndefinedUnitError, ureg.Quantity, 2, 'Å')
+        else:
             ureg.Quantity(2, 'Å')
-        except SyntaxError:
-            self.fail('Quantity with Å could not be created.')
 
     def test_alternative_angstrom_definition(self):
         ureg = UnitRegistry()
-        try:
+        if (sys.version_info < (3, 0)):
+            self.assertRaises(UndefinedUnitError, ureg.Quantity, 2, '\u212B')
+        else:
             ureg.Quantity(2, '\u212B')
-        except UndefinedUnitError:
-            self.fail('Quantity with Å could not be created.')
 
     def test_micro_creation(self):
         ureg = UnitRegistry()
-        try:
+        if (sys.version_info < (3, 0)):
+            self.assertRaises(UndefinedUnitError, ureg.Quantity, 2, 'µm')
+        else:
             ureg.Quantity(2, 'µm')
-        except SyntaxError:
-            self.fail('Quantity with µ prefix could not be created.')
-
 
 @helpers.requires_numpy()
 class TestIssuesNP(QuantityTestCase):


### PR DESCRIPTION
As suggested and discussed in #666, this PR sets `µ` as default abbreviation for micro.