### PR TITLE
collections.MutableMapping will be removed in Python 3.8

### DIFF
--- a/pint/compat/chainmap.py
+++ b/pint/compat/chainmap.py
@@ -13,7 +13,11 @@ from __future__ import division, unicode_literals, print_function, absolute_impo
 
 import sys
 
-from collections import MutableMapping
+if sys.version_info < (3, 3):
+    from collections import MutableMapping
+else:
+    from collections.abc import MutableMapping
+
 if sys.version_info < (3, 0):
     from thread import get_ident
 else:


### PR DESCRIPTION
Fixes warnings emitted in Python 3.7 of the form:

```
/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/pint/compat/chainmap.py:16
  /home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/pint/compat/chainmap.py:16: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import MutableMapping
```