### PR TITLE
Fix issue #701: Import breaks with pandas<=0.22.0 installed

### DIFF
--- a/pint/compat/__init__.py
+++ b/pint/compat/__init__.py
@@ -127,7 +127,8 @@ if not HAS_PROPER_BABEL:
 try:
     import pandas as pd
     HAS_PANDAS = True
-    HAS_PROPER_PANDAS = hasattr(pd.core, "arrays") and hasattr(pd.core.arrays.base, "ExtensionOpsMixin")
+    HAS_PROPER_PANDAS = hasattr(pd.core, "arrays") and \
+                        hasattr(pd.core.arrays.base, "ExtensionOpsMixin")
 except ImportError:
     HAS_PROPER_PANDAS = HAS_PANDAS = False
 

--- a/pint/compat/__init__.py
+++ b/pint/compat/__init__.py
@@ -128,9 +128,9 @@ try:
     import pandas as pd
     HAS_PANDAS = True
     HAS_PROPER_PANDAS = (
-            hasattr(pd.core, "arrays")
-            and hasattr(pd.core.arrays.base, "ExtensionOpsMixin")
-        )
+        hasattr(pd.core, "arrays")
+        and hasattr(pd.core.arrays.base, "ExtensionOpsMixin")
+    )
 except ImportError:
     HAS_PROPER_PANDAS = HAS_PANDAS = False
 

--- a/pint/compat/__init__.py
+++ b/pint/compat/__init__.py
@@ -127,8 +127,10 @@ if not HAS_PROPER_BABEL:
 try:
     import pandas as pd
     HAS_PANDAS = True
-    HAS_PROPER_PANDAS = hasattr(pd.core, "arrays") and \
-                        hasattr(pd.core.arrays.base, "ExtensionOpsMixin")
+    HAS_PROPER_PANDAS = (
+            hasattr(pd.core, "arrays")
+            and hasattr(pd.core.arrays.base, "ExtensionOpsMixin")
+        )
 except ImportError:
     HAS_PROPER_PANDAS = HAS_PANDAS = False
 

--- a/pint/compat/__init__.py
+++ b/pint/compat/__init__.py
@@ -127,7 +127,7 @@ if not HAS_PROPER_BABEL:
 try:
     import pandas as pd
     HAS_PANDAS = True
-    HAS_PROPER_PANDAS = hasattr(pd.core.arrays.base, "ExtensionOpsMixin")
+    HAS_PROPER_PANDAS = hasattr(pd.core, "arrays") and hasattr(pd.core.arrays.base, "ExtensionOpsMixin")
 except ImportError:
     HAS_PROPER_PANDAS = HAS_PANDAS = False
 


### PR DESCRIPTION
This fixes #701 as outlined in issue comments. Please review this with respect to the usage of the `HAS_PROPER_PANDAS` flag, which seems to indicate if pandas is present in a compatible version, which is exactly the problem here.