### PR TITLE
Add a few textile units and a conversion context

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -168,6 +168,16 @@ denier =  gram / (9000 * meter)
 tex = gram / (1000 * meter)
 dtex = decitex
 
+# These are Indirect yarn numbering systems (length/unit mass)
+jute = lb / (14400 * yd) = Tj
+Ne = 1/590.5 / tex
+Nm = 1/1000 / tex
+
+@context textile
+    # Allow switching between Direct count system (i.e. tex) and
+    # Indirect count system (i.e. Ne, Nm)
+    [mass] / [length] <-> [length] / [mass]: 1 / value
+
 # Photometry
 lumen = candela * steradian = lm
 lux = lumen / meter ** 2 = lx

--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -177,6 +177,7 @@ Nm = 1/1000 / tex
     # Allow switching between Direct count system (i.e. tex) and
     # Indirect count system (i.e. Ne, Nm)
     [mass] / [length] <-> [length] / [mass]: 1 / value
+@end
 
 # Photometry
 lumen = candela * steradian = lm

--- a/pint/testsuite/test_contexts.py
+++ b/pint/testsuite/test_contexts.py
@@ -633,6 +633,24 @@ class TestDefinedContexts(QuantityTestCase):
         for a, b in itertools.product(eq, eq):
             self.assertQuantityAlmostEqual(a.to(b.units, 'sp'), b, rtol=0.01)
 
+    def test_textile(self):
+        ureg = self.ureg
+        qty_direct = 1.331 * ureg.tex
+        with self.assertRaises(errors.DimensionalityError):
+            qty_indirect = qty_direct.to('Nm')
+
+        with ureg.context('textile'):
+            from pint.util import find_shortest_path
+            qty_indirect = qty_direct.to('Nm')
+            a = qty_direct.to_base_units()
+            b = qty_indirect.to_base_units()
+            da, db = Context.__keytransform__(a.dimensionality,
+                                              b.dimensionality)
+            p = find_shortest_path(ureg._active_ctx.graph, da, db)
+            self.assertTrue(p)
+            msg = '{} <-> {}'.format(a, b)
+            self.assertQuantityAlmostEqual(b, a, rtol=0.01, msg=msg)
+
     def test_decorator(self):
         ureg = self.ureg
 


### PR DESCRIPTION
Added jute, Ne, Nm textile units.
Added 'textile' context to allow conversion between Direct and Indirect Yarn Count systems.