### PR TITLE
Add get_application_registry (plus prettify)

### DIFF
--- a/pint/__init__.py
+++ b/pint/__init__.py
@@ -75,6 +75,14 @@ def _build_unit(units):
     return _APP_REGISTRY.Unit(units)
 
 
+def get_application_registry():
+    """
+    Get the application registry which is used for unpickling operations.
+    """
+    assert isinstance(registry, UnitRegistry)
+    return _APP_REGISTRY
+
+
 def set_application_registry(registry):
     """Set the application registry which is used for unpickling operations.
 

--- a/pint/__init__.py
+++ b/pint/__init__.py
@@ -79,7 +79,6 @@ def get_application_registry():
     """
     Get the application registry which is used for unpickling operations.
     """
-    assert isinstance(registry, UnitRegistry)
     return _APP_REGISTRY
 
 

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -144,6 +144,7 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
         # # Allow exception to propagate in case of non-iterable magnitude
         it_mag = iter(self.magnitude)
         return iter((self.__class__(mag, self._units) for mag in it_mag))
+
     @property
     def debug_used(self):
         return self.__used
@@ -161,9 +162,6 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
 
     def __str__(self):
         return format(self)
-
-    def __repr__(self):
-        return "<Quantity({}, '{}')>".format(self._magnitude, self._units)
 
     def __hash__(self):
         self_base = self.to_base_units()
@@ -323,9 +321,25 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
 
     @classmethod
     def from_tuple(cls, tup):
+        from . import _APP_REGISTRY, _DEFAULT_REGISTRY
+        if _APP_REGISTRY == _DEFAULT_REGISTRY:
+            warnings.warn("It is advised to set the application registry "
+                          "through `pint.set_application_registry` before "
+                          "using unit serialization.\nSee "
+                          "https://pint.readthedocs.io/en/latest/"
+                          "tutorial.html#using-pint-in-your-projects for "
+                          "more details.")
         return cls(tup[0], UnitsContainer(tup[1]))
 
     def to_tuple(self):
+        from . import _APP_REGISTRY, _DEFAULT_REGISTRY
+        if _APP_REGISTRY == _DEFAULT_REGISTRY:
+            warnings.warn("It is advised to set the application registry "
+                          "through `pint.set_application_registry` before "
+                          "using unit serialization.\nSee "
+                          "https://pint.readthedocs.io/en/latest/"
+                          "tutorial.html#using-pint-in-your-projects for "
+                          "more details.")
         return self.m, tuple(self._units.items())
 
     def compatible_units(self, *contexts):

--- a/pint/unit.py
+++ b/pint/unit.py
@@ -71,9 +71,6 @@ class _Unit(PrettyIPython, SharedRegistryObject):
     def __str__(self):
         return format(self)
 
-    def __repr__(self):
-        return "<Unit('{}')>".format(self._units)
-
     def __format__(self, spec):
         spec = spec or self.default_format
         # special cases

--- a/pint/util.py
+++ b/pint/util.py
@@ -16,6 +16,7 @@ import locale
 import sys
 import re
 import operator
+import warnings
 from numbers import Number
 from fractions import Fraction
 from collections import Mapping
@@ -305,9 +306,25 @@ class UnitsContainer(Mapping):
         return self._hash
 
     def __getstate__(self):
+        from . import _APP_REGISTRY, _DEFAULT_REGISTRY
+        if _APP_REGISTRY == _DEFAULT_REGISTRY:
+            warnings.warn("It is advised to set the application registry "
+                          "through `pint.set_application_registry` before "
+                          "using unit serialization.\nSee "
+                          "https://pint.readthedocs.io/en/latest/"
+                          "tutorial.html#using-pint-in-your-projects for "
+                          "more details.")
         return {'_d': self._d, '_hash': self._hash}
 
     def __setstate__(self, state):
+        from . import _APP_REGISTRY, _DEFAULT_REGISTRY
+        if _APP_REGISTRY == _DEFAULT_REGISTRY:
+            warnings.warn("It is advised to set the application registry "
+                          "through `pint.set_application_registry` before "
+                          "using unit serialization.\nSee "
+                          "https://pint.readthedocs.io/en/latest/"
+                          "tutorial.html#using-pint-in-your-projects for "
+                          "more details.")
         self._d = state['_d']
         self._hash = state['_hash']
 
@@ -646,6 +663,13 @@ class PrettyIPython(object):
             p.text("{:~P}".format(self))
         else:
             p.text("{:P}".format(self))
+
+    def __repr__(self):
+        if hasattr(self, "_magnitude"):
+            return "<{}({}, '{}')>".format(self.__class__.__name__,
+                                           self._magnitude, self._units)
+        else:
+            return "<{}('{}')>".format(self.__class__.__name__, self._units)
 
 
 def to_units_container(unit_like, registry=None):


### PR DESCRIPTION
This PR adresses #716 and helps solve #725.

I also moved the ``__repr__`` to ``PrettyIPython`` so as not to shadow the pretty representation.

Because the doc uses the tuples with pickle, I also added a warning when making tuples, though I don't understand why you do not advocate for direct pickling...
Checks are made in ``UnitsContainer`` to avoid issues with multiple inheritance hierarchies in quantities and units