### PR TITLE
formatting: revert unwanted removal of positional

### DIFF
--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -149,7 +149,8 @@ def formatter(items, as_ratio=True, single_denominator=False,
             for _babel_length in [babel_length] + other_lengths:
                 pat = unit_patterns.get(_key, {}).get(_babel_length, {}).get(plural)
                 if pat is not None:
-                    key = pat.replace('{}', '').strip()
+                    # Don't remove this positional! This is the format used in Babel
+                    key = pat.replace('{0}', '').strip()
                     break
             division_fmt = compound_unit_patterns.get("per", {}).get(babel_length, division_fmt)
             power_fmt = '{}{}'


### PR DESCRIPTION
While this was a nice change in Python, babel locale data are still using positional formatting.

This should fix the test suite for us but it's a mystery the build is passing on the master branch.

This change was introduced in commit 546ddaae991fcae400db22f87e82fffdaf5b2316.

Close #663 