### PR TITLE
Add quantity formatting with ndarray

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -292,6 +292,17 @@ Pint's physical quantities can be easily printed:
    >>> print('The magnitude is {0.magnitude} with units {0.units}'.format(accel))
    The magnitude is 1.3 with units meter / second ** 2
 
+Pint supports float formatting for numpy arrays as well:
+
+.. doctest::
+
+   >>> accel = np.array([-1.1, 1e-6, 1.2505, 1.3]) * ureg['meter/second**2']
+   >>> # float formatting numpy arrays
+   >>> print('The array is {:.2f}'.format(accel))
+   The array is [-1.10 0.00 1.25 1.30] meter / second ** 2
+   >>> # scientific form formatting with unit pretty printing
+   >>> print('The array is {:+.2E~P}'.format(accel))
+   The array is [-1.10E+00 +1.00E-06 +1.25E+00 +1.30E+00] m/s²
 
 But Pint also extends the standard formatting capabilities for unicode and
 LaTeX representations:

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -9,6 +9,7 @@
 
 from __future__ import division, unicode_literals, print_function, absolute_import
 
+import contextlib
 import copy
 import datetime
 import math
@@ -75,6 +76,21 @@ def check_implemented(f):
         result = f(self, *args, **kwargs)
         return result
     return wrapped
+
+
+@contextlib.contextmanager
+def printoptions(*args, **kwargs):
+    """
+    Numpy printoptions context manager released with version 1.15.0
+    https://docs.scipy.org/doc/numpy/reference/generated/numpy.printoptions.html
+    """
+
+    opts = np.get_printoptions()
+    try:
+        np.set_printoptions(*args, **kwargs)
+        yield np.get_printoptions()
+    finally:
+        np.set_printoptions(**opts)
 
 
 @fix_str_conversions
@@ -215,7 +231,9 @@ class _Quantity(PrettyIPython, SharedRegistryObject):
 
                 mstr = parts[0]
             else:
-                mstr = format(obj.magnitude, mspec).replace('\n', '')
+                formatter = "{{:{}}}".format(mspec)
+                with printoptions(formatter={"float_kind": formatter.format}):
+                    mstr = format(obj.magnitude).replace('\n', '')
         else:
             mstr = format(obj.magnitude, mspec).replace('\n', '')
 

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -129,6 +129,19 @@ class TestQuantity(QuantityTestCase):
         x = self.Q_(3, UnitsContainer(second=-1))
         self.assertEqual('{0}'.format(x), '3 / second')
 
+    @helpers.requires_numpy()
+    def test_quantity_array_format(self):
+        x = self.Q_(np.array([1e-16, 1.0000001, 10000000.0, 1e12, np.nan, np.inf]), "kg * m ** 2")
+        for spec, result in (('{0}',  str(x)),
+                             ('{0.magnitude}', str(x.magnitude)),
+                             ('{0:e}', "[1.000000e-16 1.000000e+00 1.000000e+07 1.000000e+12 nan inf] kilogram * meter ** 2"),
+                             ('{0:E}', "[1.000000E-16 1.000000E+00 1.000000E+07 1.000000E+12 NAN INF] kilogram * meter ** 2"),
+                             ('{0:.2f}', "[0.00 1.00 10000000.00 1000000000000.00 nan inf] kilogram * meter ** 2"),
+                             ('{0:.2f~P}', "[0.00 1.00 10000000.00 1000000000000.00 nan inf] kg·m²"),
+                             ('{0:g~P}', "[1e-16 1 1e+07 1e+12 nan inf] kg·m²"),
+                             ):
+            self.assertEqual(spec.format(x), result)
+
     def test_format_compact(self):
         q1 = (200e-9 * self.ureg.s).to_compact()
         q1b = self.Q_(200., 'nanosecond')


### PR DESCRIPTION
This allow custom float formatting in quantity with ndarray.

Fix #559 

I had to copy [numpy.printoption](https://docs.scipy.org/doc/numpy/reference/generated/numpy.printoptions.html) implementation since it was introduced in numpy v1.15.0.