### PR TITLE
Default group should only have orphan units

### DIFF
--- a/pint/registry.py
+++ b/pint/registry.py
@@ -1293,12 +1293,27 @@ class SystemRegistry(BaseRegistry):
         self._default_system = system
 
     def _after_init(self):
+        """After init function
+
+        Create default group.
+        Add all orphan units to it.
+        Set default system.
+        """
         super(SystemRegistry, self)._after_init()
 
-        #: Copy units in root group to the default group
+        #: Copy units not defined in any group to the default group
         if 'group' in self._defaults:
             grp = self.get_group(self._defaults['group'], True)
-            grp.add_units(*self.get_group('root', False).non_inherited_unit_names)
+            group_units = frozenset(
+                [
+                    member
+                    for group in self._groups.values()
+                    if group.name != "root"
+                    for member in group.members
+                ]
+            )
+            all_units = self.get_group("root", False).members
+            grp.add_units(*(all_units - group_units))
 
         #: System name to be used by default.
         self._default_system = self._default_system or self._defaults.get('system', None)


### PR DESCRIPTION
As discussed here #766

Previously, all units from root group was added to default group (international group in default definition file)

This PR change that to : 
*  Only units that are not defined in any other group are added to the default group.

This will prevent unintended group nesting to default group and diferentiate default group from root group.

Closes #766