### PR TITLE
Add hint to use the pandas interface

### DIFF
--- a/docs/pandas.rst
+++ b/docs/pandas.rst
@@ -5,7 +5,9 @@ Pandas support
 
 It is convenient to use the `Pandas package`_ when dealing with numerical data, so Pint provides `PintArray`. A `PintArray` is a `Pandas Extension Array`_, which allows Pandas to recognise the Quantity and store it in Pandas DataFrames and Series.
 
-For this to work, we rely on `Pandas Extension Types`_ which are still experimental. As a result, we are currently pinned to a specific commit, with version id ``0.24.0.dev0+625.gbdb7a16``, of Pandas.
+For this to work, we rely on `Pandas Extension Types`_ which are still experimental. As a result, we are currently pinned to a specific commit, with version id ``0.24.0.dev0+625.gbdb7a16``, of Pandas. You can install this version via pip:
+
+``pip install git+git://github.com/pandas-dev/pandas.git@bdb7a1603f1e0948ca0cab011987f616e7296167``
 
 
 Basic example


### PR DESCRIPTION
I spent the better part of the evening trying to track down the specific commit referenced by ``0.24.0.dev0+625.gbdb7a16``

Thought I might save someone else the trouble if the docs mentioned the commit hash or how to install the pinned version of pandas via pip.