### PR TITLE
Fixed DeprecationWarning in Python 3.7

### DIFF
--- a/pint/util.py
+++ b/pint/util.py
@@ -18,7 +18,7 @@ import re
 import operator
 from numbers import Number
 from fractions import Fraction
-from collections import Mapping
+from collections.abc import Mapping
 from logging import NullHandler
 
 import logging

--- a/pint/util.py
+++ b/pint/util.py
@@ -18,7 +18,12 @@ import re
 import operator
 from numbers import Number
 from fractions import Fraction
-from collections.abc import Mapping
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
+
 from logging import NullHandler
 
 import logging


### PR DESCRIPTION
pint/util.py:21: DeprecationWarning:
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is
deprecated, and in 3.8 it will stop working