### PR TITLE
Add pandas support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 dist/
 MANIFEST
 .tox
+*pytest_cache*
 
 # WebDAV file system cache files
 .DAV/
@@ -18,3 +19,9 @@ tags
 
 test/
 .coverage*
+
+# notebook stuff
+*.ipynb_checkpoints*
+
+# test csv which should be user generated
+notebooks/pandas_test.csv

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,20 @@ branches:
   - trying.tmp
 
 env:
-  - UNCERTAINTIES="N" PYTHON="3.3" NUMPY_VERSION=1.9.2
-  - UNCERTAINTIES="N" PYTHON="3.4" NUMPY_VERSION=1.11.2
-  - UNCERTAINTIES="N" PYTHON="3.5" NUMPY_VERSION=1.11.2
-  - UNCERTAINTIES="Y" PYTHON="3.5" NUMPY_VERSION=1.11.2
-  - UNCERTAINTIES="N" PYTHON="3.6" NUMPY_VERSION=1.11.2
-  - UNCERTAINTIES="N" PYTHON="2.7" NUMPY_VERSION=0
-  - UNCERTAINTIES="N" PYTHON="3.5" NUMPY_VERSION=0
+  - UNCERTAINTIES="N" PYTHON="3.6" NUMPY_VERSION=1.14 PANDAS=1
+  - UNCERTAINTIES="N" PYTHON="3.3" NUMPY_VERSION=1.9.2 PANDAS=0
+  - UNCERTAINTIES="N" PYTHON="3.4" NUMPY_VERSION=1.11.2 PANDAS=0
+  - UNCERTAINTIES="N" PYTHON="3.5" NUMPY_VERSION=1.11.2 PANDAS=0
+  - UNCERTAINTIES="Y" PYTHON="3.5" NUMPY_VERSION=1.11.2 PANDAS=0
+  - UNCERTAINTIES="N" PYTHON="3.6" NUMPY_VERSION=1.11.2 PANDAS=0
+  - UNCERTAINTIES="N" PYTHON="2.7" NUMPY_VERSION=0 PANDAS=0
+  - UNCERTAINTIES="N" PYTHON="3.5" NUMPY_VERSION=0 PANDAS=0
   # Test with the latest numpy version
-  - UNCERTAINTIES="N" PYTHON="2.7" NUMPY_VERSION=1.14
-  - UNCERTAINTIES="N" PYTHON="3.4" NUMPY_VERSION=1.14
-  - UNCERTAINTIES="N" PYTHON="3.5" NUMPY_VERSION=1.14
-  - UNCERTAINTIES="Y" PYTHON="3.5" NUMPY_VERSION=1.14
-  - UNCERTAINTIES="N" PYTHON="3.6" NUMPY_VERSION=1.14
+  - UNCERTAINTIES="N" PYTHON="2.7" NUMPY_VERSION=1.14 PANDAS=0
+  - UNCERTAINTIES="N" PYTHON="3.4" NUMPY_VERSION=1.14 PANDAS=0
+  - UNCERTAINTIES="N" PYTHON="3.5" NUMPY_VERSION=1.14 PANDAS=0
+  - UNCERTAINTIES="Y" PYTHON="3.5" NUMPY_VERSION=1.14 PANDAS=0
+  - UNCERTAINTIES="N" PYTHON="3.6" NUMPY_VERSION=1.14 PANDAS=0
 
 before_install:
   - sudo apt-get update
@@ -48,10 +49,17 @@ install:
   - if [ $UNCERTAINTIES == 'Y' ]; then pip install 'uncertainties==2.4.7.1'; fi
   - if [ $NUMPY_VERSION != '0' ]; then conda install --yes numpy==$NUMPY_VERSION; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.5' && $NUMPY_VERSION == 1.11.2 && $UNCERTAINTIES == "Y" ]]; then pip install babel serialize pyyaml; fi
+  # this is superslow but suck it up until updates to pandas are made
+  - if [[ $PANDAS == '1' ]]; then pip install numpy cython pytest pytest-cov nbval; pip install git+https://github.com/pandas-dev/pandas.git; fi
   - pip install coveralls
 
 script:
-  - python -bb -m coverage run -p --source=pint --omit="*test*","*compat*" setup.py test
+  # if we're doing the pandas tests and hence have pytest available, we can
+  # simply use it to run all the tests
+  - if [[ $PANDAS == '1' ]]; then python -bb -m coverage run -p --source=pint --omit="*test*","*compat*" -m py.test; fi
+  # test notebooks too if pandas available
+  - if [[ $PANDAS == '1' ]]; then pip install -e .; pytest --nbval notebooks/*; fi
+  - if [[ $PANDAS == '0' ]]; then python -bb -m coverage run -p --source=pint --omit="*test*","*compat*","*pandas*" setup.py test; fi
   - coverage combine
   - coverage report -m
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -102,6 +102,13 @@ points, like positions on a map or absolute temperature scales.
 **Python 2 and 3**: a single codebase that runs unchanged in Python 2.7+ and
 Python 3.3+.
 
+**Pandas integration**: Thanks to `Pandas Extension Types`_ it is now possible to use Pint with Pandas. Operations on DataFrames and between columns are units aware, providing even more convenience for users of Pandas DataFrames. For full details, see the `Pandas Support Documentation`_.
+
+
+When you choose to use a NumPy_ ndarray, its methods and
+ufuncs are supported including automatic conversion of units. For example
+`numpy.arccos(q)` will require a dimensionless `q` and the units of the output
+quantity will be radian.
 
 
 User Guide
@@ -152,3 +159,5 @@ One last thing
 .. _`NumPy`: http://www.numpy.org/
 .. _`PEP 3101`: https://www.python.org/dev/peps/pep-3101/
 .. _`Babel`: http://babel.pocoo.org/
+.. _`Pandas Extension Types`: https://pandas.pydata.org/pandas-docs/stable/extending.html#extension-types
+.. _`Pandas Support Documentation`: ./pandas.rst

--- a/docs/pandas.rst
+++ b/docs/pandas.rst
@@ -1,0 +1,329 @@
+.. _pandas:
+
+Pandas support
+==============
+
+It is convenient to use the `Pandas package`_ when dealing with numerical data, so Pint provides `PintArray`. A `PintArray` is a `Pandas Extension Array`_, which allows Pandas to recognise the Quantity and store it in Pandas DataFrames and Series.
+
+For this to work, we rely on `Pandas Extension Types`_ which are still experimental. As a result, we currently have to build the latest version of Pandas' master branch from source as documented in the `Pandas README`_.
+
+Basic example
+-------------
+
+This example gives you the basics, but is slightly fiddly as you are not reading from a file. A more normal use case is given in `Reading a csv`_.
+
+To use Pint with Pandas, as stated above, firstly ensure that you have the latest version of Pandas installed. Then import the relevant packages and create an instance of a Pint Quantity:
+
+.. doctest::
+
+   >>> import pandas as pd
+   >>> import numpy as np
+   >>> import pint
+   >>> from pint.pandas_interface import PintArray
+
+   >>> ureg = pint.UnitRegistry()
+   >>> Q_ = ureg.Quantity
+
+.. testsetup:: *
+
+   import pandas as pd
+   import numpy as np
+   import pint
+   from pint.pandas_interface import PintArray
+
+   ureg = pint.UnitRegistry()
+   Q_ = ureg.Quantity
+
+Next, we can create a DataFrame with PintArray's as columns
+
+.. doctest::
+
+   >>> torque = PintArray(Q_([1, 2, 2, 3], "lbf ft"))
+   >>> angular_velocity = PintArray(Q_([1000, 2000, 2000, 3000], "rpm"))
+   >>> df = pd.DataFrame({"torque": torque, "angular_velocity": angular_velocity})
+   >>> print(df)
+    torque angular_velocity
+   0      1             1000
+   1      2             2000
+   2      2             2000
+   3      3             3000
+
+
+Operations with columns are units aware so behave as we would intuitively expect
+
+.. doctest::
+
+   >>> df['power'] = df['torque'] * df['angular_velocity']
+   >>> print(df)
+     torque angular_velocity power
+   0      1             1000  1000
+   1      2             2000  4000
+   2      2             2000  4000
+   3      3             3000  9000
+
+
+Each column can be accessed as a Pandas Series
+
+.. doctest::
+
+   >>> print(df.power)
+   0    1000
+   1    4000
+   2    4000
+   3    9000
+   Name: power, dtype: pint
+
+
+Which contains a PintArray
+
+.. doctest::
+
+   >>> print(df.power.values)
+    PintArray([1000 foot * force_pound * revolutions_per_minute,
+               4000 foot * force_pound * revolutions_per_minute,
+               4000 foot * force_pound * revolutions_per_minute,
+               9000 foot * force_pound * revolutions_per_minute],
+              dtype='pint')
+
+
+Which contains a Quantity
+
+.. doctest::
+
+   >>> print(df.power.values.data)
+   [1000 4000 4000 9000] foot * force_pound * revolutions_per_minute
+
+
+Pandas Series accessors are provided for most Quantity properties and methods, which will convert the result to a Series where possible.
+
+.. doctest::
+
+   >>> print(df.power.pint.dimensionality)
+   [length] ** 2 * [mass] / [time] ** 3
+
+   >>> print(df.power.pint.to("kW"))
+   0    0.14198092353610375
+   1      0.567923694144415
+   2      0.567923694144415
+   3     1.2778283118249338
+   Name: power, dtype: pint
+
+
+Standard pint conversions can still be performed on the underlying quantity, and will still return a quantity.
+
+.. doctest::
+
+   >>> print(df.power.values.data.to("kW"))
+   [0.14198092 0.56792369 0.56792369 1.27782831] kilowatt
+
+Reading a csv
+-------------
+
+Thanks to the DataFrame accessors, reading from files with unit information becomes trivial. The DataFrame accessors make it easy to get to PintArrays.
+
+Setup
+~~~~~
+
+Here we create the DateFrame and save it to file, next we will show you how to load and read it.
+
+We start with an DateFrame with column headers only.
+
+.. doctest::
+
+   >>> speed = [1000, 1100, 1200, 1200]
+   >>> mech_power = [np.nan, np.nan, np.nan, np.nan]
+   >>> torque = [10, 10, 10, 10]
+   >>> rail_pressure = [1000, 1000000000000, 1000, 1000]
+   >>> fuel_flow_rate = [10, 10, 10, 10]
+   >>> fluid_power = [np.nan, np.nan, np.nan, np.nan]
+   >>> df_init = pd.DataFrame({"speed": speed, "mech power": mech_power, "torque": torque, "rail pressure": rail_pressure, "fuel flow rate": fuel_flow_rate, "fluid power": fluid_power,})
+   >>> print(df_init)
+      speed  mech power  torque  rail pressure  fuel flow rate  fluid power
+   0   1000         NaN      10           1000              10          NaN
+   1   1100         NaN      10  1000000000000              10          NaN
+   2   1200         NaN      10           1000              10          NaN
+   3   1200         NaN      10           1000              10          NaN
+
+Then we add a column header which contains units information
+
+.. doctest::
+
+   >>> units = ["rpm", "kW", "N m", "bar", "l/min", "kW"]
+   >>> df_to_save = df_init.copy()
+   >>> df_to_save.columns = pd.MultiIndex.from_arrays([df_init.columns, units])
+   >>> print(df_to_save)
+     speed mech power torque  rail pressure fuel flow rate fluid power
+       rpm         kW    N m            bar          l/min          kW
+   0  1000        NaN     10           1000             10         NaN
+   1  1100        NaN     10  1000000000000             10         NaN
+   2  1200        NaN     10           1000             10         NaN
+   3  1200        NaN     10           1000             10         NaN
+
+Now we save this to disk as a csv to give us our starting point.
+
+.. doctest::
+
+   >>> test_csv_name = "pandas_test.csv"
+   >>> df_to_save.to_csv(test_csv_name, index=False)
+
+Now we are in a position to read the csv we just saved. Let's start by reading the file with units as a level in a multiindex column.
+
+.. doctest::
+
+   >>> df = pd.read_csv(test_csv_name, header=[0,1])
+   >>> print(df)
+     speed mech power torque  rail pressure fuel flow rate fluid power
+       rpm         kW    N m            bar          l/min          kW
+   0  1000        NaN     10           1000             10         NaN
+   1  1100        NaN     10  1000000000000             10         NaN
+   2  1200        NaN     10           1000             10         NaN
+   3  1200        NaN     10           1000             10         NaN
+
+Then use the DataFrame's `pint.quantify` method to convert the columns from `np.ndarray`s to PintArrays, with units from the bottom column level.
+
+.. doctest::
+
+   >>> df_ = df.pint.quantify(ureg, level=-1)
+   >>> print(df_)
+       speed mech power torque    rail pressure fuel flow rate fluid power
+   0  1000.0        nan   10.0           1000.0           10.0         nan
+   1  1100.0        nan   10.0  1000000000000.0           10.0         nan
+   2  1200.0        nan   10.0           1000.0           10.0         nan
+   3  1200.0        nan   10.0           1000.0           10.0         nan
+
+
+As previously, operations between DataFrame columns are unit aware
+
+.. doctest::
+
+   >>> df_['mech power'] = df_.speed*df_.torque
+   >>> df_['fluid power'] = df_['fuel flow rate'] * df_['rail pressure']
+   >>> print(df_)
+       speed mech power torque    rail pressure fuel flow rate       fluid power
+   0  1000.0    10000.0   10.0           1000.0           10.0           10000.0
+   1  1100.0    11000.0   10.0  1000000000000.0           10.0  10000000000000.0
+   2  1200.0    12000.0   10.0           1000.0           10.0           10000.0
+   3  1200.0    12000.0   10.0           1000.0           10.0           10000.0
+
+
+The DataFrame's `pint.dequantify` method then allows us to retrieve the units information as a header row once again
+
+.. doctest::
+
+   >>> print(df_.pint.dequantify())
+                      speed                              mech power  \
+     revolutions_per_minute meter * newton * revolutions_per_minute
+   0                 1000.0                                 10000.0
+   1                 1100.0                                 11000.0
+   2                 1200.0                                 12000.0
+   3                 1200.0                                 12000.0
+
+             torque rail pressure fuel flow rate          fluid power
+     meter * newton           bar liter / minute bar * liter / minute
+   0           10.0  1.000000e+03           10.0         1.000000e+04
+   1           10.0  1.000000e+12           10.0         1.000000e+13
+   2           10.0  1.000000e+03           10.0         1.000000e+04
+   3           10.0  1.000000e+03           10.0         1.000000e+04
+
+
+
+This allows for some rather powerful abilities. For example, to change single column units
+
+.. doctest::
+
+   >>> df_['fluid power'] = df_['fluid power'].pint.to("kW")
+   >>> df_['mech power'] = df_['mech power'].pint.to("kW")
+   >>> print(df_.pint.dequantify())
+
+                      speed mech power         torque rail pressure  \
+     revolutions_per_minute   kilowatt meter * newton           bar
+   0                 1000.0   1.047198           10.0  1.000000e+03
+   1                 1100.0   1.151917           10.0  1.000000e+12
+   2                 1200.0   1.256637           10.0  1.000000e+03
+   3                 1200.0   1.256637           10.0  1.000000e+03
+
+     fuel flow rate   fluid power
+     liter / minute      kilowatt
+   0           10.0  1.666667e+01
+   1           10.0  1.666667e+10
+   2           10.0  1.666667e+01
+   3           10.0  1.666667e+01
+
+
+or the entire table's units
+
+.. doctest::
+
+   >>> print(df_.pint.to_base_units().pint.dequantify())
+
+               speed                          mech power  \
+     radian / second kilogram * meter ** 2 / second ** 3
+   0      104.719755                         1047.197551
+   1      115.191731                         1151.917306
+   2      125.663706                         1256.637061
+   3      125.663706                         1256.637061
+
+                                  torque                  rail pressure  \
+     kilogram * meter ** 2 / second ** 2 kilogram / meter / second ** 2
+   0                                10.0                   1.000000e+08
+   1                                10.0                   1.000000e+17
+   2                                10.0                   1.000000e+08
+   3                                10.0                   1.000000e+08
+
+          fuel flow rate                         fluid power
+     meter ** 3 / second kilogram * meter ** 2 / second ** 3
+   0            0.000167                        1.666667e+04
+   1            0.000167                        1.666667e+13
+   2            0.000167                        1.666667e+04
+   3            0.000167                        1.666667e+04
+
+
+Comments
+--------
+
+What follows is a short discussion about Pint's `PintArray` Object.
+
+It is first useful to distinguish between three different things:
+
+1. A scalar value
+
+.. doctest::
+
+   >>> print(Q_(123,"m"))
+   123 meter
+
+2. A scalar value
+
+.. doctest::
+
+   >>> print(Q_([1, 2, 3], "m"))
+   [1 2 3] meter
+
+3. A scalar value
+
+.. doctest::
+
+   >>> print(Q_([[1, 2], [3, 4]], "m"))
+   [[1 2] [3 4]] meter
+
+
+The first, a single scalar value is not intended to be stored in the PintArray as it's not an array, and should raise an error (TODO). The scalar Quantity is the scalar form of the PintArray, and is returned when performing operations that use `get_item`, eg indexing. A PintArray can be created from a list of scalar Quantitys using `PintArray._from_sequence`.
+
+The second, a 1d array or list, is intended to be stored in the PintArray, and is stored in the PintArray.data attribute.
+
+The third, 2d+ arrays or lists, are beyond the capabilities of ExtensionArrays which are limited to 1d arrays, so cannot be stored in the array, and should raise an error (TODO).
+
+Most operations on the PintArray act on the Quantity stored in `PintArray.data`, so will behave similiarly to operations on a Quantity, with some caveats:
+
+1. An operation that would return a 1d Quantity will return a PintArray containing the Quantity. This allows pandas to assign the result to a Series.
+2. Arithemetic and comparative operations are limited to scalars and sequences of the same length as the stored Quantity. This ensures results are the same length as the stored Quantity, so can be added to the same DataFrame.
+
+
+
+
+.. _`Pandas package`: https://pandas.pydata.org/pandas-docs/stable/index.html
+.. _`Pandas Dataframes`: https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html
+.. _`Pandas Extension Array`: https://pandas.pydata.org/pandas-docs/stable/extending.html#extensionarray
+.. _`Pandas Extension Types`: https://pandas.pydata.org/pandas-docs/stable/extending.html#extension-types
+.. _`Pandas README`: https://github.com/pandas-dev/pandas/blob/master/README.md
+

--- a/notebooks/pandas-support.ipynb
+++ b/notebooks/pandas-support.ipynb
@@ -1,0 +1,1286 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pandas support\n",
+    "\n",
+    "This notebook provides a simple example of how to use Pint with Pandas. See the documentation for full details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd \n",
+    "import pint\n",
+    "import numpy as np\n",
+    "\n",
+    "from pint.pandas_interface import PintArray"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ureg=pint.UnitRegistry()\n",
+    "Q_=ureg.Quantity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic example\n",
+    "\n",
+    "This example shows how the DataFrame works with Pint. However, it's not the most usual case so we also show how to read from a csv below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>torque</th>\n",
+       "      <th>angular_velocity</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>2000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>2000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3</td>\n",
+       "      <td>3000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  torque angular_velocity\n",
+       "0      1             1000\n",
+       "1      2             2000\n",
+       "2      2             2000\n",
+       "3      3             3000"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pd.DataFrame({\n",
+    "    \"torque\": PintArray(Q_([1, 2, 2, 3], \"lbf ft\")),\n",
+    "    \"angular_velocity\": PintArray(Q_([1000, 2000, 2000, 3000], \"rpm\"))\n",
+    "})\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>torque</th>\n",
+       "      <th>angular_velocity</th>\n",
+       "      <th>power</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1000</td>\n",
+       "      <td>1000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>2000</td>\n",
+       "      <td>4000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>2000</td>\n",
+       "      <td>4000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3</td>\n",
+       "      <td>3000</td>\n",
+       "      <td>9000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  torque angular_velocity power\n",
+       "0      1             1000  1000\n",
+       "1      2             2000  4000\n",
+       "2      2             2000  4000\n",
+       "3      3             3000  9000"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df['power'] = df['torque'] * df['angular_velocity']\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    1000\n",
+       "1    4000\n",
+       "2    4000\n",
+       "3    9000\n",
+       "Name: power, dtype: pint"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.power"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PintArray([1000 foot * force_pound * revolutions_per_minute,\n",
+       "           4000 foot * force_pound * revolutions_per_minute,\n",
+       "           4000 foot * force_pound * revolutions_per_minute,\n",
+       "           9000 foot * force_pound * revolutions_per_minute],\n",
+       "          dtype='pint')"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.power.values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\\[\\begin{pmatrix}1000 & 4000 & 4000 & 9000\\end{pmatrix} foot force_pound revolutions_per_minute\\]"
+      ],
+      "text/latex": [
+       "$\\begin{pmatrix}1000 & 4000 & 4000 & 9000\\end{pmatrix}\\ \\mathrm{foot} \\cdot \\mathrm{force_pound} \\cdot \\mathrm{revolutions_per_minute}$"
+      ],
+      "text/plain": [
+       "array([1000, 4000, 4000, 9000]) <Unit('foot * force_pound * revolutions_per_minute')>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.power.values.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\\[\\begin{pmatrix}1000 & 2000 & 2000 & 3000\\end{pmatrix} revolutions_per_minute\\]"
+      ],
+      "text/latex": [
+       "$\\begin{pmatrix}1000 & 2000 & 2000 & 3000\\end{pmatrix}\\ \\mathrm{revolutions_per_minute}$"
+      ],
+      "text/plain": [
+       "array([1000, 2000, 2000, 3000]) <Unit('revolutions_per_minute')>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.angular_velocity.values.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "foot force_pound revolutions_per_minute"
+      ],
+      "text/latex": [
+       "$\\mathrm{foot} \\cdot \\mathrm{force_pound} \\cdot \\mathrm{revolutions_per_minute}$"
+      ],
+      "text/plain": [
+       "<Unit('foot * force_pound * revolutions_per_minute')>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.power.pint.units"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PintArray([0.14198092353610375 kilowatt, 0.567923694144415 kilowatt,\n",
+       "           0.567923694144415 kilowatt, 1.2778283118249338 kilowatt],\n",
+       "          dtype='pint')"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.power.pint.to(\"kW\").values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reading from csv\n",
+    "\n",
+    "Reading from files is the far more standard way to use pandas. To facilitate this, DataFrame accessors are provided to make it easy to get to PintArrays. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Here we create the DateFrame and save it to file, next we will show you how to load and read it.\n",
+    "\n",
+    "We start with a DateFrame with column headers only."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>speed</th>\n",
+       "      <th>mech power</th>\n",
+       "      <th>torque</th>\n",
+       "      <th>rail pressure</th>\n",
+       "      <th>fuel flow rate</th>\n",
+       "      <th>fluid power</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10</td>\n",
+       "      <td>1000</td>\n",
+       "      <td>10</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1100</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10</td>\n",
+       "      <td>1000000000000</td>\n",
+       "      <td>10</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1200</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10</td>\n",
+       "      <td>1000</td>\n",
+       "      <td>10</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1200</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10</td>\n",
+       "      <td>1000</td>\n",
+       "      <td>10</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   speed  mech power  torque  rail pressure  fuel flow rate  fluid power\n",
+       "0   1000         NaN      10           1000              10          NaN\n",
+       "1   1100         NaN      10  1000000000000              10          NaN\n",
+       "2   1200         NaN      10           1000              10          NaN\n",
+       "3   1200         NaN      10           1000              10          NaN"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_init = pd.DataFrame({\n",
+    "    \"speed\": [1000, 1100, 1200, 1200],\n",
+    "    \"mech power\": [np.nan, np.nan, np.nan, np.nan],\n",
+    "    \"torque\": [10, 10, 10, 10],\n",
+    "    \"rail pressure\": [1000, 1000000000000, 1000, 1000],\n",
+    "    \"fuel flow rate\": [10, 10, 10, 10],\n",
+    "    \"fluid power\": [np.nan, np.nan, np.nan, np.nan],\n",
+    "})\n",
+    "df_init"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we add a column header which contains units information"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>speed</th>\n",
+       "      <th>mech power</th>\n",
+       "      <th>torque</th>\n",
+       "      <th>rail pressure</th>\n",
+       "      <th>fuel flow rate</th>\n",
+       "      <th>fluid power</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>rpm</th>\n",
+       "      <th>kW</th>\n",
+       "      <th>N m</th>\n",
+       "      <th>bar</th>\n",
+       "      <th>l/min</th>\n",
+       "      <th>kW</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10</td>\n",
+       "      <td>1000</td>\n",
+       "      <td>10</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1100</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10</td>\n",
+       "      <td>1000000000000</td>\n",
+       "      <td>10</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1200</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10</td>\n",
+       "      <td>1000</td>\n",
+       "      <td>10</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1200</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10</td>\n",
+       "      <td>1000</td>\n",
+       "      <td>10</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  speed mech power torque  rail pressure fuel flow rate fluid power\n",
+       "    rpm         kW    N m            bar          l/min          kW\n",
+       "0  1000        NaN     10           1000             10         NaN\n",
+       "1  1100        NaN     10  1000000000000             10         NaN\n",
+       "2  1200        NaN     10           1000             10         NaN\n",
+       "3  1200        NaN     10           1000             10         NaN"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "units = [\"rpm\", \"kW\", \"N m\", \"bar\", \"l/min\", \"kW\"]\n",
+    "df_to_save = df_init.copy()\n",
+    "df_to_save.columns = pd.MultiIndex.from_arrays([df_init.columns, units])\n",
+    "df_to_save"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we save this to disk as a csv to give us our starting point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_csv_name = \"pandas_test.csv\"\n",
+    "df_to_save.to_csv(test_csv_name, index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we are in a position to read the csv we just saved. Let's start by reading the file with units as a level in a multiindex column."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>speed</th>\n",
+       "      <th>mech power</th>\n",
+       "      <th>torque</th>\n",
+       "      <th>rail pressure</th>\n",
+       "      <th>fuel flow rate</th>\n",
+       "      <th>fluid power</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>rpm</th>\n",
+       "      <th>kW</th>\n",
+       "      <th>N m</th>\n",
+       "      <th>bar</th>\n",
+       "      <th>l/min</th>\n",
+       "      <th>kW</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10</td>\n",
+       "      <td>1000</td>\n",
+       "      <td>10</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1100</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10</td>\n",
+       "      <td>1000000000000</td>\n",
+       "      <td>10</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1200</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10</td>\n",
+       "      <td>1000</td>\n",
+       "      <td>10</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1200</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10</td>\n",
+       "      <td>1000</td>\n",
+       "      <td>10</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  speed mech power torque  rail pressure fuel flow rate fluid power\n",
+       "    rpm         kW    N m            bar          l/min          kW\n",
+       "0  1000        NaN     10           1000             10         NaN\n",
+       "1  1100        NaN     10  1000000000000             10         NaN\n",
+       "2  1200        NaN     10           1000             10         NaN\n",
+       "3  1200        NaN     10           1000             10         NaN"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pd.read_csv(test_csv_name, header=[0,1])\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then use the DataFrame's pint accessor's quantify method to convert the columns from `np.ndarray`s to PintArrays, with units from the bottom column level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>speed</th>\n",
+       "      <th>mech power</th>\n",
+       "      <th>torque</th>\n",
+       "      <th>rail pressure</th>\n",
+       "      <th>fuel flow rate</th>\n",
+       "      <th>fluid power</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>nan</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>nan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1100.0</td>\n",
+       "      <td>nan</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1000000000000.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>nan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1200.0</td>\n",
+       "      <td>nan</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>nan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1200.0</td>\n",
+       "      <td>nan</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>nan</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    speed mech power torque    rail pressure fuel flow rate fluid power\n",
+       "0  1000.0        nan   10.0           1000.0           10.0         nan\n",
+       "1  1100.0        nan   10.0  1000000000000.0           10.0         nan\n",
+       "2  1200.0        nan   10.0           1000.0           10.0         nan\n",
+       "3  1200.0        nan   10.0           1000.0           10.0         nan"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_ = df.pint.quantify(ureg, level=-1)\n",
+    "df_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As previously, operations between DataFrame columns are unit aware"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>speed</th>\n",
+       "      <th>mech power</th>\n",
+       "      <th>torque</th>\n",
+       "      <th>rail pressure</th>\n",
+       "      <th>fuel flow rate</th>\n",
+       "      <th>fluid power</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>10000.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>10000.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1100.0</td>\n",
+       "      <td>11000.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1000000000000.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>10000000000000.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1200.0</td>\n",
+       "      <td>12000.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>10000.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1200.0</td>\n",
+       "      <td>12000.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>10000.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    speed mech power torque    rail pressure fuel flow rate       fluid power\n",
+       "0  1000.0    10000.0   10.0           1000.0           10.0           10000.0\n",
+       "1  1100.0    11000.0   10.0  1000000000000.0           10.0  10000000000000.0\n",
+       "2  1200.0    12000.0   10.0           1000.0           10.0           10000.0\n",
+       "3  1200.0    12000.0   10.0           1000.0           10.0           10000.0"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_['mech power'] = df_.speed*df_.torque\n",
+    "df_['fluid power'] = df_['fuel flow rate'] * df_['rail pressure']\n",
+    "df_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The DataFrame's `pint.dequantify` method then allows us to retrieve the units information as a header row once again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>speed</th>\n",
+       "      <th>mech power</th>\n",
+       "      <th>torque</th>\n",
+       "      <th>rail pressure</th>\n",
+       "      <th>fuel flow rate</th>\n",
+       "      <th>fluid power</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>revolutions_per_minute</th>\n",
+       "      <th>meter * newton * revolutions_per_minute</th>\n",
+       "      <th>meter * newton</th>\n",
+       "      <th>bar</th>\n",
+       "      <th>liter / minute</th>\n",
+       "      <th>bar * liter / minute</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>10000.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.000000e+03</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.000000e+04</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1100.0</td>\n",
+       "      <td>11000.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.000000e+12</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.000000e+13</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1200.0</td>\n",
+       "      <td>12000.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.000000e+03</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.000000e+04</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1200.0</td>\n",
+       "      <td>12000.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.000000e+03</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.000000e+04</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   speed                              mech power  \\\n",
+       "  revolutions_per_minute meter * newton * revolutions_per_minute   \n",
+       "0                 1000.0                                 10000.0   \n",
+       "1                 1100.0                                 11000.0   \n",
+       "2                 1200.0                                 12000.0   \n",
+       "3                 1200.0                                 12000.0   \n",
+       "\n",
+       "          torque rail pressure fuel flow rate          fluid power  \n",
+       "  meter * newton           bar liter / minute bar * liter / minute  \n",
+       "0           10.0  1.000000e+03           10.0         1.000000e+04  \n",
+       "1           10.0  1.000000e+12           10.0         1.000000e+13  \n",
+       "2           10.0  1.000000e+03           10.0         1.000000e+04  \n",
+       "3           10.0  1.000000e+03           10.0         1.000000e+04  "
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_.pint.dequantify()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This allows for some rather powerful abilities. For example, to change single column units"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>speed</th>\n",
+       "      <th>mech power</th>\n",
+       "      <th>torque</th>\n",
+       "      <th>rail pressure</th>\n",
+       "      <th>fuel flow rate</th>\n",
+       "      <th>fluid power</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>revolutions_per_minute</th>\n",
+       "      <th>kilowatt</th>\n",
+       "      <th>meter * newton</th>\n",
+       "      <th>bar</th>\n",
+       "      <th>liter / minute</th>\n",
+       "      <th>kilowatt</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>1.047198</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.000000e+03</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.666667e+01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1100.0</td>\n",
+       "      <td>1.151917</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.000000e+12</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.666667e+10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1200.0</td>\n",
+       "      <td>1.256637</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.000000e+03</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.666667e+01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1200.0</td>\n",
+       "      <td>1.256637</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.000000e+03</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.666667e+01</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   speed mech power         torque rail pressure  \\\n",
+       "  revolutions_per_minute   kilowatt meter * newton           bar   \n",
+       "0                 1000.0   1.047198           10.0  1.000000e+03   \n",
+       "1                 1100.0   1.151917           10.0  1.000000e+12   \n",
+       "2                 1200.0   1.256637           10.0  1.000000e+03   \n",
+       "3                 1200.0   1.256637           10.0  1.000000e+03   \n",
+       "\n",
+       "  fuel flow rate   fluid power  \n",
+       "  liter / minute      kilowatt  \n",
+       "0           10.0  1.666667e+01  \n",
+       "1           10.0  1.666667e+10  \n",
+       "2           10.0  1.666667e+01  \n",
+       "3           10.0  1.666667e+01  "
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_['fluid power'] = df_['fluid power'].pint.to(\"kW\")\n",
+    "df_['mech power'] = df_['mech power'].pint.to(\"kW\")\n",
+    "df_.pint.dequantify()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or the entire table's units"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>speed</th>\n",
+       "      <th>mech power</th>\n",
+       "      <th>torque</th>\n",
+       "      <th>rail pressure</th>\n",
+       "      <th>fuel flow rate</th>\n",
+       "      <th>fluid power</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>radian / second</th>\n",
+       "      <th>kilogram * meter ** 2 / second ** 3</th>\n",
+       "      <th>kilogram * meter ** 2 / second ** 2</th>\n",
+       "      <th>kilogram / meter / second ** 2</th>\n",
+       "      <th>meter ** 3 / second</th>\n",
+       "      <th>kilogram * meter ** 2 / second ** 3</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>104.719755</td>\n",
+       "      <td>1047.197551</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.000000e+08</td>\n",
+       "      <td>0.000167</td>\n",
+       "      <td>1.666667e+04</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>115.191731</td>\n",
+       "      <td>1151.917306</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.000000e+17</td>\n",
+       "      <td>0.000167</td>\n",
+       "      <td>1.666667e+13</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>125.663706</td>\n",
+       "      <td>1256.637061</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.000000e+08</td>\n",
+       "      <td>0.000167</td>\n",
+       "      <td>1.666667e+04</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>125.663706</td>\n",
+       "      <td>1256.637061</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.000000e+08</td>\n",
+       "      <td>0.000167</td>\n",
+       "      <td>1.666667e+04</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            speed                          mech power  \\\n",
+       "  radian / second kilogram * meter ** 2 / second ** 3   \n",
+       "0      104.719755                         1047.197551   \n",
+       "1      115.191731                         1151.917306   \n",
+       "2      125.663706                         1256.637061   \n",
+       "3      125.663706                         1256.637061   \n",
+       "\n",
+       "                               torque                  rail pressure  \\\n",
+       "  kilogram * meter ** 2 / second ** 2 kilogram / meter / second ** 2   \n",
+       "0                                10.0                   1.000000e+08   \n",
+       "1                                10.0                   1.000000e+17   \n",
+       "2                                10.0                   1.000000e+08   \n",
+       "3                                10.0                   1.000000e+08   \n",
+       "\n",
+       "       fuel flow rate                         fluid power  \n",
+       "  meter ** 3 / second kilogram * meter ** 2 / second ** 3  \n",
+       "0            0.000167                        1.666667e+04  \n",
+       "1            0.000167                        1.666667e+13  \n",
+       "2            0.000167                        1.666667e+04  \n",
+       "3            0.000167                        1.666667e+04  "
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_.pint.to_base_units().pint.dequantify()"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pint/compat/__init__.py
+++ b/pint/compat/__init__.py
@@ -123,3 +123,16 @@ except ImportError:
 
 if not HAS_PROPER_BABEL:
     Loc = babel_units = None
+
+try:
+    import pandas as pd
+    HAS_PANDAS = True
+    HAS_PROPER_PANDAS = hasattr(pd.core.arrays.base, "ExtensionOpsMixin")
+except ImportError:
+    HAS_PROPER_PANDAS = HAS_PANDAS = False
+
+try:
+    import pytest
+    HAS_PYTEST = True
+except ImportError:
+    HAS_PYTEST = False

--- a/pint/pandas_interface/__init__.py
+++ b/pint/pandas_interface/__init__.py
@@ -1,0 +1,1 @@
+from .pint_array import PintArray, PintType

--- a/pint/pandas_interface/pint_array.py
+++ b/pint/pandas_interface/pint_array.py
@@ -1,0 +1,633 @@
+# -*- coding: utf-8 -*-
+"""
+    pint.pandas_interface.pint_array
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    # I'm happy with both of these as long as Andrew and Zebedee are added on
+    # but need to check with Pint Authors...
+    :copyright: 2018 by Pint Authors, see AUTHORS for more details.
+    :license: BSD, see LICENSE for more details.
+"""
+
+from pint.compat import HAS_PROPER_PANDAS
+if not HAS_PROPER_PANDAS:
+    error_msg = (
+        "Pint's Pandas interface requires that the latest version of "
+        "Pandas is installed from Pandas' master branch"
+    )
+    raise ImportError(error_msg)
+
+import copy
+import warnings
+
+import numpy as np
+
+from pandas.core import ops
+from pandas.core.arrays import ExtensionArray
+from pandas.api.extensions import register_dataframe_accessor, register_series_accessor
+from pandas.core.arrays.base import ExtensionOpsMixin
+from pandas.core.dtypes.base import ExtensionDtype
+from pandas.core.dtypes.common import (
+    is_integer, is_scalar,
+    is_list_like,
+    is_bool)
+from pandas.core.dtypes.dtypes import registry
+from pandas.compat import u, set_function_name
+from pandas.io.formats.printing import (
+    format_object_summary, format_object_attrs, default_pprint)
+from pandas import Series, DataFrame
+
+from ..quantity import build_quantity_class, _Quantity
+from ..compat import string_types
+from .. import _DEFAULT_REGISTRY
+
+class PintType(ExtensionDtype):
+    # I think this is the way to build a Quantity class and force it to be a
+    # numpy array
+    type = build_quantity_class(_DEFAULT_REGISTRY, force_ndarray=True)
+    # # AS: I'm not sure that does force it as an ndarray.
+    # # Trying the below as running into registry issues
+    # type = _Quantity
+    name = 'pint'
+
+    @classmethod
+    def construct_array_type(cls, type_str='pint'):
+        if type_str is not cls.name:
+            raise NotImplementedError
+        return PintArray
+
+    @classmethod
+    def construct_from_string(cls, string):
+        if string == cls.name:
+            return cls()
+        else:
+            raise TypeError("Cannot construct a '{}' from "
+                            "'{}'".format(cls, string))
+
+
+class PintArray(ExtensionArray, ExtensionOpsMixin):
+    _dtype = PintType
+
+    def __init__(self, values, dtype=None, copy=False):
+        if isinstance(values, _Quantity):
+            self._dtype.type = type(values)
+            assert self._dtype.type._REGISTRY == values._REGISTRY
+        self._data = self._coerce_to_pint_array(values, dtype=dtype, copy=copy)
+
+    def _coerce_to_pint_array(self, values, dtype=None, copy=False):
+        if isinstance(values, self._dtype.type):
+            return values
+
+        if is_list_like(values):
+            if all(is_bool(v) for v in values):
+                # known bug in pint https://github.com/hgrecco/pint/issues/673
+                raise TypeError("Invalid magnitude for {}: {}"
+                                "".format(self._dtype.type, values))
+
+            for i, v in enumerate(values):
+                if isinstance(v, self._dtype.type):
+                    continue
+                else:
+                    values[i] = v * self._find_first_unit(values)
+
+            units = set(v.units for v in values)
+            if len(units) > 1:
+                # need to work out a way to test this
+                raise TypeError("The units of all quantities are not the same"
+                                " for input {}".format(values))
+
+            magnitudes = [v.magnitude for v in values]
+
+            return self._dtype.type(magnitudes, values[0].units)
+
+        raise NotImplementedError
+
+    def _find_first_unit(self, values):
+        for v in values:
+            if isinstance(v, self._dtype.type):
+                return v.units
+
+        return self._dtype.type(1).units
+
+    def __getitem__(self, item):
+        # type (Any) -> Any
+        """Select a subset of self.
+        Parameters
+        ----------
+        item : int, slice, or ndarray
+            * int: The position in 'self' to get.
+            * slice: A slice object, where 'start', 'stop', and 'step' are
+              integers or None
+            * ndarray: A 1-d boolean NumPy ndarray the same length as 'self'
+        Returns
+        -------
+        item : scalar or PintArray
+        """
+        if is_integer(item):
+            return self._data[item]
+
+        return self.__class__(self._data[item])
+
+    def __len__(self):
+        # type: () -> int
+        """Length of this array
+
+        Returns
+        -------
+        length : int
+        """
+        return len(self._data)
+
+    def __repr__(self):
+        """
+        Return a string representation for this object.
+
+        Invoked by unicode(df) in py2 only. Yields a Unicode String in both
+        py2/py3.
+        """
+
+        klass = self.__class__.__name__
+        data = format_object_summary(self, default_pprint, False)
+        attrs = format_object_attrs(self)
+        space = " "
+
+        prepr = (u(",%s") %
+                 space).join(u("%s=%s") % (k, v) for k, v in attrs)
+
+        res = u("%s(%s%s)") % (klass, data, prepr)
+
+        return res
+
+    def __array__(self, dtype=None, copy=False):
+    # this is necessary for some pandas operations, eg transpose
+    # note, units will be lost
+        if dtype is None:
+            dtype = object
+        if isinstance(dtype, string_types):
+            dtype = getattr(np, dtype)
+        # it seems impossible to avoid using this, even dtype is object causes
+        # failure...
+        if dtype == object:
+            return np.array(list(self._data), dtype = dtype, copy = copy)
+        if not isinstance(dtype, np.dtype):
+            list_of_converteds = [dtype(item) for item in self._data]
+        else:
+            list_of_converteds = [dtype.type(item) for item in self._data]
+
+        return np.array(list_of_converteds)
+
+    def isna(self):
+        # type: () -> np.ndarray
+        """Return a Boolean NumPy array indicating if each value is missing.
+
+        Returns
+        -------
+        missing : np.array
+        """
+        return np.isnan(self._data.magnitude)
+
+    def astype(self, dtype, copy=True):
+        """Cast to a NumPy array with 'dtype'.
+
+        Parameters
+        ----------
+        dtype : str or dtype
+            Typecode or data-type to which the array is cast.
+        copy : bool, default True
+            Whether to copy the data, even if not necessary. If False,
+            a copy is made only if the old dtype does not match the
+            new dtype.
+
+        Returns
+        -------
+        array : ndarray
+            NumPy ndarray with 'dtype' for its dtype.
+        """
+        return self.__array__(dtype,copy)
+
+    def take(self, indices, allow_fill=False, fill_value=None):
+        # type: (Sequence[int], bool, Optional[Any]) -> PintArray
+        """Take elements from an array.
+        Parameters
+        ----------
+        indices : sequence of integers
+            Indices to be taken.
+        allow_fill : bool, default False
+            How to handle negative values in `indices`.
+            * False: negative values in `indices` indicate positional indices
+              from the right (the default). This is similar to
+              :func:`numpy.take`.
+            * True: negative values in `indices` indicate
+              missing values. These values are set to `fill_value`. Any other
+              other negative values raise a ``ValueError``.
+        fill_value : any, optional
+            Fill value to use for NA-indices when `allow_fill` is True.
+            This may be ``None``, in which case the default NA value for
+            the type, ``self.dtype.na_value``, is used.
+        Returns
+        -------
+        PintArray
+        Raises
+        ------
+        IndexError
+            When the indices are out of bounds for the array.
+        ValueError
+            When `indices` contains negative values other than ``-1``
+            and `allow_fill` is True.
+        Notes
+        -----
+        PintArray.take is called by ``Series.__getitem__``, ``.loc``,
+        ``iloc``, when `indices` is a sequence of values. Additionally,
+        it's called by :meth:`Series.reindex`, or any other method
+        that causes realignemnt, with a `fill_value`.
+        See Also
+        --------
+        numpy.take
+        pandas.api.extensions.take
+        Examples
+        --------
+        """
+        from pandas.core.algorithms import take
+
+        data = self._data.magnitude
+        if allow_fill and fill_value is None:
+            fill_value = self.dtype.na_value
+        if isinstance(fill_value, _Quantity):
+            fill_value = fill_value.to(self._data).magnitude
+
+        result = take(data, indices, fill_value=fill_value,
+                      allow_fill=allow_fill)
+
+        return type(self)(type(self._data)(result, self._data.units))
+
+    def copy(self, deep=False):
+        data = self._data
+        if deep:
+            data = copy.deepcopy(data)
+        else:
+            data = data.copy()
+
+        return type(self)(data, dtype=self.dtype)
+
+    def __setitem__(self, key, value):
+        _is_scalar = is_scalar(value)
+        if _is_scalar:
+            value = [value]
+
+        # need to not use `not value` on numpy arrays
+        if isinstance(value, (list, tuple)) and (not value):
+            # doing nothing here seems to be ok
+            return
+
+        value = self._coerce_to_pint_array(value, dtype=self.dtype)
+
+        if _is_scalar:
+            value = value[0]
+
+        self._data[key] = value
+
+
+    @classmethod
+    def _concat_same_type(cls, to_concat):
+        # taken from Metpy, would be great to somehow include in pint...
+        for a in to_concat:
+            if all(np.isnan(a._data)):
+                continue
+            units = a._data.units
+
+        data = []
+        for a in to_concat:
+            if (all(np.isnan(a._data))) and (a._data.units != units):
+                a = a*units
+            mag_common_unit = a._data.to(units).magnitude
+            data.append(np.atleast_1d(mag_common_unit))
+
+        return cls(np.concatenate(data) * units)
+
+
+    @classmethod
+    def _from_sequence(cls, scalars, dtype=None, copy=False):
+        return cls(scalars, dtype=dtype, copy=copy)
+
+    @classmethod
+    def _from_factorized(cls, values, original):
+        return cls(values, dtype=original.dtype)
+
+    def value_counts(self, dropna=True):
+        """
+        Returns a Series containing counts of each category.
+
+        Every category will have an entry, even those with a count of 0.
+
+        Parameters
+        ----------
+        dropna : boolean, default True
+            Don't include counts of NaN.
+
+        Returns
+        -------
+        counts : Series
+
+        See Also
+        --------
+        Series.value_counts
+        """
+
+        from pandas import Index, Series
+
+        # compute counts on the data with no nans
+        data = self._data
+        if dropna:
+            data = data[~np.isnan(data.magnitude)]
+
+        data_list = data.tolist()
+        index = list(set(data))
+        array = [data_list.count(item) for item in index]
+
+        return Series(array, index=index)
+
+    def unique(self):
+        """Compute the PintArray of unique values.
+
+        Returns
+        -------
+        uniques : PintArray
+        """
+        from pandas import unique
+
+        return self._from_sequence(unique(self._data) * self._data.units)
+
+    @property
+    def dtype(self):
+        # type: () -> ExtensionDtype
+        """An instance of 'ExtensionDtype'."""
+        return self._dtype()
+
+    @property
+    def data(self):
+        return self._data
+
+    @property
+    def nbytes(self):
+        return self._data.nbytes
+
+    # The _can_hold_na attribute is set to True so that pandas internals
+    # will use the ExtensionDtype.na_value as the NA value in operations
+    # such as take(), reindex(), shift(), etc.  In addition, those results
+    # will then be of the ExtensionArray subclass rather than an array
+    # of objects
+    _can_hold_na = True
+
+    @property
+    def _ndarray_values(self):
+        # type: () -> np.ndarray
+        """Internal pandas method for lossy conversion to a NumPy ndarray.
+        This method is not part of the pandas interface.
+        The expectation is that this is cheap to compute, and is primarily
+        used for interacting with our indexers.
+        """
+        return np.array(self)
+
+    def _formatting_values(self):
+        # type: () -> np.ndarray
+        # At the moment, this has to be an array since we use result.dtype
+        """An array of values to be printed in, e.g. the Series repr"""
+        output=[str(item) for item in self.data.magnitude]
+        # Tried this but it doesn't print as a newline in pandas
+        # output[0]= str(self.data.units) + r"\n" + output[0]
+        return np.array(output)
+
+
+    @classmethod
+    def _create_method(cls, op, coerce_to_dtype=True):
+        """
+        A class method that returns a method that will correspond to an
+        operator for an ExtensionArray subclass, by dispatching to the
+        relevant operator defined on the individual elements of the
+        ExtensionArray.
+        Parameters
+        ----------
+        op : function
+            An operator that takes arguments op(a, b)
+        coerce_to_dtype :  bool
+            boolean indicating whether to attempt to convert
+            the result to the underlying ExtensionArray dtype
+            (default True)
+        Returns
+        -------
+        A method that can be bound to a method of a class
+        Example
+        -------
+        Given an ExtensionArray subclass called MyExtensionArray, use
+        >>> __add__ = cls._create_method(operator.add)
+        in the class definition of MyExtensionArray to create the operator
+        for addition, that will be based on the operator implementation
+        of the underlying elements of the ExtensionArray
+        """
+
+
+        def _binop(self, other):
+            def validate_length(l,r):
+                #validates length and converts to listlike
+                try:
+                    if len(l)==len(r):
+                        return r
+                    else:
+                        raise ValueError("Lengths must match")
+                except TypeError:
+                    return [r] * len(l)
+            def convert_values(param):
+                # convert to a quantity or listlike
+                if isinstance(param,Series) and isinstance(param.values,cls):
+                    return param.values.data
+                elif isinstance(param,cls):
+                    return param.data
+                elif isinstance(param,_Quantity):
+                    return param
+                elif is_list_like(param) and isinstance(param[0],_Quantity):
+                    return type(param[0])([p.magnitude for p in param], param[0].units)
+                else:
+                    return param
+            lvalues = self.data
+            other=validate_length(lvalues,other)
+            rvalues = convert_values(other)
+            # Pint quantities may only be exponented by single values, not arrays.
+            # Reduce single value arrays to single value to allow power ops
+            if isinstance(rvalues,_Quantity):
+                if len(set(np.array(rvalues.data)))==1:
+                    rvalues=rvalues[0]
+            elif len(set(np.array(rvalues)))==1:
+                rvalues=rvalues[0]
+            # If the operator is not defined for the underlying objects,
+            # a TypeError should be raised
+            res = op(lvalues,rvalues)
+
+            if op.__name__ == 'divmod':
+                return cls(res[0]),cls(res[1])
+
+            if coerce_to_dtype:
+                try:
+                    res = cls(res)
+                except TypeError:
+                    pass
+
+            return res
+
+        op_name = ops._get_op_name(op, True)
+        return set_function_name(_binop, op_name, cls)
+
+    @classmethod
+    def _create_arithmetic_method(cls, op):
+        return cls._create_method(op)
+
+    @classmethod
+    def _create_comparison_method(cls, op):
+        return cls._create_method(op, coerce_to_dtype=False)
+PintArray._add_arithmetic_ops()
+PintArray._add_comparison_ops()
+# register
+registry.register(PintType)
+
+@register_dataframe_accessor("pint")
+class PintDataFrameAccessor(object):
+    def __init__(self, pandas_obj):
+        self._obj = pandas_obj
+
+    def quantify(self, ureg, level=-1):
+        df = self._obj
+        Q_ = ureg.Quantity
+        df_columns = df.columns.to_frame()
+        unit_col_name = df_columns.columns[level]
+        units = df_columns[unit_col_name]
+        df_columns = df_columns.drop(columns=unit_col_name)
+        df_columns.values
+        df_new = DataFrame({i: PintArray(Q_(df.values[:, i], unit))
+            for i, unit in enumerate(units.values)
+        })
+        df_new.columns = df_columns.index.droplevel(unit_col_name)
+        df_new.index = df.index
+        return df_new
+
+    def dequantify(self):
+        df=self._obj
+        df_columns=df.columns.to_frame()
+        df_columns['units']=[str(df[col].values.data.units) for col in df.columns]
+        df_new=DataFrame({ tuple(df_columns.iloc[i]) : df[col].values.data.magnitude
+            for i,col in enumerate(df.columns)
+        })
+        return df_new
+
+    def to_base_units(self):
+        obj=self._obj
+        df=self._obj
+        index = object.__getattribute__(obj, 'index')
+        # name = object.__getattribute__(obj, '_name')
+        return DataFrame({
+        col: df[col].pint.to_base_units()
+        for col in df.columns
+        },index=index)
+
+@register_series_accessor("pint")
+class PintSeriesAccessor(object):
+    def __init__(self, pandas_obj):
+        self._validate(pandas_obj)
+        self.pandas_obj = pandas_obj
+        self._data = pandas_obj.values
+        self._index = pandas_obj.index
+        self._name = pandas_obj.name
+    @staticmethod
+    def _validate(obj):
+        if not is_pint_type(obj):
+            raise AttributeError("Cannot use 'pint' accessor on objects of "
+                                 "dtype '{}'.".format(obj.dtype))
+
+
+class Delegated:
+    # Descriptor for delegating attribute access to from
+    # a Series to an underlying array
+    to_series = True
+    def __init__(self, name):
+        self.name = name
+
+
+class DelegatedProperty(Delegated):
+    def __get__(self, obj, type=None):
+        index = object.__getattribute__(obj, '_index')
+        name = object.__getattribute__(obj, '_name')
+        result = getattr(object.__getattribute__(obj, '_data')._data, self.name)
+        if self.to_series:
+            if isinstance(result, _Quantity):
+                result = PintArray(result)
+            return Series(result, index, name=name)
+        else:
+            return result
+
+class DelegatedScalarProperty(DelegatedProperty):
+    to_series = False
+
+class DelegatedMethod(Delegated):
+    def __get__(self, obj, type=None):
+        index = object.__getattribute__(obj, '_index')
+        name = object.__getattribute__(obj, '_name')
+        method = getattr(object.__getattribute__(obj, '_data')._data, self.name)
+        def delegated_method(*args, **kwargs):
+            result = method(*args, **kwargs)
+            if self.to_series:
+                if isinstance(result, _Quantity):
+                    result = PintArray(result)
+                result = Series(result, index, name=name)
+            return result
+        return delegated_method
+
+class DelegatedScalarMethod(DelegatedMethod):
+    to_series = False
+
+for attr in [
+'debug_used',
+'default_format',
+'dimensionality',
+'dimensionless',
+'force_ndarray',
+'shape',
+'u',
+'unitless',
+'units']:
+    setattr(PintSeriesAccessor,attr,DelegatedScalarProperty(attr))
+for attr in [
+'imag',
+'m',
+'magnitude',
+'real']:
+    setattr(PintSeriesAccessor,attr,DelegatedProperty(attr))
+
+for attr in [
+'check',
+'compatible_units',
+'format_babel',
+'ito',
+'ito_base_units',
+'ito_reduced_units',
+'ito_root_units',
+'plus_minus',
+'put',
+'to_tuple',
+'tolist']:
+    setattr(PintSeriesAccessor,attr,DelegatedScalarMethod(attr))
+for attr in [
+'clip',
+'from_tuple',
+'m_as',
+'searchsorted',
+'to',
+'to_base_units',
+'to_compact',
+'to_reduced_units',
+'to_root_units',
+'to_timedelta']:
+    setattr(PintSeriesAccessor,attr,DelegatedMethod(attr))
+def is_pint_type(obj):
+    t = getattr(obj, 'dtype', obj)
+    try:
+        return isinstance(t, PintType) or issubclass(t, PintType)
+    except Exception:
+        return False

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -30,7 +30,6 @@ from .util import (PrettyIPython, logger, UnitsContainer, SharedRegistryObject,
                    fix_str_conversions)
 from pint.compat import Loc
 
-
 def _eq(first, second, check_all):
     """Comparison of scalars and arrays
     """
@@ -61,6 +60,19 @@ def ireduce_dimensions(f):
         result = f(self, *args, **kwargs)
         if result._REGISTRY.auto_reduce_dimensions:
             result.ito_reduced_units()
+        return result
+    return wrapped
+
+def check_implemented(f):
+    def wrapped(self, *args, **kwargs):
+        other=args[0]
+        if other.__class__.__name__ in ["PintArray", "Series"]:
+            return NotImplemented
+        # pandas often gets to arrays of quantities [ Q_(1,"m"), Q_(2,"m")]
+        # and expects Quantity * array[Quantity] should return NotImplemented
+        elif isinstance(other, list) and isinstance(other[0], type(self)):
+            return NotImplemented
+        result = f(self, *args, **kwargs)
         return result
     return wrapped
 
@@ -120,8 +132,18 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
 
         inst.__used = False
         inst.__handling = None
+        # Only instances where the magnitude is iterable should have __iter__()
+        if hasattr(inst._magnitude,"__iter__"):
+            inst.__iter__ = cls._iter
         return inst
 
+    def _iter(self):
+        """
+        Will be become __iter__() for instances with iterable magnitudes
+        """
+        # # Allow exception to propagate in case of non-iterable magnitude
+        it_mag = iter(self.magnitude)
+        return iter((self.__class__(mag, self._units) for mag in it_mag))
     @property
     def debug_used(self):
         return self.__used
@@ -610,6 +632,7 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
 
         return self
 
+    @check_implemented
     def _add_sub(self, other, op):
         """Perform addition or subtraction operation and return the result.
 
@@ -800,6 +823,7 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
 
         return self
 
+    @check_implemented
     @ireduce_dimensions
     def _mul_div(self, other, magnitude_op, units_op=None):
         """Perform multiplication or division operation and return the result.
@@ -908,6 +932,7 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
         self._units = UnitsContainer({})
         return self
 
+    @check_implemented
     def __floordiv__(self, other):
         if self._check(other):
             magnitude = self._magnitude // other.to(self._units)._magnitude
@@ -917,6 +942,7 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
             raise DimensionalityError(self._units, 'dimensionless')
         return self.__class__(magnitude, UnitsContainer({}))
 
+    @check_implemented
     def __rfloordiv__(self, other):
         if self._check(other):
             magnitude = other._magnitude // self.to(other._units)._magnitude
@@ -932,12 +958,14 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
         self._magnitude %= other.to(self._units)._magnitude
         return self
 
+    @check_implemented
     def __mod__(self, other):
         if not self._check(other):
             other = self.__class__(other, UnitsContainer({}))
         magnitude = self._magnitude % other.to(self._units)._magnitude
         return self.__class__(magnitude, self._units)
 
+    @check_implemented
     def __rmod__(self, other):
         if self._check(other):
             magnitude = other._magnitude % self.to(other._units)._magnitude
@@ -948,6 +976,7 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
         else:
             raise DimensionalityError(self._units, 'dimensionless')
 
+    @check_implemented
     def __divmod__(self, other):
         if not self._check(other):
             other = self.__class__(other, UnitsContainer({}))
@@ -955,6 +984,7 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
         return (self.__class__(q, UnitsContainer({})),
                 self.__class__(r, self._units))
 
+    @check_implemented
     def __rdivmod__(self, other):
         if self._check(other):
             q, r = divmod(other._magnitude, self.to(other._units)._magnitude)
@@ -1018,6 +1048,7 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
             self._magnitude **= _to_magnitude(other, self.force_ndarray)
             return self
 
+    @check_implemented
     def __pow__(self, other):
         try:
             other_magnitude = _to_magnitude(other, self.force_ndarray)
@@ -1058,13 +1089,14 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
                 if getattr(other, 'dimensionless', False):
                     units = new_self._units ** other.to_root_units().magnitude
                 elif not getattr(other, 'dimensionless', True):
-                    raise DimensionalityError(self._units, 'dimensionless')
+                    raise DimensionalityError(other._units, 'dimensionless')
                 else:
                     units = new_self._units ** other
 
             magnitude = new_self._magnitude ** _to_magnitude(other, self.force_ndarray)
             return self.__class__(magnitude, units)
 
+    @check_implemented
     def __rpow__(self, other):
         try:
             other_magnitude = _to_magnitude(other, self.force_ndarray)
@@ -1330,11 +1362,6 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
 
     def __len__(self):
         return len(self._magnitude)
-
-    def __iter__(self):
-        # Allow exception to propagate in case of non-iterable magnitude
-        it_mag = iter(self.magnitude)
-        return iter((self.__class__(mag, self._units) for mag in it_mag))
 
     def __getattr__(self, item):
         # Attributes starting with `__array_` are common attributes of NumPy ndarray.
@@ -1607,6 +1634,7 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
 
     def to_timedelta(self):
         return datetime.timedelta(microseconds=self.to('microseconds').magnitude)
+
 
 
 def build_quantity_class(registry, force_ndarray=False):

--- a/pint/testsuite/test-data/pandas_test.csv
+++ b/pint/testsuite/test-data/pandas_test.csv
@@ -1,0 +1,6 @@
+speed,mech power,torque,rail pressure,fuel flow rate,fluid power
+rpm,kW,N m,bar,l/min,kW
+1000,,10,1000,10,
+1100,,10,1000000000000,10,
+1200,,10,1000,10,
+1200,,10,1000,10,

--- a/pint/testsuite/test_pandas_interface.py
+++ b/pint/testsuite/test_pandas_interface.py
@@ -1,0 +1,602 @@
+# -*- coding: utf-8 -*-
+
+# - pandas test resources https://github.com/pandas-dev/pandas/blob/master/pandas/tests/extension/base/__init__.py
+
+from pint.compat import HAS_PROPER_PANDAS, HAS_PYTEST
+
+# I can't see how else to do this without this massive if clause...
+if not (HAS_PYTEST and HAS_PROPER_PANDAS):
+    from pint.testsuite import BaseTestCase
+    class TestPandasException(BaseTestCase):
+        def test_pandas_exception(self):
+            expected_error_msg = (
+                "Pint's Pandas interface requires that the latest version of "
+                "Pandas is installed from Pandas' master branch"
+            )
+            with self.assertRaises(ImportError) as cm:
+                import pint.pandas_interface
+
+            self.assertEqual(str(cm.exception), expected_error_msg)
+
+    if not (HAS_PYTEST and HAS_PROPER_PANDAS):
+        msg_end = "the latest version of Pandas from the master branch and pytest installed"
+    elif not HAS_PROPER_PANDAS:
+        msg_end = "the latest version of Pandas from the master branch installed"
+    elif not HAS_PYTEST:
+        msg_end = "pytest installed"
+
+    print("Skipping all Pandas tests except exception raising as we don't have {}".format(msg_end))
+
+
+else:
+    import sys
+    from os.path import join, dirname
+
+
+    import numpy as np
+    import pytest
+    import operator
+    import warnings
+
+    import pint
+    import pint.pandas_interface as ppi
+    from pint.testsuite import helpers
+
+    import pandas as pd
+    from pandas.compat import PY3
+    from pandas.tests.extension import base
+    from pandas.core import ops
+
+
+    from pint.testsuite.test_quantity import QuantityTestCase
+    from pint.errors import DimensionalityError
+    from pint.pandas_interface import PintArray
+
+
+    ureg = pint.UnitRegistry()
+
+
+    @pytest.fixture
+    def dtype():
+        return ppi.PintType()
+
+
+    @pytest.fixture
+    def data():
+        return ppi.PintArray(np.arange(start=1., stop=101.) * ureg.kilogram)
+
+
+    @pytest.fixture
+    def data_missing():
+        return ppi.PintArray([np.nan, 1] * ureg.meter)
+
+
+    @pytest.fixture(params=['data', 'data_missing'])
+    def all_data(request, data, data_missing):
+        if request.param == 'data':
+            return data
+        elif request.param == 'data_missing':
+            return data_missing
+
+
+    @pytest.fixture
+    def data_repeated(data):
+        """Return different versions of data for count times"""
+        # no idea what I'm meant to put here, try just copying from https://github.com/pandas-dev/pandas/blob/master/pandas/tests/extension/integer/test_integer.py
+        def gen(count):
+            for _ in range(count):
+                yield data
+        yield gen
+
+
+    @pytest.fixture
+    def data_for_sorting():
+        return ppi.PintArray([0.3, 10, -50])
+        # should probably get more sophisticated and do something like
+        # [1 * ureg.meter, 3 * ureg.meter, 10 * ureg.centimeter]
+
+
+    @pytest.fixture
+    def data_missing_for_sorting():
+        return ppi.PintArray([4, np.nan, -5])
+        # should probably get more sophisticated and do something like
+        # [4 * ureg.meter, np.nan, 10 * ureg.centimeter]
+
+
+    @pytest.fixture
+    def na_cmp():
+        """Binary operator for comparing NA values.
+        """
+        return lambda x, y: bool(np.isnan(x.magnitude)) & bool(np.isnan(y))
+
+
+    @pytest.fixture
+    def na_value():
+        return ppi.PintType.na_value
+
+
+    @pytest.fixture
+    def data_for_grouping():
+        # should probably get more sophisticated here and use units on all these
+        # quantities
+        a = 1
+        b = 2 ** 32 + 1
+        c = 2 ** 32 + 10
+        return ppi.PintArray([
+            b, b, np.nan, np.nan, a, a, b, c
+        ])
+
+    # === missing from pandas extension docs about what has to be included in tests ===
+    # copied from pandas/pandas/conftest.py
+    _all_arithmetic_operators = ['__add__', '__radd__',
+                                 '__sub__', '__rsub__',
+                                 '__mul__', '__rmul__',
+                                 '__floordiv__', '__rfloordiv__',
+                                 '__truediv__', '__rtruediv__',
+                                 '__pow__', '__rpow__',
+                                 '__mod__', '__rmod__']
+    if not PY3:
+        _all_arithmetic_operators.extend(['__div__', '__rdiv__'])
+
+    @pytest.fixture(params=_all_arithmetic_operators)
+    def all_arithmetic_operators(request):
+        """
+        Fixture for dunder names for common arithmetic operations
+        """
+        return request.param
+
+    @pytest.fixture(params=['__eq__', '__ne__', '__le__',
+                            '__lt__', '__ge__', '__gt__'])
+    def all_compare_operators(request):
+        """
+        Fixture for dunder names for common compare operations
+
+        * >=
+        * >
+        * ==
+        * !=
+        * <
+        * <=
+        """
+        return request.param
+    # =================================================================
+
+
+    class TestCasting(base.BaseCastingTests):
+        pass
+
+
+    class TestConstructors(base.BaseConstructorsTests):
+        pass
+
+
+    class TestDtype(base.BaseDtypeTests):
+        pass
+
+
+    class TestGetitem(base.BaseGetitemTests):
+        pass
+
+
+    class TestGroupby(base.BaseGroupbyTests):
+        pass
+
+
+    class TestInterface(base.BaseInterfaceTests):
+        pass
+
+
+    class TestMethods(base.BaseMethodsTests):
+
+        @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
+        # See test_setitem_mask_broadcast note
+        @pytest.mark.parametrize('dropna', [True, False])
+        def test_value_counts(self, all_data, dropna):
+            all_data = all_data[:10]
+            if dropna:
+                other = all_data[~all_data.isna()]
+            else:
+                other = all_data
+
+            result = pd.Series(all_data).value_counts(dropna=dropna).sort_index()
+            expected = pd.Series(other).value_counts(
+                dropna=dropna).sort_index()
+
+            self.assert_series_equal(result, expected)
+
+        @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
+        # See test_setitem_mask_broadcast note
+        @pytest.mark.parametrize('box', [pd.Series, lambda x: x])
+        @pytest.mark.parametrize('method', [lambda x: x.unique(), pd.unique])
+        def test_unique(self, data, box, method):
+            duplicated = box(data._from_sequence([data[0], data[0]]))
+
+            result = method(duplicated)
+
+            assert len(result) == 1
+            assert isinstance(result, type(data))
+            assert result[0] == duplicated[0]
+
+
+    class TestArithmeticOps(base.BaseArithmeticOpsTests):
+        def check_opname(self, s, op_name, other, exc=None):
+            op = self.get_op_from_name(op_name)
+
+            self._check_op(s, op, other, exc)
+
+        def _check_op(self, s, op, other, exc=None):
+            if exc is None:
+                result = op(s, other)
+                expected = s.combine(other, op)
+                self.assert_series_equal(result, expected)
+            else:
+                with pytest.raises(exc):
+                    op(s, other)
+
+        def _check_divmod_op(self, s, op, other, exc=None):
+            # divmod has multiple return values, so check separately
+            if exc is None:
+                result_div, result_mod = op(s, other)
+                if op is divmod:
+                    expected_div, expected_mod = s // other, s % other
+                else:
+                    expected_div, expected_mod = other // s, other % s
+                self.assert_series_equal(result_div, expected_div)
+                self.assert_series_equal(result_mod, expected_mod)
+            else:
+                with pytest.raises(exc):
+                    divmod(s, other)
+
+        def _get_exception(self, data, op_name):
+            if op_name in ["__pow__", "__rpow__"]:
+                return op_name, DimensionalityError
+            else:
+                return op_name, None
+
+        def test_arith_series_with_scalar(self, data, all_arithmetic_operators):
+            # series & scalar
+            op_name, exc = self._get_exception(data, all_arithmetic_operators)
+            s = pd.Series(data)
+            self.check_opname(s, op_name, s.iloc[0], exc=exc)
+
+        @pytest.mark.xfail(run=True, reason="_reduce needs implementation")
+        def test_arith_frame_with_scalar(self, data, all_arithmetic_operators):
+            # frame & scalar
+            op_name, exc = self._get_exception(data, all_arithmetic_operators)
+            df = pd.DataFrame({'A': data})
+            self.check_opname(df, op_name, data[0], exc=exc)
+
+        @pytest.mark.xfail(run=True, reason="s.combine does not accept arrays")
+        def test_arith_series_with_array(self, data, all_arithmetic_operators):
+            # ndarray & other series
+            op_name, exc = self._get_exception(data, all_arithmetic_operators)
+            s = pd.Series(data)
+            self.check_opname(s, op_name, data, exc=exc)
+
+        # parameterise this to try divisor not equal to 1
+        def test_divmod(self, data):
+            s = pd.Series(data)
+            self._check_divmod_op(s, divmod, 1*ureg.kg)
+            self._check_divmod_op(1*ureg.kg, ops.rdivmod, s)
+
+        def test_error(self, data, all_arithmetic_operators):
+            # invalid ops
+
+            op = all_arithmetic_operators
+            s = pd.Series(data)
+            ops = getattr(s, op)
+            opa = getattr(data, op)
+
+            # invalid scalars
+            # TODO: work out how to make this more specific/test for the two
+            #       different possible errors here
+            with pytest.raises(Exception):
+                ops('foo')
+
+            # TODO: work out how to make this more specific/test for the two
+            #       different possible errors here
+            with pytest.raises(Exception):
+                ops(pd.Timestamp('20180101'))
+
+            # invalid array-likes
+            # TODO: work out how to make this more specific/test for the two
+            #       different possible errors here
+            with pytest.raises(Exception):
+                ops(pd.Series('foo', index=s.index))
+
+            # 2d
+            with pytest.raises(KeyError):
+                opa(pd.DataFrame({'A': s}))
+
+            with pytest.raises(ValueError):
+                opa(np.arange(len(s)).reshape(-1, len(s)))
+
+
+
+    class TestComparisonOps(base.BaseComparisonOpsTests):
+        def _compare_other(self, s, data, op_name, other):
+            op = self.get_op_from_name(op_name)
+
+            result = op(s,other)
+            expected = op(s.values.data, other)
+            assert (result==expected).all()
+
+        def test_compare_scalar(self, data, all_compare_operators):
+            op_name = all_compare_operators
+            s = pd.Series(data)
+            other = data[0]
+            self._compare_other(s, data, op_name, other)
+
+        def test_compare_array(self, data, all_compare_operators):
+            # nb this compares an quantity containing array
+            # eg Q_([1,2],"m")
+            op_name = all_compare_operators
+            s = pd.Series(data)
+            other = data.data
+            self._compare_other(s, data, op_name, other)
+
+
+
+    class TestOpsUtil(base.BaseOpsUtil):
+        pass
+
+
+    class TestMissing(base.BaseMissingTests):
+        pass
+
+
+    class TestReshaping(base.BaseReshapingTests):
+        pass
+
+
+    class TestSetitem(base.BaseSetitemTests):
+        @pytest.mark.parametrize('setter', ['loc', None])
+        @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
+        # Pandas performs a hasattr(__array__), which triggers the warning
+        # Debugging it does not pass through a PintArray, so
+        # I think this needs changing in pint quantity
+        # eg s[[True]*len(s)]=Q_(1,"m")
+        def test_setitem_mask_broadcast(self, data, setter):
+            ser = pd.Series(data)
+            mask = np.zeros(len(data), dtype=bool)
+            mask[:2] = True
+
+            if setter:   # loc
+                target = getattr(ser, setter)
+            else:  # __setitem__
+                target = ser
+
+            operator.setitem(target, mask, data[10])
+            assert ser[0] == data[10]
+            assert ser[1] == data[10]
+
+
+    # would be ideal to just test all of this by running the example notebook
+    # but this isn't a discussion we've had yet
+
+    class TestUserInterface(object):
+        def test_get_underlying_data(self, data):
+            ser = pd.Series(data)
+            # this first test creates an array of bool (which is desired, eg for indexing)
+            assert all(ser.values == data)
+            assert ser.values[23] == data[23]
+
+        def test_arithmetic(self, data):
+            ser = pd.Series(data)
+            ser2 = ser + ser
+            assert all(ser2.values == 2*data)
+
+        def test_initialisation(self, data):
+            # fails with plain array
+            # works with PintArray
+            strt = np.arange(100) * ureg.newton
+
+            # it is sad this doesn't work
+            with pytest.raises(ValueError):
+                ser_fail = pd.Series(strt, dtype=ppi.PintType())
+                assert all(ser_fail.values == strt)
+
+            # This needs to be a list of scalar quantities to work :<
+            ser = pd.Series([q for q in strt], dtype=ppi.PintType())
+            assert all(ser.values == strt)
+
+        def test_df_operations(self):
+            # simply a copy of what's in the notebook
+            Q_ = ureg.Quantity
+            df = pd.DataFrame({
+                "torque": PintArray(Q_([1, 2, 2, 3], "lbf ft")),
+                "angular_velocity": PintArray(Q_([1000, 2000, 2000, 3000], "rpm"))
+            })
+
+            df['power'] = df['torque'] * df['angular_velocity']
+
+            df.power.values.data
+            df.torque.values.data
+            df.angular_velocity.values.data
+
+            df.power.values.data.to("kW")
+
+            test_csv = join(
+                dirname(__file__),
+                "test-data", "pandas_test.csv"
+            )
+
+            df=pd.read_csv(test_csv, header=[0,1])
+            df_ = df.pint.quantify(ureg, level=-1)
+
+            df_['mech power'] = df_.speed*df_.torque
+            df_['fluid power'] = df_['fuel flow rate'] * df_['rail pressure']
+
+            df_.pint.dequantify()
+
+            df_['fluid power'] = df_['fluid power'].pint.to("kW")
+            df_['mech power'] = df_['mech power'].pint.to("kW")
+            df_.pint.dequantify()
+
+            df_.pint.to_base_units().pint.dequantify()
+
+
+
+    class TestSeriesAccessors(object):
+        @pytest.mark.parametrize('attr', [
+            'debug_used',
+            'default_format',
+            'dimensionality',
+            'dimensionless',
+            'force_ndarray',
+            'shape',
+            'u',
+            'unitless',
+            'units',
+        ])
+        def test_series_scalar_property_accessors(self, data, attr):
+            s = pd.Series(data)
+            assert getattr(s.pint, attr) == getattr(data._data,attr)
+
+        @pytest.mark.parametrize('attr', [
+            'm',
+            'magnitude',
+            #'imag', # failing, not sure why
+            #'real', # failing, not sure why
+        ])
+        def test_series_property_accessors(self, data, attr):
+            s = pd.Series(data)
+            assert all(getattr(s.pint, attr) == pd.Series(getattr(data._data,attr)))
+
+        @pytest.mark.parametrize('attr_args', [
+            ('check', ({"[length]": 1})),
+            ('compatible_units', ()),
+            # ('format_babel', ()), Needs babel installed?
+            # ('plus_minus', ()), Needs uncertanties
+            ('to_tuple', ()),
+            ('tolist', ())
+        ])
+        def test_series_scalar_method_accessors(self, data, attr_args):
+            attr = attr_args[0]
+            args = attr_args[1]
+            s = pd.Series(data)
+            assert getattr(s.pint, attr)(*args) == getattr(data._data, attr)(*args)
+
+        @pytest.mark.parametrize('attr_args', [
+            ('ito', ("g",)),
+            ('ito_base_units', ()),
+            ('ito_reduced_units', ()),
+            ('ito_root_units', ()),
+            ('put', (1, data()[0]))
+        ])
+        def test_series_inplace_method_accessors(self, data, attr_args):
+            attr = attr_args[0]
+            args = attr_args[1]
+            from copy import deepcopy
+            s = pd.Series(deepcopy(data))
+            getattr(s.pint, attr)(*args)
+            getattr(data._data, attr)(*args)
+            assert all(s.values == data)
+
+        @pytest.mark.parametrize('attr_args', [
+            ('clip', (data()[10], data()[20])),
+            ('from_tuple', (data().data.to_tuple(),)),
+            ('m_as', ("g",)),
+            ('searchsorted', (data()[10],)),
+            ('to', ("g")),
+            ('to_base_units', ()),
+            ('to_compact', ()),
+            ('to_reduced_units', ()),
+            ('to_root_units', ()),
+            # ('to_timedelta', ()),
+        ])
+        def test_series_method_accessors(self, data, attr_args):
+            attr=attr_args[0]
+            args=attr_args[1]
+            s = pd.Series(data)
+            assert all(getattr(s.pint, attr)(*args) == getattr(data._data,attr)(*args))
+
+
+    arithmetic_ops = [
+        operator.add,
+        operator.sub,
+        operator.mul,
+        operator.truediv,
+        operator.floordiv,
+        operator.pow,
+    ]
+
+    comparative_ops = [
+        operator.eq,
+        operator.le,
+        operator.lt,
+        operator.ge,
+        operator.gt,
+    ]
+
+
+
+    class TestPintArrayQuantity(QuantityTestCase):
+        FORCE_NDARRAY = True
+
+        def test_pintarray_creation(self):
+            x = self.Q_([1, 2, 3],"m")
+            ys = [
+                PintArray(x),
+                PintArray._from_sequence([item for item in x])
+            ]
+            for y in ys:
+                self.assertQuantityAlmostEqual(x,y.data)
+
+
+        @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
+        @pytest.mark.filterwarnings("ignore::RuntimeWarning")
+        def test_pintarray_operations(self):
+            # Perform operations with Quantities and PintArrays
+            # The resulting Quantity and PintArray.Data should be the same
+            # a op b == c
+            # warnings ignored here as it these tests are to ensure
+            # pint array behaviour is the same as quantity
+            def test_op(a_pint, a_pint_array, b_, coerce=True):
+                try:
+                    result_pint = op(a_pint, b_)
+                    if coerce:
+                        # a PintArray is returned from arithmetics, so need the data
+                        c_pint_array = op(a_pint_array, b_).data
+                    else:
+                        # a boolean array is returned from comparatives
+                        c_pint_array = op(a_pint_array, b_)
+
+                    self.assertQuantityAlmostEqual(result_pint, c_pint_array)
+
+                except Exception as caught_exception:
+                    self.assertRaises(type(caught_exception), op, a_pint_array, b_)
+
+
+            a_pints = [
+                self.Q_([3, 4], "m"),
+                self.Q_([3, 4], ""),
+            ]
+
+            a_pint_arrays = [PintArray(q) for q in a_pints]
+
+            bs = [
+                2,
+                self.Q_(3, "m"),
+                [1., 3.],
+                [3.3, 4.4],
+                self.Q_([6, 6], "m"),
+                self.Q_([7., np.nan]),
+            ]
+
+            for a_pint, a_pint_array in zip(a_pints, a_pint_arrays):
+                for b in bs:
+                    for op in arithmetic_ops:
+                        test_op(a_pint, a_pint_array, b)
+                    for op in comparative_ops:
+                        test_op(a_pint, a_pint_array, b, coerce=False)
+
+        def test_mismatched_dimensions(self):
+            x_and_ys=[
+                (PintArray(self.Q_([5], "m")), [1, 1]),
+                (PintArray(self.Q_([5, 5, 5], "m")), [1, 1]),
+                (PintArray(self.Q_([5, 5], "m")), [1]),
+            ]
+            for x, y in x_and_ys:
+                for op in comparative_ops + arithmetic_ops:
+                    self.assertRaises(ValueError, op, x, y)


### PR DESCRIPTION
This pull request adds pandas support to pint (hence is related to #645, #401 and pandas-dev/pandas#10349).

An example can be seen in `example-notebooks/basic-example.ipynb`.

It's a little bit hacksih, feedback would be greatly appreciated by me and @andrewgsavage. One obvious example is that we have to run all the interface tests with `pytest` to fit with `pandas` test suite, which introduces a dependency for the CI and currently gives us this awkward testing setup (see the alterations we had to make to `testsuite`). This also means that our code coverage tests are fiddly too.

If you'd like us to squash the commits, that can be done.

If pint has a linter, it would be good to run that over this pull request too as we're a little bit all over the place re style.

Things to discuss:

- [x]  general feedback and changes
- [x] test setup, especially need for pytest for pandas tests and hackish way to get around automatic discovery
- [x] squashing/rebasing
- [x] linting/other code style (related to #664 and #628: we're happy with whatever, I've found using an automatic linter e.g. black and/or flake8 has made things much simpler in other projects)
- [x] including notebooks in the repo (if we want to, I'm happy to put them under CI so we can make sure they run)
- [x] setting up the docs correctly