### PR TITLE
WIP: Cleanup pandas tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,7 @@ install:
 
 script:
   # if we haven't installed pandas, don't use pytest to run tests
-  - if [[ $PANDAS == '0' ]]; then python -bb -m coverage run -p --source=pint --omit="*test*","*compat*" setup.py test; fi
-  # - if [[ $PANDAS == '0' ]]; then python -bb -m coverage run -p --source=pint --omit="*test*","*compat*","*pandas*" setup.py test; fi
+  - if [[ $PANDAS == '0' ]]; then python -bb -m coverage run -p --source=pint --omit="*test*","*compat*","*pandas*" setup.py test; fi
   # if we're doing the pandas tests and hence have pytest available, we can
   # simply use pytest to run all the tests
   - if [[ $PANDAS == '1' ]]; then python -bb -m coverage run -p --source=pint --omit="*test*","*compat*" -m py.test -rfsxEX; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
 
 script:
   # if we haven't installed pandas, don't use pytest to run tests
-  - if [[ $PANDAS == '0' ]]; then python -bb -m coverage run -p --source=pint --omit="*test*","*compat*","*pandas*" setup.py test; fi
+  - if [[ $PANDAS == '0' ]]; then python -bb -m coverage run -p --source=pint --omit="*test*","*compat*" setup.py test; fi
   # if we're doing the pandas tests and hence have pytest available, we can
   # simply use pytest to run all the tests
   - if [[ $PANDAS == '1' ]]; then python -bb -m coverage run -p --source=pint --omit="*test*","*compat*" -m py.test -rfsxEX; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,12 +54,13 @@ install:
   - pip install coveralls
 
 script:
+  # if we haven't installed pandas, don't use pytest to run tests
+  - if [[ $PANDAS == '0' ]]; then python -bb -m coverage run -p --source=pint --omit="*test*","*compat*" setup.py test; fi
   # if we're doing the pandas tests and hence have pytest available, we can
-  # simply use it to run all the tests
+  # simply use pytest to run all the tests
   - if [[ $PANDAS == '1' ]]; then python -bb -m coverage run -p --source=pint --omit="*test*","*compat*" -m py.test -rfsxEX; fi
   # test notebooks too if pandas available
-  - if [[ $PANDAS == '1' ]]; then pip install -e .; pytest --nbval notebooks/*; fi
-  - if [[ $PANDAS == '0' ]]; then python -bb -m coverage run -p --source=pint --omit="*test*","*compat*","*pandas*" setup.py test; fi
+  - if [[ $PANDAS == '1' ]]; then pip install -e .; pytest --nbval notebooks/*.ipynb; fi
   - coverage combine
   - coverage report -m
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ install:
 script:
   # if we haven't installed pandas, don't use pytest to run tests
   - if [[ $PANDAS == '0' ]]; then python -bb -m coverage run -p --source=pint --omit="*test*","*compat*" setup.py test; fi
+  # - if [[ $PANDAS == '0' ]]; then python -bb -m coverage run -p --source=pint --omit="*test*","*compat*","*pandas*" setup.py test; fi
   # if we're doing the pandas tests and hence have pytest available, we can
   # simply use pytest to run all the tests
   - if [[ $PANDAS == '1' ]]; then python -bb -m coverage run -p --source=pint --omit="*test*","*compat*" -m py.test -rfsxEX; fi

--- a/pint/compat/__init__.py
+++ b/pint/compat/__init__.py
@@ -86,7 +86,8 @@ try:
         return value
 
 except ImportError:
-
+    # why is there both np = None and HAS_NUMPY = False, surely np = None implies
+    # HAS_NUMPY = False
     np = None
 
     class ndarray(object):

--- a/pint/compat/__init__.py
+++ b/pint/compat/__init__.py
@@ -130,6 +130,9 @@ try:
     # pin Pandas version for now
     HAS_PROPER_PANDAS = pd.__version__.startswith("0.24.0.dev0+625.gbdb7a16")
 except ImportError:
+
+    pd = None
+
     HAS_PROPER_PANDAS = HAS_PANDAS = False
 
 try:

--- a/pint/compat/__init__.py
+++ b/pint/compat/__init__.py
@@ -86,8 +86,7 @@ try:
         return value
 
 except ImportError:
-    # why is there both np = None and HAS_NUMPY = False, surely np = None implies
-    # HAS_NUMPY = False
+
     np = None
 
     class ndarray(object):

--- a/pint/compat/__init__.py
+++ b/pint/compat/__init__.py
@@ -139,4 +139,5 @@ try:
     import pytest
     HAS_PYTEST = True
 except ImportError:
+    pytest = None
     HAS_PYTEST = False

--- a/pint/pandas_interface/pint_array.py
+++ b/pint/pandas_interface/pint_array.py
@@ -7,8 +7,8 @@
     :license: BSD, see LICENSE for more details.
 """
 
-from pint.compat import HAS_PROPER_PANDAS
-if not HAS_PROPER_PANDAS:
+from pint.compat import pd
+if pd is None:
     error_msg = (
         "The installed version of Pandas is not compatible with Pint, please check "
         "the docs."

--- a/pint/testsuite/helpers.py
+++ b/pint/testsuite/helpers.py
@@ -8,7 +8,7 @@ from distutils.version import StrictVersion
 import re
 import unittest
 
-from pint.compat import HAS_NUMPY, HAS_PROPER_BABEL, HAS_UNCERTAINTIES, NUMPY_VER, PYTHON3
+from pint.compat import HAS_NUMPY, HAS_PROPER_BABEL, HAS_UNCERTAINTIES, NUMPY_VER, PYTHON3, HAS_PROPER_PANDAS
 
 
 def requires_numpy18():
@@ -29,6 +29,14 @@ def requires_numpy():
 
 def requires_not_numpy():
     return unittest.skipIf(HAS_NUMPY, 'Requires NumPy is not installed.')
+
+
+def requires_pandas():
+    return unittest.skipUnless(HAS_PROPER_PANDAS, 'Requires compatible Pandas')
+
+
+def requires_not_pandas():
+    return unittest.skipIf(HAS_PROPER_PANDAS, 'Requires compatible Pandas is not installed')
 
 
 def requires_proper_babel():

--- a/pint/testsuite/helpers.py
+++ b/pint/testsuite/helpers.py
@@ -8,7 +8,7 @@ from distutils.version import StrictVersion
 import re
 import unittest
 
-from pint.compat import HAS_NUMPY, HAS_PROPER_BABEL, HAS_UNCERTAINTIES, NUMPY_VER, PYTHON3, HAS_PROPER_PANDAS
+from pint.compat import HAS_NUMPY, HAS_PROPER_BABEL, HAS_UNCERTAINTIES, NUMPY_VER, PYTHON3, HAS_PROPER_PANDAS, HAS_PYTEST
 
 
 def requires_numpy18():
@@ -37,6 +37,10 @@ def requires_pandas():
 
 def requires_not_pandas():
     return unittest.skipIf(HAS_PROPER_PANDAS, 'Requires compatible Pandas is not installed')
+
+
+def requires_pytest():
+    return unittest.skipUnless(HAS_PYTEST, 'Requires pytest')
 
 
 def requires_proper_babel():

--- a/pint/testsuite/pandas_interface/__init__.py
+++ b/pint/testsuite/pandas_interface/__init__.py
@@ -1,0 +1,16 @@
+import unittest
+
+from pint.compat import pd, pytest
+
+def setUpModule():
+    if (pytest is None) or (pd is None):
+        if (pytest is None) and (pd is None):
+            missing_msg = (
+                "pytest and the right pandas version are not available, check the docs"
+            )
+        elif pytest is None:
+            missing_msg = "pytest is not available"
+        elif pd is None:
+            missing_msg = "the right pandas version is not available, check the docs"
+
+        raise unittest.SkipTest(missing_msg)

--- a/pint/testsuite/pandas_interface/__init__.py
+++ b/pint/testsuite/pandas_interface/__init__.py
@@ -3,7 +3,10 @@ import unittest
 from pint.compat import pd, pytest
 
 def setUpModule():
-    if (pytest is None) or (pd is None):
+    print("Hit setupmodule")
+    try:
+        import pint.pandas_interface as ppi
+    except:
         if (pytest is None) and (pd is None):
             missing_msg = (
                 "pytest and the right pandas version are not available, check the docs"

--- a/pint/testsuite/pandas_interface/test_pandas_interface.py
+++ b/pint/testsuite/pandas_interface/test_pandas_interface.py
@@ -13,17 +13,20 @@ from pint.compat import np, pd, pytest
 from pint.errors import DimensionalityError
 from pint.testsuite import BaseTestCase, QuantityTestCase, helpers
 
-if (pytest is None) or (pd is None):
-    if (pytest is None) and (pd is None):
-        missing_msg = (
-            "pytest and the right pandas version are not available, check the docs"
-        )
-    elif pytest is None:
-        missing_msg = "pytest is not available"
-    elif pd is None:
-        missing_msg = "the right pandas version is not available, check the docs"
+def setUpModule():
+    if (pytest is None) or (pd is None):
+        if (pytest is None) and (pd is None):
+            missing_msg = (
+                "pytest and the right pandas version are not available, check the docs"
+            )
+        elif pytest is None:
+            missing_msg = "pytest is not available"
+        elif pd is None:
+            missing_msg = "the right pandas version is not available, check the docs"
 
-    raise unittest.SkipTest(missing_msg)
+        raise unittest.SkipTest(missing_msg)
+
+setUpModule()
 
 import pint.pandas_interface as ppi
 from pint.pandas_interface import PintArray
@@ -31,7 +34,6 @@ from pint.pandas_interface import PintArray
 from pandas.tests.extension import base
 from pandas.core import ops
 from pandas.compat import PY3
-
 
 @pytest.fixture
 def dtype():

--- a/pint/testsuite/pandas_interface/test_pandas_interface.py
+++ b/pint/testsuite/pandas_interface/test_pandas_interface.py
@@ -7,26 +7,13 @@ import operator
 import warnings
 import unittest
 
+
+
 import pint
 
 from pint.compat import np, pd, pytest
 from pint.errors import DimensionalityError
 from pint.testsuite import BaseTestCase, QuantityTestCase, helpers
-
-def setUpModule():
-    if (pytest is None) or (pd is None):
-        if (pytest is None) and (pd is None):
-            missing_msg = (
-                "pytest and the right pandas version are not available, check the docs"
-            )
-        elif pytest is None:
-            missing_msg = "pytest is not available"
-        elif pd is None:
-            missing_msg = "the right pandas version is not available, check the docs"
-
-        raise unittest.SkipTest(missing_msg)
-
-setUpModule()
 
 import pint.pandas_interface as ppi
 from pint.pandas_interface import PintArray
@@ -34,6 +21,7 @@ from pint.pandas_interface import PintArray
 from pandas.tests.extension import base
 from pandas.core import ops
 from pandas.compat import PY3
+
 
 @pytest.fixture
 def dtype():
@@ -441,7 +429,7 @@ class TestUserInterface(object):
 
         test_csv = join(
             dirname(__file__),
-            "test-data", "pandas_test.csv"
+            "..", "test-data", "pandas_test.csv"
         )
 
         df = pd.read_csv(test_csv, header=[0,1])
@@ -465,7 +453,7 @@ class TestDataFrameAccessor(object):
     def test_index_maintained(self):
         test_csv = join(
             dirname(__file__),
-            "test-data", "pandas_test.csv"
+            "..", "test-data", "pandas_test.csv"
         )
 
         df = pd.read_csv(test_csv, header=[0, 1])

--- a/pint/testsuite/test_pandas_interface.py
+++ b/pint/testsuite/test_pandas_interface.py
@@ -6,10 +6,7 @@ from copy import deepcopy
 import operator
 import warnings
 
-from pandas.core import ops
-from pandas.compat import PY3
 import pint
-from pint.pandas_interface import PintArray
 
 from pint.compat import np, pd, pytest
 from pint.errors import DimensionalityError
@@ -23,7 +20,12 @@ if (pytest is None) or (pd is None):
     get_tdata = MagicMock()
 else:
     import pint.pandas_interface as ppi
+    from pint.pandas_interface import PintArray
+
     from pandas.tests.extension import base
+    from pandas.core import ops
+    from pandas.compat import PY3
+
     @pytest.fixture
     def dtype():
         return ppi.PintType()

--- a/pint/testsuite/test_pandas_interface.py
+++ b/pint/testsuite/test_pandas_interface.py
@@ -19,39 +19,39 @@ from pint.testsuite import BaseTestCase, QuantityTestCase, helpers
 if pd is not None:
     import pint.pandas_interface as ppi
 
-if not (pytest is not None and pd is not None):
-    class TestPandasException(BaseTestCase):
-        def test_pandas_exception(self):
-            expected_error_msg = (
-                "The installed version of Pandas is not compatible with Pint, please "
-                "check the docs."
-            )
-            with self.assertRaises(ImportError) as cm:
-                import pint.pandas_interface
 
-            self.assertEqual(str(cm.exception), expected_error_msg)
-
-    if not (HAS_PYTEST and HAS_PROPER_PANDAS):
-        msg_end = "the correct version of Pandas and pytest installed"
-    elif not HAS_PROPER_PANDAS:
-        msg_end = "the latest version of Pandas installed"
-    elif not HAS_PYTEST:
-        msg_end = "pytest installed"
-
-    print("Skipping all Pandas tests except exception raising as we don't have {}".format(msg_end))
+UREG = pint.UnitRegistry()
 
 
-else:
-    ureg = pint.UnitRegistry()
+@helpers.requires_not_pandas()
+class TestPandasException(BaseTestCase):
+    def test_pandas_exception(self):
+        expected_error_msg = (
+            "The installed version of Pandas is not compatible with Pint, please "
+            "check the docs."
+        )
+        with self.assertRaises(ImportError) as cm:
+            import pint.pandas_interface
 
+        self.assertEqual(str(cm.exception), expected_error_msg)
 
+# if not (HAS_PYTEST and HAS_PROPER_PANDAS):
+#     msg_end = "the correct version of Pandas and pytest installed"
+# elif not HAS_PROPER_PANDAS:
+#     msg_end = "the latest version of Pandas installed"
+# elif not HAS_PYTEST:
+#     msg_end = "pytest installed"
+
+# print("Skipping all Pandas tests except exception raising as we don't have {}".format(msg_end))
+
+if pytest is not None:
     @pytest.fixture
     def dtype():
         return ppi.PintType()
 
 
     def get_tdata():
-        return ppi.PintArray(np.arange(start=1., stop=101.) * ureg.kilogram)
+        return ppi.PintArray(np.arange(start=1., stop=101.) * UREG.kilogram)
 
 
     @pytest.fixture
@@ -61,7 +61,7 @@ else:
 
     @pytest.fixture
     def data_missing():
-        return ppi.PintArray([np.nan, 1] * ureg.meter)
+        return ppi.PintArray([np.nan, 1] * UREG.meter)
 
 
     @pytest.fixture(params=['data', 'data_missing'])
@@ -86,14 +86,14 @@ else:
     def data_for_sorting():
         return ppi.PintArray([0.3, 10, -50])
         # should probably get more sophisticated and do something like
-        # [1 * ureg.meter, 3 * ureg.meter, 10 * ureg.centimeter]
+        # [1 * UREG.meter, 3 * UREG.meter, 10 * UREG.centimeter]
 
 
     @pytest.fixture
     def data_missing_for_sorting():
         return ppi.PintArray([4, np.nan, -5])
         # should probably get more sophisticated and do something like
-        # [4 * ureg.meter, np.nan, 10 * ureg.centimeter]
+        # [4 * UREG.meter, np.nan, 10 * UREG.centimeter]
 
 
     @pytest.fixture
@@ -152,489 +152,488 @@ else:
         * <=
         """
         return request.param
-    # =================================================================
+# =================================================================
 
 
-    class TestCasting(base.BaseCastingTests):
-        pass
+class TestCasting(base.BaseCastingTests):
+    pass
 
 
-    class TestConstructors(base.BaseConstructorsTests):
-        pass
+class TestConstructors(base.BaseConstructorsTests):
+    pass
 
 
-    class TestDtype(base.BaseDtypeTests):
-        pass
+class TestDtype(base.BaseDtypeTests):
+    pass
 
 
-    class TestGetitem(base.BaseGetitemTests):
-        pass
+class TestGetitem(base.BaseGetitemTests):
+    pass
 
 
-    class TestGroupby(base.BaseGroupbyTests):
-        pass
+class TestGroupby(base.BaseGroupbyTests):
+    pass
 
 
-    class TestInterface(base.BaseInterfaceTests):
-        pass
+class TestInterface(base.BaseInterfaceTests):
+    pass
 
 
-    class TestMethods(base.BaseMethodsTests):
+class TestMethods(base.BaseMethodsTests):
+    @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
+    # See test_setitem_mask_broadcast note
+    @pytest.mark.parametrize('dropna', [True, False])
+    def test_value_counts(self, all_data, dropna):
+        all_data = all_data[:10]
+        if dropna:
+            other = all_data[~all_data.isna()]
+        else:
+            other = all_data
 
-        @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
-        # See test_setitem_mask_broadcast note
-        @pytest.mark.parametrize('dropna', [True, False])
-        def test_value_counts(self, all_data, dropna):
-            all_data = all_data[:10]
-            if dropna:
-                other = all_data[~all_data.isna()]
-            else:
-                other = all_data
+        result = pd.Series(all_data).value_counts(dropna=dropna).sort_index()
+        expected = pd.Series(other).value_counts(
+            dropna=dropna).sort_index()
 
-            result = pd.Series(all_data).value_counts(dropna=dropna).sort_index()
-            expected = pd.Series(other).value_counts(
-                dropna=dropna).sort_index()
+        self.assert_series_equal(result, expected)
 
+    @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
+    # See test_setitem_mask_broadcast note
+    @pytest.mark.parametrize('box', [pd.Series, lambda x: x])
+    @pytest.mark.parametrize('method', [lambda x: x.unique(), pd.unique])
+    def test_unique(self, data, box, method):
+        duplicated = box(data._from_sequence([data[0], data[0]]))
+
+        result = method(duplicated)
+
+        assert len(result) == 1
+        assert isinstance(result, type(data))
+        assert result[0] == duplicated[0]
+
+
+class TestArithmeticOps(base.BaseArithmeticOpsTests):
+    def check_opname(self, s, op_name, other, exc=None):
+        op = self.get_op_from_name(op_name)
+
+        self._check_op(s, op, other, exc)
+
+    def _check_op(self, s, op, other, exc=None):
+        if exc is None:
+            result = op(s, other)
+            expected = s.combine(other, op)
             self.assert_series_equal(result, expected)
+        else:
+            with pytest.raises(exc):
+                op(s, other)
 
-        @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
-        # See test_setitem_mask_broadcast note
-        @pytest.mark.parametrize('box', [pd.Series, lambda x: x])
-        @pytest.mark.parametrize('method', [lambda x: x.unique(), pd.unique])
-        def test_unique(self, data, box, method):
-            duplicated = box(data._from_sequence([data[0], data[0]]))
-
-            result = method(duplicated)
-
-            assert len(result) == 1
-            assert isinstance(result, type(data))
-            assert result[0] == duplicated[0]
-
-
-    class TestArithmeticOps(base.BaseArithmeticOpsTests):
-        def check_opname(self, s, op_name, other, exc=None):
-            op = self.get_op_from_name(op_name)
-
-            self._check_op(s, op, other, exc)
-
-        def _check_op(self, s, op, other, exc=None):
-            if exc is None:
-                result = op(s, other)
-                expected = s.combine(other, op)
-                self.assert_series_equal(result, expected)
+    def _check_divmod_op(self, s, op, other, exc=None):
+        # divmod has multiple return values, so check separately
+        if exc is None:
+            result_div, result_mod = op(s, other)
+            if op is divmod:
+                expected_div, expected_mod = s // other, s % other
             else:
-                with pytest.raises(exc):
-                    op(s, other)
+                expected_div, expected_mod = other // s, other % s
+            self.assert_series_equal(result_div, expected_div)
+            self.assert_series_equal(result_mod, expected_mod)
+        else:
+            with pytest.raises(exc):
+                divmod(s, other)
 
-        def _check_divmod_op(self, s, op, other, exc=None):
-            # divmod has multiple return values, so check separately
-            if exc is None:
-                result_div, result_mod = op(s, other)
-                if op is divmod:
-                    expected_div, expected_mod = s // other, s % other
+    def _get_exception(self, data, op_name):
+        if op_name in ["__pow__", "__rpow__"]:
+            return op_name, DimensionalityError
+        else:
+            return op_name, None
+
+    def test_arith_series_with_scalar(self, data, all_arithmetic_operators):
+        # series & scalar
+        op_name, exc = self._get_exception(data, all_arithmetic_operators)
+        s = pd.Series(data)
+        self.check_opname(s, op_name, s.iloc[0], exc=exc)
+
+    @pytest.mark.xfail(run=True, reason="_reduce needs implementation")
+    def test_arith_frame_with_scalar(self, data, all_arithmetic_operators):
+        # frame & scalar
+        op_name, exc = self._get_exception(data, all_arithmetic_operators)
+        df = pd.DataFrame({'A': data})
+        self.check_opname(df, op_name, data[0], exc=exc)
+
+    @pytest.mark.xfail(run=True, reason="s.combine does not accept arrays")
+    def test_arith_series_with_array(self, data, all_arithmetic_operators):
+        # ndarray & other series
+        op_name, exc = self._get_exception(data, all_arithmetic_operators)
+        s = pd.Series(data)
+        self.check_opname(s, op_name, data, exc=exc)
+
+    # parameterise this to try divisor not equal to 1
+    def test_divmod(self, data):
+        s = pd.Series(data)
+        self._check_divmod_op(s, divmod, 1*UREG.kg)
+        self._check_divmod_op(1*UREG.kg, ops.rdivmod, s)
+
+    def test_error(self, data, all_arithmetic_operators):
+        # invalid ops
+
+        op = all_arithmetic_operators
+        s = pd.Series(data)
+        ops = getattr(s, op)
+        opa = getattr(data, op)
+
+        # invalid scalars
+        # TODO: work out how to make this more specific/test for the two
+        #       different possible errors here
+        with pytest.raises(Exception):
+            ops('foo')
+
+        # TODO: work out how to make this more specific/test for the two
+        #       different possible errors here
+        with pytest.raises(Exception):
+            ops(pd.Timestamp('20180101'))
+
+        # invalid array-likes
+        # TODO: work out how to make this more specific/test for the two
+        #       different possible errors here
+        with pytest.raises(Exception):
+            ops(pd.Series('foo', index=s.index))
+
+        # 2d
+        with pytest.raises(KeyError):
+            opa(pd.DataFrame({'A': s}))
+
+        with pytest.raises(ValueError):
+            opa(np.arange(len(s)).reshape(-1, len(s)))
+
+
+
+class TestComparisonOps(base.BaseComparisonOpsTests):
+    def _compare_other(self, s, data, op_name, other):
+        op = self.get_op_from_name(op_name)
+
+        result = op(s,other)
+        expected = op(s.values.data, other)
+        assert (result==expected).all()
+
+    def test_compare_scalar(self, data, all_compare_operators):
+        op_name = all_compare_operators
+        s = pd.Series(data)
+        other = data[0]
+        self._compare_other(s, data, op_name, other)
+
+    def test_compare_array(self, data, all_compare_operators):
+        # nb this compares an quantity containing array
+        # eg Q_([1,2],"m")
+        op_name = all_compare_operators
+        s = pd.Series(data)
+        other = data.data
+        self._compare_other(s, data, op_name, other)
+
+
+
+class TestOpsUtil(base.BaseOpsUtil):
+    pass
+
+
+class TestMissing(base.BaseMissingTests):
+    pass
+
+
+class TestReshaping(base.BaseReshapingTests):
+    pass
+
+
+class TestSetitem(base.BaseSetitemTests):
+    @pytest.mark.parametrize('setter', ['loc', None])
+    @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
+    # Pandas performs a hasattr(__array__), which triggers the warning
+    # Debugging it does not pass through a PintArray, so
+    # I think this needs changing in pint quantity
+    # eg s[[True]*len(s)]=Q_(1,"m")
+    def test_setitem_mask_broadcast(self, data, setter):
+        ser = pd.Series(data)
+        mask = np.zeros(len(data), dtype=bool)
+        mask[:2] = True
+
+        if setter:   # loc
+            target = getattr(ser, setter)
+        else:  # __setitem__
+            target = ser
+
+        operator.setitem(target, mask, data[10])
+        assert ser[0] == data[10]
+        assert ser[1] == data[10]
+
+
+# would be ideal to just test all of this by running the example notebook
+# but this isn't a discussion we've had yet
+
+class TestUserInterface(object):
+    def test_get_underlying_data(self, data):
+        ser = pd.Series(data)
+        # this first test creates an array of bool (which is desired, eg for indexing)
+        assert all(ser.values == data)
+        assert ser.values[23] == data[23]
+
+    def test_arithmetic(self, data):
+        ser = pd.Series(data)
+        ser2 = ser + ser
+        assert all(ser2.values == 2*data)
+
+    def test_initialisation(self, data):
+        # fails with plain array
+        # works with PintArray
+        strt = np.arange(100) * UREG.newton
+
+        # it is sad this doesn't work
+        with pytest.raises(ValueError):
+            ser_fail = pd.Series(strt, dtype=ppi.PintType())
+            assert all(ser_fail.values == strt)
+
+        # This needs to be a list of scalar quantities to work :<
+        ser = pd.Series([q for q in strt], dtype=ppi.PintType())
+        assert all(ser.values == strt)
+
+    def test_df_operations(self):
+        # simply a copy of what's in the notebook
+        Q_ = UREG.Quantity
+        df = pd.DataFrame({
+            "torque": PintArray(Q_([1, 2, 2, 3], "lbf ft")),
+            "angular_velocity": PintArray(Q_([1000, 2000, 2000, 3000], "rpm"))
+        })
+
+        df['power'] = df['torque'] * df['angular_velocity']
+
+        df.power.values.data
+        df.torque.values.data
+        df.angular_velocity.values.data
+
+        df.power.values.data.to("kW")
+
+        test_csv = join(
+            dirname(__file__),
+            "test-data", "pandas_test.csv"
+        )
+
+        df = pd.read_csv(test_csv, header=[0,1])
+        df_ = df.pint.quantify(UREG, level=-1)
+
+        df_['mech power'] = df_.speed*df_.torque
+        df_['fluid power'] = df_['fuel flow rate'] * df_['rail pressure']
+
+        df_.pint.dequantify()
+
+        df_['fluid power'] = df_['fluid power'].pint.to("kW")
+        df_['mech power'] = df_['mech power'].pint.to("kW")
+        df_.pint.dequantify()
+
+        df_.pint.to_base_units().pint.dequantify()
+
+
+class TestDataFrameAccessor(object):
+    def test_index_maintained(self):
+        test_csv = join(
+            dirname(__file__),
+            "test-data", "pandas_test.csv"
+        )
+
+        df = pd.read_csv(test_csv, header=[0, 1])
+        df.columns = pd.MultiIndex.from_arrays(
+            [
+                ['Holden', 'Holden', 'Holden', 'Ford', 'Ford', 'Ford'],
+                ['speed', 'mech power', 'torque', 'rail pressure', 'fuel flow rate' ,'fluid power'],
+                ['rpm', 'kW', 'N m', 'bar', 'l/min', 'kW'],
+            ],
+            names = ['Car type', 'metric', 'unit']
+        )
+        df.index = pd.MultiIndex.from_arrays(
+            [
+                [1, 12, 32, 48],
+                ['Tim', 'Tim', 'Jane', 'Steve'],
+            ],
+            names = ['Measurement number', 'Measurer']
+
+        )
+
+
+        expected = df.copy()
+
+        # we expect the result to come back with pint names, not input
+        # names
+        def get_pint_value(in_str):
+            return str(UREG.Quantity(1, in_str).units)
+
+        units_level = [
+            i for i, name in enumerate(df.columns.names) if name == 'unit'
+        ][0]
+
+        expected.columns = df.columns.set_levels(
+            df.columns.levels[units_level].map(get_pint_value),
+            level='unit'
+        )
+
+
+        result = df.pint.quantify(UREG, level=-1).pint.dequantify()
+
+        pd.testing.assert_frame_equal(result, expected)
+
+
+class TestSeriesAccessors(object):
+    @pytest.mark.parametrize('attr', [
+        'debug_used',
+        'default_format',
+        'dimensionality',
+        'dimensionless',
+        'force_ndarray',
+        'shape',
+        'u',
+        'unitless',
+        'units',
+    ])
+    def test_series_scalar_property_accessors(self, data, attr):
+        s = pd.Series(data)
+        assert getattr(s.pint, attr) == getattr(data._data,attr)
+
+    @pytest.mark.parametrize('attr', [
+        'm',
+        'magnitude',
+        #'imag', # failing, not sure why
+        #'real', # failing, not sure why
+    ])
+    def test_series_property_accessors(self, data, attr):
+        s = pd.Series(data)
+        assert all(getattr(s.pint, attr) == pd.Series(getattr(data._data,attr)))
+
+    @pytest.mark.parametrize('attr_args', [
+        ('check', ({"[length]": 1})),
+        ('compatible_units', ()),
+        # ('format_babel', ()), Needs babel installed?
+        # ('plus_minus', ()), Needs uncertanties
+        ('to_tuple', ()),
+        ('tolist', ())
+    ])
+    def test_series_scalar_method_accessors(self, data, attr_args):
+        attr = attr_args[0]
+        args = attr_args[1]
+        s = pd.Series(data)
+        assert getattr(s.pint, attr)(*args) == getattr(data._data, attr)(*args)
+
+    @pytest.mark.parametrize('attr_args', [
+        ('ito', ("g",)),
+        ('ito_base_units', ()),
+        ('ito_reduced_units', ()),
+        ('ito_root_units', ()),
+        ('put', (1, get_tdata()[0]))
+    ])
+    def test_series_inplace_method_accessors(self, data, attr_args):
+        attr = attr_args[0]
+        args = attr_args[1]
+        s = pd.Series(deepcopy(data))
+        getattr(s.pint, attr)(*args)
+        getattr(data._data, attr)(*args)
+        assert all(s.values == data)
+
+    @pytest.mark.parametrize('attr_args', [
+        ('clip', (get_tdata()[10], get_tdata()[20])),
+        ('from_tuple', (get_tdata().data.to_tuple(),)),
+        ('m_as', ("g",)),
+        ('searchsorted', (get_tdata()[10],)),
+        ('to', ("g")),
+        ('to_base_units', ()),
+        ('to_compact', ()),
+        ('to_reduced_units', ()),
+        ('to_root_units', ()),
+        # ('to_timedelta', ()),
+    ])
+    def test_series_method_accessors(self, data, attr_args):
+        attr=attr_args[0]
+        args=attr_args[1]
+        s = pd.Series(data)
+        assert all(getattr(s.pint, attr)(*args) == getattr(data._data,attr)(*args))
+
+
+arithmetic_ops = [
+    operator.add,
+    operator.sub,
+    operator.mul,
+    operator.truediv,
+    operator.floordiv,
+    operator.pow,
+]
+
+comparative_ops = [
+    operator.eq,
+    operator.le,
+    operator.lt,
+    operator.ge,
+    operator.gt,
+]
+
+
+class TestPintArrayQuantity(QuantityTestCase):
+    FORCE_NDARRAY = True
+
+    def test_pintarray_creation(self):
+        x = self.Q_([1, 2, 3],"m")
+        ys = [
+            PintArray(x),
+            PintArray._from_sequence([item for item in x])
+        ]
+        for y in ys:
+            self.assertQuantityAlmostEqual(x,y.data)
+
+
+    @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
+    @pytest.mark.filterwarnings("ignore::RuntimeWarning")
+    def test_pintarray_operations(self):
+        # Perform operations with Quantities and PintArrays
+        # The resulting Quantity and PintArray.Data should be the same
+        # a op b == c
+        # warnings ignored here as it these tests are to ensure
+        # pint array behaviour is the same as quantity
+        def test_op(a_pint, a_pint_array, b_, coerce=True):
+            try:
+                result_pint = op(a_pint, b_)
+                if coerce:
+                    # a PintArray is returned from arithmetics, so need the data
+                    c_pint_array = op(a_pint_array, b_).data
                 else:
-                    expected_div, expected_mod = other // s, other % s
-                self.assert_series_equal(result_div, expected_div)
-                self.assert_series_equal(result_mod, expected_mod)
-            else:
-                with pytest.raises(exc):
-                    divmod(s, other)
-
-        def _get_exception(self, data, op_name):
-            if op_name in ["__pow__", "__rpow__"]:
-                return op_name, DimensionalityError
-            else:
-                return op_name, None
-
-        def test_arith_series_with_scalar(self, data, all_arithmetic_operators):
-            # series & scalar
-            op_name, exc = self._get_exception(data, all_arithmetic_operators)
-            s = pd.Series(data)
-            self.check_opname(s, op_name, s.iloc[0], exc=exc)
-
-        @pytest.mark.xfail(run=True, reason="_reduce needs implementation")
-        def test_arith_frame_with_scalar(self, data, all_arithmetic_operators):
-            # frame & scalar
-            op_name, exc = self._get_exception(data, all_arithmetic_operators)
-            df = pd.DataFrame({'A': data})
-            self.check_opname(df, op_name, data[0], exc=exc)
-
-        @pytest.mark.xfail(run=True, reason="s.combine does not accept arrays")
-        def test_arith_series_with_array(self, data, all_arithmetic_operators):
-            # ndarray & other series
-            op_name, exc = self._get_exception(data, all_arithmetic_operators)
-            s = pd.Series(data)
-            self.check_opname(s, op_name, data, exc=exc)
-
-        # parameterise this to try divisor not equal to 1
-        def test_divmod(self, data):
-            s = pd.Series(data)
-            self._check_divmod_op(s, divmod, 1*ureg.kg)
-            self._check_divmod_op(1*ureg.kg, ops.rdivmod, s)
-
-        def test_error(self, data, all_arithmetic_operators):
-            # invalid ops
-
-            op = all_arithmetic_operators
-            s = pd.Series(data)
-            ops = getattr(s, op)
-            opa = getattr(data, op)
-
-            # invalid scalars
-            # TODO: work out how to make this more specific/test for the two
-            #       different possible errors here
-            with pytest.raises(Exception):
-                ops('foo')
-
-            # TODO: work out how to make this more specific/test for the two
-            #       different possible errors here
-            with pytest.raises(Exception):
-                ops(pd.Timestamp('20180101'))
-
-            # invalid array-likes
-            # TODO: work out how to make this more specific/test for the two
-            #       different possible errors here
-            with pytest.raises(Exception):
-                ops(pd.Series('foo', index=s.index))
-
-            # 2d
-            with pytest.raises(KeyError):
-                opa(pd.DataFrame({'A': s}))
-
-            with pytest.raises(ValueError):
-                opa(np.arange(len(s)).reshape(-1, len(s)))
-
-
-
-    class TestComparisonOps(base.BaseComparisonOpsTests):
-        def _compare_other(self, s, data, op_name, other):
-            op = self.get_op_from_name(op_name)
-
-            result = op(s,other)
-            expected = op(s.values.data, other)
-            assert (result==expected).all()
-
-        def test_compare_scalar(self, data, all_compare_operators):
-            op_name = all_compare_operators
-            s = pd.Series(data)
-            other = data[0]
-            self._compare_other(s, data, op_name, other)
-
-        def test_compare_array(self, data, all_compare_operators):
-            # nb this compares an quantity containing array
-            # eg Q_([1,2],"m")
-            op_name = all_compare_operators
-            s = pd.Series(data)
-            other = data.data
-            self._compare_other(s, data, op_name, other)
-
-
-
-    class TestOpsUtil(base.BaseOpsUtil):
-        pass
-
-
-    class TestMissing(base.BaseMissingTests):
-        pass
-
-
-    class TestReshaping(base.BaseReshapingTests):
-        pass
-
-
-    class TestSetitem(base.BaseSetitemTests):
-        @pytest.mark.parametrize('setter', ['loc', None])
-        @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
-        # Pandas performs a hasattr(__array__), which triggers the warning
-        # Debugging it does not pass through a PintArray, so
-        # I think this needs changing in pint quantity
-        # eg s[[True]*len(s)]=Q_(1,"m")
-        def test_setitem_mask_broadcast(self, data, setter):
-            ser = pd.Series(data)
-            mask = np.zeros(len(data), dtype=bool)
-            mask[:2] = True
-
-            if setter:   # loc
-                target = getattr(ser, setter)
-            else:  # __setitem__
-                target = ser
-
-            operator.setitem(target, mask, data[10])
-            assert ser[0] == data[10]
-            assert ser[1] == data[10]
-
-
-    # would be ideal to just test all of this by running the example notebook
-    # but this isn't a discussion we've had yet
-
-    class TestUserInterface(object):
-        def test_get_underlying_data(self, data):
-            ser = pd.Series(data)
-            # this first test creates an array of bool (which is desired, eg for indexing)
-            assert all(ser.values == data)
-            assert ser.values[23] == data[23]
-
-        def test_arithmetic(self, data):
-            ser = pd.Series(data)
-            ser2 = ser + ser
-            assert all(ser2.values == 2*data)
-
-        def test_initialisation(self, data):
-            # fails with plain array
-            # works with PintArray
-            strt = np.arange(100) * ureg.newton
-
-            # it is sad this doesn't work
-            with pytest.raises(ValueError):
-                ser_fail = pd.Series(strt, dtype=ppi.PintType())
-                assert all(ser_fail.values == strt)
-
-            # This needs to be a list of scalar quantities to work :<
-            ser = pd.Series([q for q in strt], dtype=ppi.PintType())
-            assert all(ser.values == strt)
-
-        def test_df_operations(self):
-            # simply a copy of what's in the notebook
-            Q_ = ureg.Quantity
-            df = pd.DataFrame({
-                "torque": PintArray(Q_([1, 2, 2, 3], "lbf ft")),
-                "angular_velocity": PintArray(Q_([1000, 2000, 2000, 3000], "rpm"))
-            })
-
-            df['power'] = df['torque'] * df['angular_velocity']
-
-            df.power.values.data
-            df.torque.values.data
-            df.angular_velocity.values.data
-
-            df.power.values.data.to("kW")
-
-            test_csv = join(
-                dirname(__file__),
-                "test-data", "pandas_test.csv"
-            )
-
-            df = pd.read_csv(test_csv, header=[0,1])
-            df_ = df.pint.quantify(ureg, level=-1)
-
-            df_['mech power'] = df_.speed*df_.torque
-            df_['fluid power'] = df_['fuel flow rate'] * df_['rail pressure']
-
-            df_.pint.dequantify()
-
-            df_['fluid power'] = df_['fluid power'].pint.to("kW")
-            df_['mech power'] = df_['mech power'].pint.to("kW")
-            df_.pint.dequantify()
-
-            df_.pint.to_base_units().pint.dequantify()
-
-
-    class TestDataFrameAccessor(object):
-        def test_index_maintained(self):
-            test_csv = join(
-                dirname(__file__),
-                "test-data", "pandas_test.csv"
-            )
-
-            df = pd.read_csv(test_csv, header=[0, 1])
-            df.columns = pd.MultiIndex.from_arrays(
-                [
-                    ['Holden', 'Holden', 'Holden', 'Ford', 'Ford', 'Ford'],
-                    ['speed', 'mech power', 'torque', 'rail pressure', 'fuel flow rate' ,'fluid power'],
-                    ['rpm', 'kW', 'N m', 'bar', 'l/min', 'kW'],
-                ],
-                names = ['Car type', 'metric', 'unit']
-            )
-            df.index = pd.MultiIndex.from_arrays(
-                [
-                    [1, 12, 32, 48],
-                    ['Tim', 'Tim', 'Jane', 'Steve'],
-                ],
-                names = ['Measurement number', 'Measurer']
-
-            )
-
-
-            expected = df.copy()
-
-            # we expect the result to come back with pint names, not input
-            # names
-            def get_pint_value(in_str):
-                return str(ureg.Quantity(1, in_str).units)
-
-            units_level = [
-                i for i, name in enumerate(df.columns.names) if name == 'unit'
-            ][0]
-
-            expected.columns = df.columns.set_levels(
-                df.columns.levels[units_level].map(get_pint_value),
-                level='unit'
-            )
-
-
-            result = df.pint.quantify(ureg, level=-1).pint.dequantify()
-
-            pd.testing.assert_frame_equal(result, expected)
-
-
-    class TestSeriesAccessors(object):
-        @pytest.mark.parametrize('attr', [
-            'debug_used',
-            'default_format',
-            'dimensionality',
-            'dimensionless',
-            'force_ndarray',
-            'shape',
-            'u',
-            'unitless',
-            'units',
-        ])
-        def test_series_scalar_property_accessors(self, data, attr):
-            s = pd.Series(data)
-            assert getattr(s.pint, attr) == getattr(data._data,attr)
-
-        @pytest.mark.parametrize('attr', [
-            'm',
-            'magnitude',
-            #'imag', # failing, not sure why
-            #'real', # failing, not sure why
-        ])
-        def test_series_property_accessors(self, data, attr):
-            s = pd.Series(data)
-            assert all(getattr(s.pint, attr) == pd.Series(getattr(data._data,attr)))
-
-        @pytest.mark.parametrize('attr_args', [
-            ('check', ({"[length]": 1})),
-            ('compatible_units', ()),
-            # ('format_babel', ()), Needs babel installed?
-            # ('plus_minus', ()), Needs uncertanties
-            ('to_tuple', ()),
-            ('tolist', ())
-        ])
-        def test_series_scalar_method_accessors(self, data, attr_args):
-            attr = attr_args[0]
-            args = attr_args[1]
-            s = pd.Series(data)
-            assert getattr(s.pint, attr)(*args) == getattr(data._data, attr)(*args)
-
-        @pytest.mark.parametrize('attr_args', [
-            ('ito', ("g",)),
-            ('ito_base_units', ()),
-            ('ito_reduced_units', ()),
-            ('ito_root_units', ()),
-            ('put', (1, get_tdata()[0]))
-        ])
-        def test_series_inplace_method_accessors(self, data, attr_args):
-            attr = attr_args[0]
-            args = attr_args[1]
-            s = pd.Series(deepcopy(data))
-            getattr(s.pint, attr)(*args)
-            getattr(data._data, attr)(*args)
-            assert all(s.values == data)
-
-        @pytest.mark.parametrize('attr_args', [
-            ('clip', (get_tdata()[10], get_tdata()[20])),
-            ('from_tuple', (get_tdata().data.to_tuple(),)),
-            ('m_as', ("g",)),
-            ('searchsorted', (get_tdata()[10],)),
-            ('to', ("g")),
-            ('to_base_units', ()),
-            ('to_compact', ()),
-            ('to_reduced_units', ()),
-            ('to_root_units', ()),
-            # ('to_timedelta', ()),
-        ])
-        def test_series_method_accessors(self, data, attr_args):
-            attr=attr_args[0]
-            args=attr_args[1]
-            s = pd.Series(data)
-            assert all(getattr(s.pint, attr)(*args) == getattr(data._data,attr)(*args))
-
-
-    arithmetic_ops = [
-        operator.add,
-        operator.sub,
-        operator.mul,
-        operator.truediv,
-        operator.floordiv,
-        operator.pow,
-    ]
-
-    comparative_ops = [
-        operator.eq,
-        operator.le,
-        operator.lt,
-        operator.ge,
-        operator.gt,
-    ]
-
-
-    class TestPintArrayQuantity(QuantityTestCase):
-        FORCE_NDARRAY = True
-
-        def test_pintarray_creation(self):
-            x = self.Q_([1, 2, 3],"m")
-            ys = [
-                PintArray(x),
-                PintArray._from_sequence([item for item in x])
-            ]
-            for y in ys:
-                self.assertQuantityAlmostEqual(x,y.data)
-
-
-        @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
-        @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-        def test_pintarray_operations(self):
-            # Perform operations with Quantities and PintArrays
-            # The resulting Quantity and PintArray.Data should be the same
-            # a op b == c
-            # warnings ignored here as it these tests are to ensure
-            # pint array behaviour is the same as quantity
-            def test_op(a_pint, a_pint_array, b_, coerce=True):
-                try:
-                    result_pint = op(a_pint, b_)
-                    if coerce:
-                        # a PintArray is returned from arithmetics, so need the data
-                        c_pint_array = op(a_pint_array, b_).data
-                    else:
-                        # a boolean array is returned from comparatives
-                        c_pint_array = op(a_pint_array, b_)
-
-                    self.assertQuantityAlmostEqual(result_pint, c_pint_array)
-
-                except Exception as caught_exception:
-                    self.assertRaises(type(caught_exception), op, a_pint_array, b_)
-
-
-            a_pints = [
-                self.Q_([3, 4], "m"),
-                self.Q_([3, 4], ""),
-            ]
-
-            a_pint_arrays = [PintArray(q) for q in a_pints]
-
-            bs = [
-                2,
-                self.Q_(3, "m"),
-                [1., 3.],
-                [3.3, 4.4],
-                self.Q_([6, 6], "m"),
-                self.Q_([7., np.nan]),
-            ]
-
-            for a_pint, a_pint_array in zip(a_pints, a_pint_arrays):
-                for b in bs:
-                    for op in arithmetic_ops:
-                        test_op(a_pint, a_pint_array, b)
-                    for op in comparative_ops:
-                        test_op(a_pint, a_pint_array, b, coerce=False)
-
-        def test_mismatched_dimensions(self):
-            x_and_ys=[
-                (PintArray(self.Q_([5], "m")), [1, 1]),
-                (PintArray(self.Q_([5, 5, 5], "m")), [1, 1]),
-                (PintArray(self.Q_([5, 5], "m")), [1]),
-            ]
-            for x, y in x_and_ys:
-                for op in comparative_ops + arithmetic_ops:
-                    self.assertRaises(ValueError, op, x, y)
+                    # a boolean array is returned from comparatives
+                    c_pint_array = op(a_pint_array, b_)
+
+                self.assertQuantityAlmostEqual(result_pint, c_pint_array)
+
+            except Exception as caught_exception:
+                self.assertRaises(type(caught_exception), op, a_pint_array, b_)
+
+
+        a_pints = [
+            self.Q_([3, 4], "m"),
+            self.Q_([3, 4], ""),
+        ]
+
+        a_pint_arrays = [PintArray(q) for q in a_pints]
+
+        bs = [
+            2,
+            self.Q_(3, "m"),
+            [1., 3.],
+            [3.3, 4.4],
+            self.Q_([6, 6], "m"),
+            self.Q_([7., np.nan]),
+        ]
+
+        for a_pint, a_pint_array in zip(a_pints, a_pint_arrays):
+            for b in bs:
+                for op in arithmetic_ops:
+                    test_op(a_pint, a_pint_array, b)
+                for op in comparative_ops:
+                    test_op(a_pint, a_pint_array, b, coerce=False)
+
+    def test_mismatched_dimensions(self):
+        x_and_ys=[
+            (PintArray(self.Q_([5], "m")), [1, 1]),
+            (PintArray(self.Q_([5, 5, 5], "m")), [1, 1]),
+            (PintArray(self.Q_([5, 5], "m")), [1]),
+        ]
+        for x, y in x_and_ys:
+            for op in comparative_ops + arithmetic_ops:
+                self.assertRaises(ValueError, op, x, y)

--- a/pint/testsuite/test_pandas_interface.py
+++ b/pint/testsuite/test_pandas_interface.py
@@ -1,12 +1,25 @@
 # -*- coding: utf-8 -*-
 
 # - pandas test resources https://github.com/pandas-dev/pandas/blob/master/pandas/tests/extension/base/__init__.py
+from os.path import join, dirname
+from copy import deepcopy
+import operator
+import warnings
 
-from pint.compat import HAS_PROPER_PANDAS, HAS_PYTEST
+from pandas.core import ops
+from pandas.compat import PY3
+from pandas.tests.extension import base
+import pint
+from pint.pandas_interface import PintArray
 
-# I can't see how else to do this without this massive if clause...
-if not (HAS_PYTEST and HAS_PROPER_PANDAS):
-    from pint.testsuite import BaseTestCase
+from pint.compat import np, pd, pytest
+from pint.errors import DimensionalityError
+from pint.testsuite import BaseTestCase, QuantityTestCase, helpers
+
+if pd is not None:
+    import pint.pandas_interface as ppi
+
+if not (pytest is not None and pd is not None):
     class TestPandasException(BaseTestCase):
         def test_pandas_exception(self):
             expected_error_msg = (
@@ -29,30 +42,6 @@ if not (HAS_PYTEST and HAS_PROPER_PANDAS):
 
 
 else:
-    import sys
-    from os.path import join, dirname
-
-
-    import numpy as np
-    import pytest
-    import operator
-    import warnings
-
-    import pint
-    import pint.pandas_interface as ppi
-    from pint.testsuite import helpers
-
-    import pandas as pd
-    from pandas.compat import PY3
-    from pandas.tests.extension import base
-    from pandas.core import ops
-
-
-    from pint.testsuite.test_quantity import QuantityTestCase
-    from pint.errors import DimensionalityError
-    from pint.pandas_interface import PintArray
-
-
     ureg = pint.UnitRegistry()
 
 
@@ -538,7 +527,6 @@ else:
         def test_series_inplace_method_accessors(self, data, attr_args):
             attr = attr_args[0]
             args = attr_args[1]
-            from copy import deepcopy
             s = pd.Series(deepcopy(data))
             getattr(s.pint, attr)(*args)
             getattr(data._data, attr)(*args)

--- a/pint/testsuite/test_pandas_interface.py
+++ b/pint/testsuite/test_pandas_interface.py
@@ -155,30 +155,37 @@ if pytest is not None:
 # =================================================================
 
 
+@helpers.requires_pandas()
 class TestCasting(base.BaseCastingTests):
     pass
 
 
+@helpers.requires_pandas()
 class TestConstructors(base.BaseConstructorsTests):
     pass
 
 
+@helpers.requires_pandas()
 class TestDtype(base.BaseDtypeTests):
     pass
 
 
+@helpers.requires_pandas()
 class TestGetitem(base.BaseGetitemTests):
     pass
 
 
+@helpers.requires_pandas()
 class TestGroupby(base.BaseGroupbyTests):
     pass
 
 
+@helpers.requires_pandas()
 class TestInterface(base.BaseInterfaceTests):
     pass
 
 
+@helpers.requires_pandas()
 class TestMethods(base.BaseMethodsTests):
     @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
     # See test_setitem_mask_broadcast note
@@ -210,6 +217,7 @@ class TestMethods(base.BaseMethodsTests):
         assert result[0] == duplicated[0]
 
 
+@helpers.requires_pandas()
 class TestArithmeticOps(base.BaseArithmeticOpsTests):
     def check_opname(self, s, op_name, other, exc=None):
         op = self.get_op_from_name(op_name)
@@ -304,7 +312,7 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
             opa(np.arange(len(s)).reshape(-1, len(s)))
 
 
-
+@helpers.requires_pandas()
 class TestComparisonOps(base.BaseComparisonOpsTests):
     def _compare_other(self, s, data, op_name, other):
         op = self.get_op_from_name(op_name)
@@ -328,19 +336,22 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
         self._compare_other(s, data, op_name, other)
 
 
-
+@helpers.requires_pandas()
 class TestOpsUtil(base.BaseOpsUtil):
     pass
 
 
+@helpers.requires_pandas()
 class TestMissing(base.BaseMissingTests):
     pass
 
 
+@helpers.requires_pandas()
 class TestReshaping(base.BaseReshapingTests):
     pass
 
 
+@helpers.requires_pandas()
 class TestSetitem(base.BaseSetitemTests):
     @pytest.mark.parametrize('setter', ['loc', None])
     @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
@@ -365,7 +376,7 @@ class TestSetitem(base.BaseSetitemTests):
 
 # would be ideal to just test all of this by running the example notebook
 # but this isn't a discussion we've had yet
-
+@helpers.requires_pandas()
 class TestUserInterface(object):
     def test_get_underlying_data(self, data):
         ser = pd.Series(data)
@@ -428,6 +439,7 @@ class TestUserInterface(object):
         df_.pint.to_base_units().pint.dequantify()
 
 
+@helpers.requires_pandas()
 class TestDataFrameAccessor(object):
     def test_index_maintained(self):
         test_csv = join(
@@ -476,6 +488,7 @@ class TestDataFrameAccessor(object):
         pd.testing.assert_frame_equal(result, expected)
 
 
+@helpers.requires_pandas()
 class TestSeriesAccessors(object):
     @pytest.mark.parametrize('attr', [
         'debug_used',
@@ -568,6 +581,7 @@ comparative_ops = [
 ]
 
 
+@helpers.requires_pandas()
 class TestPintArrayQuantity(QuantityTestCase):
     FORCE_NDARRAY = True
 

--- a/pint/testsuite/test_pandas_interface.py
+++ b/pint/testsuite/test_pandas_interface.py
@@ -8,7 +8,6 @@ import warnings
 
 from pandas.core import ops
 from pandas.compat import PY3
-from pandas.tests.extension import base
 import pint
 from pint.pandas_interface import PintArray
 
@@ -16,35 +15,15 @@ from pint.compat import np, pd, pytest
 from pint.errors import DimensionalityError
 from pint.testsuite import BaseTestCase, QuantityTestCase, helpers
 
-if pd is not None:
+if (pytest is None) or (pd is None):
+    # not a great solution but not sure what is...
+    from unittest.mock import MagicMock
+    base = MagicMock()
+    pytest = MagicMock()
+    get_tdata = MagicMock()
+else:
     import pint.pandas_interface as ppi
-
-
-UREG = pint.UnitRegistry()
-
-
-@helpers.requires_not_pandas()
-class TestPandasException(BaseTestCase):
-    def test_pandas_exception(self):
-        expected_error_msg = (
-            "The installed version of Pandas is not compatible with Pint, please "
-            "check the docs."
-        )
-        with self.assertRaises(ImportError) as cm:
-            import pint.pandas_interface
-
-        self.assertEqual(str(cm.exception), expected_error_msg)
-
-# if not (HAS_PYTEST and HAS_PROPER_PANDAS):
-#     msg_end = "the correct version of Pandas and pytest installed"
-# elif not HAS_PROPER_PANDAS:
-#     msg_end = "the latest version of Pandas installed"
-# elif not HAS_PYTEST:
-#     msg_end = "pytest installed"
-
-# print("Skipping all Pandas tests except exception raising as we don't have {}".format(msg_end))
-
-if pytest is not None:
+    from pandas.tests.extension import base
     @pytest.fixture
     def dtype():
         return ppi.PintType()
@@ -155,36 +134,59 @@ if pytest is not None:
 # =================================================================
 
 
+UREG = pint.UnitRegistry()
+
+
+@helpers.requires_not_pandas()
+class TestPandasException(BaseTestCase):
+    def test_pandas_exception(self):
+        expected_error_msg = (
+            "The installed version of Pandas is not compatible with Pint, please "
+            "check the docs."
+        )
+        with self.assertRaises(ImportError) as cm:
+            import pint.pandas_interface
+
+        self.assertEqual(str(cm.exception), expected_error_msg)
+
+
+@helpers.requires_pytest()
 @helpers.requires_pandas()
 class TestCasting(base.BaseCastingTests):
     pass
 
 
+@helpers.requires_pytest()
 @helpers.requires_pandas()
 class TestConstructors(base.BaseConstructorsTests):
     pass
 
 
+@helpers.requires_pytest()
 @helpers.requires_pandas()
 class TestDtype(base.BaseDtypeTests):
     pass
 
 
+@helpers.requires_pytest()
 @helpers.requires_pandas()
 class TestGetitem(base.BaseGetitemTests):
     pass
 
 
+@helpers.requires_pytest()
 @helpers.requires_pandas()
 class TestGroupby(base.BaseGroupbyTests):
     pass
 
 
+@helpers.requires_pytest()
 @helpers.requires_pandas()
 class TestInterface(base.BaseInterfaceTests):
     pass
 
 
+@helpers.requires_pytest()
 @helpers.requires_pandas()
 class TestMethods(base.BaseMethodsTests):
     @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
@@ -217,6 +219,7 @@ class TestMethods(base.BaseMethodsTests):
         assert result[0] == duplicated[0]
 
 
+@helpers.requires_pytest()
 @helpers.requires_pandas()
 class TestArithmeticOps(base.BaseArithmeticOpsTests):
     def check_opname(self, s, op_name, other, exc=None):
@@ -312,6 +315,7 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
             opa(np.arange(len(s)).reshape(-1, len(s)))
 
 
+@helpers.requires_pytest()
 @helpers.requires_pandas()
 class TestComparisonOps(base.BaseComparisonOpsTests):
     def _compare_other(self, s, data, op_name, other):
@@ -336,21 +340,25 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
         self._compare_other(s, data, op_name, other)
 
 
+@helpers.requires_pytest()
 @helpers.requires_pandas()
 class TestOpsUtil(base.BaseOpsUtil):
     pass
 
 
+@helpers.requires_pytest()
 @helpers.requires_pandas()
 class TestMissing(base.BaseMissingTests):
     pass
 
 
+@helpers.requires_pytest()
 @helpers.requires_pandas()
 class TestReshaping(base.BaseReshapingTests):
     pass
 
 
+@helpers.requires_pytest()
 @helpers.requires_pandas()
 class TestSetitem(base.BaseSetitemTests):
     @pytest.mark.parametrize('setter', ['loc', None])
@@ -376,6 +384,7 @@ class TestSetitem(base.BaseSetitemTests):
 
 # would be ideal to just test all of this by running the example notebook
 # but this isn't a discussion we've had yet
+@helpers.requires_pytest()
 @helpers.requires_pandas()
 class TestUserInterface(object):
     def test_get_underlying_data(self, data):
@@ -439,6 +448,7 @@ class TestUserInterface(object):
         df_.pint.to_base_units().pint.dequantify()
 
 
+@helpers.requires_pytest()
 @helpers.requires_pandas()
 class TestDataFrameAccessor(object):
     def test_index_maintained(self):
@@ -488,6 +498,7 @@ class TestDataFrameAccessor(object):
         pd.testing.assert_frame_equal(result, expected)
 
 
+@helpers.requires_pytest()
 @helpers.requires_pandas()
 class TestSeriesAccessors(object):
     @pytest.mark.parametrize('attr', [
@@ -581,6 +592,7 @@ comparative_ops = [
 ]
 
 
+@helpers.requires_pytest()
 @helpers.requires_pandas()
 class TestPintArrayQuantity(QuantityTestCase):
     FORCE_NDARRAY = True

--- a/pint/testsuite/test_pandas_interface.py
+++ b/pint/testsuite/test_pandas_interface.py
@@ -61,9 +61,13 @@ else:
         return ppi.PintType()
 
 
+    def get_tdata():
+        return ppi.PintArray(np.arange(start=1., stop=101.) * ureg.kilogram)
+
+
     @pytest.fixture
     def data():
-        return ppi.PintArray(np.arange(start=1., stop=101.) * ureg.kilogram)
+        return get_tdata()
 
 
     @pytest.fixture
@@ -529,7 +533,7 @@ else:
             ('ito_base_units', ()),
             ('ito_reduced_units', ()),
             ('ito_root_units', ()),
-            ('put', (1, data()[0]))
+            ('put', (1, get_tdata()[0]))
         ])
         def test_series_inplace_method_accessors(self, data, attr_args):
             attr = attr_args[0]
@@ -541,10 +545,10 @@ else:
             assert all(s.values == data)
 
         @pytest.mark.parametrize('attr_args', [
-            ('clip', (data()[10], data()[20])),
-            ('from_tuple', (data().data.to_tuple(),)),
+            ('clip', (get_tdata()[10], get_tdata()[20])),
+            ('from_tuple', (get_tdata().data.to_tuple(),)),
             ('m_as', ("g",)),
-            ('searchsorted', (data()[10],)),
+            ('searchsorted', (get_tdata()[10],)),
             ('to', ("g")),
             ('to_base_units', ()),
             ('to_compact', ()),

--- a/pint/testsuite/test_pandas_interface.py
+++ b/pint/testsuite/test_pandas_interface.py
@@ -5,6 +5,7 @@ from os.path import join, dirname
 from copy import deepcopy
 import operator
 import warnings
+import unittest
 
 import pint
 
@@ -13,11 +14,6 @@ from pint.errors import DimensionalityError
 from pint.testsuite import BaseTestCase, QuantityTestCase, helpers
 
 if (pytest is None) or (pd is None):
-    solution_msg = (
-        'Run the tests with \n'
-        'python -bb -m coverage run -p --source=pint --omit="*test*","*compat*","*pandas*" setup.py test\n'
-        'to avoid the Pandas tests'
-    )
     if (pytest is None) and (pd is None):
         missing_msg = (
             "pytest and the right pandas version are not available, check the docs"
@@ -26,7 +22,8 @@ if (pytest is None) or (pd is None):
         missing_msg = "pytest is not available"
     elif pd is None:
         missing_msg = "the right pandas version is not available, check the docs"
-    raise ValueError("{}\n{}".format(missing_msg, solution_msg))
+
+    raise unittest.SkipTest(missing_msg)
 
 import pint.pandas_interface as ppi
 from pint.pandas_interface import PintArray

--- a/pint/testsuite/test_pandas_interface.py
+++ b/pint/testsuite/test_pandas_interface.py
@@ -8,15 +8,20 @@ import warnings
 
 import pint
 
-from pint.compat import np, pd, pytest
+from pint.compat import np, pd, pytest, PYTHON3
 from pint.errors import DimensionalityError
 from pint.testsuite import BaseTestCase, QuantityTestCase, helpers
 
 if (pytest is None) or (pd is None):
     # not a great solution but not sure what is...
-    from unittest.mock import MagicMock
+    if PYTHON3:
+        from unittest.mock import MagicMock
+    else:
+        from mock import MagicMock
+
     base = MagicMock()
     pytest = MagicMock()
+    pd = MagicMock()
     get_tdata = MagicMock()
 else:
     import pint.pandas_interface as ppi


### PR DESCRIPTION
An attempt to clean the pandas tests up a bit. @hgrecco I'm still a bit unsure whether to use `HAS_PANDAS` or set `pd = None` if there's no Pandas available. It's not that clear which convention to use where and it seems like `pd = None` implies there is no pandas available (like `np = None` implies no numpy available).