### PR TITLE
BUG: Fix using Quantity with numpy.searchsorted

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1293,7 +1293,7 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
     def shape(self, value):
         self._magnitude.shape = value
 
-    def searchsorted(self, v, side='left'):
+    def searchsorted(self, v, side='left', sorter=None):
         if isinstance(v, self.__class__):
             v = v.to(self).magnitude
         elif self.dimensionless:

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -113,6 +113,12 @@ class TestNumpyMethods(QuantityTestCase):
         q = self.q.flatten()
         self.assertRaises(ValueError, q.searchsorted, [1.5, 2.5])
 
+    def test_searchsorted_numpy_func(self):
+        """Test searchsorted as numpy function."""
+        q = self.q.flatten()
+        np.testing.assert_array_equal(np.searchsorted(q, [1.5, 2.5] * self.ureg.m),
+                                      [1, 2])
+
     def test_nonzero(self):
         q = [1, 0, 5, 6, 0, 9] * self.ureg.m
         np.testing.assert_array_equal(q.nonzero()[0], [0, 2, 3, 5])


### PR DESCRIPTION
The method on Quantity was not up to date with the numpy set of arguments, which [as of 1.7](https://docs.scipy.org/doc/numpy/reference/generated/numpy.searchsorted.html?highlight=searchsorted#numpy.searchsorted) includes a `sorter` argument. Adding this allows the numpy function to properly delegate to the Quantity method.