### PR TITLE
Wrap converts strings

### DIFF
--- a/docs/wrapping.rst
+++ b/docs/wrapping.rst
@@ -91,19 +91,23 @@ Strict Mode
 -----------
 
 By default, the function is wrapped in `strict` mode. In this mode,
-the input arguments assigned to units must be a Quantities, or strings that
-can be converted to Quantities.
+the input arguments assigned to units must be Quantities.
 
 .. doctest::
 
     >>> mypp(1. * ureg.meter)
     <Quantity(2.0064092925890407, 'second')>
-    >>> mypp('2 m')
-    <Quantity(2.0064092925890407, 'second')>
     >>> mypp(1.)
     Traceback (most recent call last):
     ...
     ValueError: A wrapped function using strict=True requires quantity for all arguments with not None units. (error found for meter, 1.0)
+
+Strict mode also enables automatic conversion of strings into Quantities when possible.
+
+.. doctest::
+
+    >>> mypp('1 m')
+    <Quantity(2.0064092925890407, 'second')>
 
 To enable using non-Quantity numerical values, set strict to False`.
 

--- a/docs/wrapping.rst
+++ b/docs/wrapping.rst
@@ -82,6 +82,8 @@ Or in the decorator format:
                 Use None to skip conversion of any given element.
     - **strict**: if `True` all convertible arguments must be a Quantity
                   and others will raise a ValueError (True by default)
+                  `strict` also enables implicit string conversion. If
+                  a string can be converted to a Quantity, it will be.
 
 
 
@@ -89,11 +91,14 @@ Strict Mode
 -----------
 
 By default, the function is wrapped in `strict` mode. In this mode,
-the input arguments assigned to units must be a Quantities.
+the input arguments assigned to units must be a Quantities, or strings that
+can be converted to Quantities.
 
 .. doctest::
 
     >>> mypp(1. * ureg.meter)
+    <Quantity(2.0064092925890407, 'second')>
+    >>> mypp('2 m')
     <Quantity(2.0064092925890407, 'second')>
     >>> mypp(1.)
     Traceback (most recent call last):

--- a/pint/registry_helpers.py
+++ b/pint/registry_helpers.py
@@ -120,6 +120,15 @@ def _parse_wrap_args(args, registry=None):
                 new_values[ndx] = ureg._convert(values[ndx]._magnitude,
                                                 values[ndx]._units,
                                                 args_as_uc[ndx][0])
+
+            # If the input is a string and strict is active, convert it to a quantity.
+            elif string_types in type(values[ndx]).mro() and strict:
+                implicit_quantity = ureg.Quantity(values[ndx])
+                new_values[ndx] = ureg._convert(implicit_quantity._magnitude,
+                                                implicit_quantity._units,
+                                                args_as_uc[ndx][0])
+
+
             else:
                 if strict:
                     raise ValueError('A wrapped function using strict=True requires '
@@ -143,7 +152,7 @@ def _apply_defaults(func, args, kwargs):
         if param.name not in bound_arguments.arguments:
             bound_arguments.arguments[param.name] = param.default
     args = [bound_arguments.arguments[key] for key in sig.parameters.keys()]
-    return args, {} 
+    return args, {}
 
 def wraps(ureg, ret, args, strict=True):
     """Wraps a function to become pint-aware.
@@ -186,7 +195,7 @@ def wraps(ureg, ret, args, strict=True):
         def wrapper(*values, **kw):
 
             values, kw = _apply_defaults(func, values, kw)
-                
+
             # In principle, the values are used as is
             # When then extract the magnitudes when needed.
             new_values, values_by_name = converter(ureg, values, strict)

--- a/pint/registry_helpers.py
+++ b/pint/registry_helpers.py
@@ -132,7 +132,7 @@ def _parse_wrap_args(args, registry=None):
             else:
                 if strict:
                     raise ValueError('A wrapped function using strict=True requires '
-                                     'quantity for all arguments with not None units. '
+                                     'quantity or string for all arguments with not None units. '
                                      '(error found for {}, {})'.format(args_as_uc[ndx][0], new_values[ndx]))
 
         return new_values, values_by_name

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -347,6 +347,8 @@ class TestRegistry(QuantityTestCase):
         f3 = ureg.wraps('centimeter', ['meter', ], strict=True)(func)
         self.assertEqual(f3('3 cm'), .03 * ureg.centimeter)
         self.assertEqual(f3('3 m'), 3. * ureg.centimeter)
+        # Test that string conversion also rejects incorrect units.
+        self.assertRaises(ValueError, f3, '3 s')
 
         # Test that string conversion fails when strict=False
         f3 = ureg.wraps('centimeter', ['meter', ], strict=False)(func)

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -343,6 +343,17 @@ class TestRegistry(QuantityTestCase):
         self.assertEqual(f3(3. * ureg.centimeter), 0.03 * ureg.centimeter)
         self.assertEqual(f3(3. * ureg.meter), 3. * ureg.centimeter)
 
+        # Test string conversion when strict=True.
+        f3 = ureg.wraps('centimeter', ['meter', ], strict=True)(func)
+        self.assertEqual(f3('3 cm'), .03 * ureg.centimeter)
+        self.assertEqual(f3('3 m'), 3. * ureg.centimeter)
+
+        # Test that string conversion fails when strict=False
+        f3 = ureg.wraps('centimeter', ['meter', ], strict=False)(func)
+        # self.assertRaises(ValueError, f3, '3 cm')
+        self.assertEqual(f3('3 cm'), '3 cm' * ureg.centimeter)
+        # self.assertEqual(f3('3 m'), 3. * ureg.centimeter)
+
         def gfunc(x, y):
             return x + y
 


### PR DESCRIPTION
When strict=True, ureg.wraps is capable of converting strings to Quantities on function input. 

Also includes updates to tests, docs, and error messages. 

This PR is responsive to issue #711. 