### PR TITLE
Add missing closing parenthesis

### DIFF
--- a/docs/wrapping.rst
+++ b/docs/wrapping.rst
@@ -144,7 +144,7 @@ the extra outputs. For example, given the NREL SOLPOS calculator that outputs
 solar zenith, azimuth and air mass, the following wrapper assumes no units for
 airmass::
 
-    @UREG.wraps(('deg', 'deg'), ('deg', 'deg', 'millibar', 'degC')
+    @UREG.wraps(('deg', 'deg'), ('deg', 'deg', 'millibar', 'degC'))
     def solar_position(lat, lon, press, tamb, timestamp):
         return zenith, azimuth, airmass
 


### PR DESCRIPTION
Add missing closing parenthesis to the solar_position example in Multiple arguments or return values section