### PR TITLE
add the unit katal

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -76,6 +76,10 @@ hectare = 100 * are = ha
 [concentration] = [substance] / [volume]
 molar = mol / (1e-3 * m ** 3) = M
 
+# Activity
+[activity] = [substance] / [time]
+katal = mole / second = kat
+
 # EM
 esu = 1 * erg**0.5 * centimeter**0.5 = statcoulombs = statC = franklin = Fr
 esu_per_second = 1 * esu / second = statampere


### PR DESCRIPTION
katal is the official SI unit for catalytic activity. This adds this unit, its abbreviation (kat), and the dimension name "activity".