### PR TITLE
to_compact() now prefers to prefix numerator

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ Other contributors, listed alphabetically, are:
 * Ryan Dwyer <ryanpdwyer@gmail.com>
 * Ryan Kingsbury <RyanSKingsbury@alumni.unc.edu>
 * Ryan May
+* Sigvald Marholm <sigvald@marebakken.com>
 * Sundar Raman <cybertoast@gmail.com>
 * Tiago Coutinho <coutinho@esrf.fr>
 * Thomas Kluyver <takowl@gmail.com>

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -497,9 +497,14 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
         q_base = self.to(unit)
 
         magnitude = q_base.magnitude
-        # Only changes the prefix on the first unit in the UnitContainer
-        unit_str = list(q_base._units.items())[0][0]
-        unit_power = list(q_base._units.items())[0][1]
+
+        units = list(q_base._units.items())
+        units_numerator = list(filter(lambda a: a[1]>0, units))
+
+        if len(units_numerator) > 0:
+            unit_str, unit_power = units_numerator[0]
+        else:
+            unit_str, unit_power = units[0]
 
         if unit_power > 0:
             power = int(math.floor(math.log10(abs(magnitude)) / unit_power / 3)) * 3

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -385,6 +385,12 @@ class TestQuantityToCompact(QuantityTestCase):
         self.compareQuantity_compact(1/ureg.m**2, 1/ureg.m**2)
         self.compareQuantity_compact(1e11/ureg.m**2, 1e5/ureg.mm**2)
 
+    def test_fractional_units(self):
+        ureg = self.ureg
+        # Typing denominator first to provoke potential error
+        self.compareQuantity_compact(20e3*ureg('hr^(-1) m'),
+            20*ureg.km/ureg.hr)
+
     def test_fractional_exponent_units(self):
         ureg = self.ureg
         self.compareQuantity_compact(1*ureg.m**0.5, 1*ureg.m**0.5)


### PR DESCRIPTION
C.f. https://github.com/hgrecco/pint/issues/724