### PR TITLE
Added t_force, short_ton_force and long_ton_force

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -132,7 +132,7 @@ force_kilogram = g_0 * kilogram = kgf = kilogram_force = pond
 force_gram = g_0 * gram = gf = gram_force
 force_ounce = g_0 * ounce = ozf = ounce_force
 force_pound = g_0 * lb = lbf = pound_force
-force_ton = 2000 * force_pound = ton_force
+force_metric_ton = g_0 * t = metric_ton_force = force_t = t_force
 poundal = lb * feet / second ** 2 = pdl
 kip = 1000*lbf
 
@@ -405,6 +405,8 @@ stere = meter ** 3
     long_hunderweight = 112 avoirdupois_pound = lg_cwt
     short_ton = 2000 avoirdupois_pound
     long_ton = 2240 avoirdupois_pound
+    force_short_ton = short_ton * g_0 = short_ton_force
+    force_long_ton = long_ton * g_0 = long_ton_force
 @end
 
 @group Troy
@@ -425,11 +427,13 @@ stere = meter ** 3
     quarter = 28 stone
     UK_hundredweight = long_hunderweight = UK_cwt
     UK_ton = long_ton
+    UK_ton_force = force_long_ton
 @end
 
 @group AvoirdupoisUS using Avoirdupois
     US_hundredweight = short_hunderdweight = US_cwt
     US_ton = short_ton = ton
+    US_ton_force = force_short_ton = ton_force = force_ton
 @end
 
 @group Printer


### PR DESCRIPTION
I added the definitions of the different ton force metrics. Added: 

- ``force_metric_ton``, ``metric_ton_force``, ``t_force`` and ``force_t`` in the root system 
- ``force_long_ton`` and ``long_ton_force`` in the Avoir-Dupois group 
- ``force_short_ton`` and ``short_ton_force`` in the Avoir-Dupois group 
- ``UK_ton_force`` and ``US_ton_force`` in AvoirdupoisUK and AvoirdupoisUS

Furthermore, I moved ``force_ton`` and ``ton_force`` to the AvoirdupoisUS. 

This definition is backward compatible (i.e. ``force_ton`` and ``ton_force`` are still the same). 

I'm not entirely sure if I'm working with the systems and groups correctly. I haven't been able to create different implementations of ``ton_force``, depending on what system is used. In my case, the one defined last in the definitions file is used, irrespective of what system is used. 

Please let me know what you think! 