### PR TITLE
Preserve caches across context changes (fixes #795)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@ Other contributors, listed alphabetically, are:
 * Brend Wanders <b.wanders@utwente.nl>
 * choloepus
 * coutinho <coutinho@esrf.fr>
+* Clément Pit-Claudel <clement.pitclaudel@live.com>
 * Daniel Sokolowski <daniel.sokolowski@danols.com>
 * Dave Brooks <dave@bcs.co.nz>
 * David Linke

--- a/pint/context.py
+++ b/pint/context.py
@@ -192,6 +192,8 @@ class Context(object):
         _key = self.__keytransform__(src, dst)
         return self.funcs[_key](registry, value, **self.defaults)
 
+    def __hash__(self):
+        return hash(self.name)
 
 class ContextChain(ChainMap):
     """A specialized ChainMap for contexts that simplifies finding rules
@@ -201,7 +203,7 @@ class ContextChain(ChainMap):
     def __init__(self, *args, **kwargs):
         super(ContextChain, self).__init__(*args, **kwargs)
         self._graph = None
-        self._contexts = []
+        self._contexts = ()
 
     def insert_contexts(self, *contexts):
         """Insert one or more contexts in reversed order the chained map.
@@ -210,7 +212,7 @@ class ContextChain(ChainMap):
         To facilitate the identification of the context with the matching rule,
         the *relation_to_context* dictionary of the context is used.
         """
-        self._contexts.insert(0, contexts)
+        self._contexts = tuple(contexts) + self._contexts
         self.maps = [ctx.relation_to_context for ctx in reversed(contexts)] + self.maps
         self._graph = None
 
@@ -244,3 +246,6 @@ class ContextChain(ChainMap):
         :raises: KeyError if the rule is not found.
         """
         return self[(src, dst)].transform(src, dst, registry, value)
+
+    def __hash__(self):
+        return hash(self._contexts)

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -318,7 +318,7 @@ class BaseRegistry(meta.with_metaclass(_Meta)):
             if self._on_redefinition == 'raise':
                 raise RedefinitionError(key, type(value))
             elif self._on_redefinition == 'warn':
-                logger.warning("Redefining '%s' (%s)", key, type(value))
+                logger.warning("Redefining '%s' (%s)" % (key, type(value)))
 
         unit_dict[key] = value
         if casei_unit_dict is not None:


### PR DESCRIPTION
Things that need to be double-checked:

* With this changed, switching contexts clears the whole cache (until now, only dimensional_equivalents was cleared)
* I'm assuming that the list of context names is enough to characterize a context chain; if not (that is, if context chains or contexts can be mutated without name changes), then this approach is unsound.