### PR TITLE
Fix instantiation of errors.DefinitionSyntaxError in context.py

### DIFF
--- a/pint/context.py
+++ b/pint/context.py
@@ -125,7 +125,7 @@ class Context(object):
                 defaults = dict((str(k).strip(), to_num(v))
                                 for k, v in defaults)
             except (ValueError, TypeError):
-                raise DefinitionSyntaxError("Could not parse Context definition defaults: '%s'", _txt,
+                raise DefinitionSyntaxError("Could not parse Context definition defaults: '%s'" % _txt,
                                             lineno=lineno)
 
             ctx = cls(name, aliases, defaults)


### PR DESCRIPTION
The original message led to the following being displayed:

    pint.errors.DefinitionSyntaxError: While opening units.txt, in line 3:
    Could not parse Context definition defaults: '%s'

instead of the intended:
    
    pint.errors.DefinitionSyntaxError: While opening units.txt, in line 3: 
    Could not parse Context definition defaults: '(factor=xyz)'