### PR TITLE
Fix import on Python 2.7

### DIFF
--- a/pint/matplotlib.py
+++ b/pint/matplotlib.py
@@ -9,6 +9,8 @@
     :copyright: 2017 by Pint Authors, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
+from __future__ import absolute_import
+
 import matplotlib.units
 
 


### PR DESCRIPTION
Need to enable absolute imports so that when we do `import
matplotlib.units`, it doesn't look at the current module (`matplotlib`)
first, since it's ours.