### PR TITLE
Fix definition of dimensionless units

### DIFF
--- a/pint/constants_en.txt
+++ b/pint/constants_en.txt
@@ -4,6 +4,8 @@
 # Source: http://physics.nist.gov/cuu/Constants/Table/allascii.txt
 # :copyright: 2013 by Pint Authors, see AUTHORS for more details.
 
+ln10 = 2.302585092994046
+
 speed_of_light = 299792458 * meter / second = c
 standard_gravity = 9.806650 * meter / second ** 2 = g_0 = g_n = gravity
 vacuum_permeability = 4 * pi * 1e-7 * newton / ampere ** 2 = mu_0 = magnetic_constant

--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -19,7 +19,7 @@ micro- = 1e-6  = µ- = u-
 milli- = 1e-3  = m-
 centi- = 1e-2  = c-
 deci- =  1e-1  = d-
-deca- =  1e+1  = da- = deka
+deca- =  1e+1  = da- = deka-
 hecto- = 1e2   = h-
 kilo- =  1e3   = k-
 mega- =  1e6   = M-
@@ -343,8 +343,6 @@ stere = meter ** 3
     cubic_inch = 1 in ** 3 = cu_in
     cubic_foot = 1 ft ** 3 = cu_ft = cubic_feet
     cubic_yard = 1 yd ** 3 = cu_yd
-
-    acre_foot = acre * foot = acre_feet
 @end
 
 @group USCSLengthSurvey
@@ -361,6 +359,8 @@ stere = meter ** 3
     us_statute_mile = 5280 survey_foot
     league = 3 us_statute_mile
     furlong = us_statute_mile / 8
+
+    acre_foot = acre * survey_foot = acre_feet
 @end
 
 @group USCSDryVolume
@@ -369,7 +369,7 @@ stere = meter ** 3
     dry_gallon = 8 dry_pint = dgal = US_dry_gallon
     peck = 16 dry_pint = pk
     bushel = 64 dry_pint = bu
-    dry_barrel = 7065 cubic_inch = US_dry_barrel
+    dry_barrel = 7056 cubic_inch = US_dry_barrel
 @end
 
 @group USCSLiquidVolume
@@ -401,8 +401,8 @@ stere = meter ** 3
     ounce = pound / 16 = oz = avoirdupois_ounce = avdp_ounce
     pound = 453.59237 gram = lb = avoirdupois_pound = avdp_pound
 
-    short_hunderdweight = 100 avoirdupois_pound = ch_cwt
-    long_hunderweight = 112 avoirdupois_pound = lg_cwt
+    short_hundredweight = 100 avoirdupois_pound = ch_cwt
+    long_hundredweight = 112 avoirdupois_pound = lg_cwt
     short_ton = 2000 avoirdupois_pound
     long_ton = 2240 avoirdupois_pound
     force_short_ton = short_ton * g_0 = short_ton_force
@@ -425,13 +425,13 @@ stere = meter ** 3
 @group AvoirdupoisUK using Avoirdupois
     stone = 14 pound
     quarter = 28 stone
-    UK_hundredweight = long_hunderweight = UK_cwt
+    UK_hundredweight = long_hundredweight = UK_cwt
     UK_ton = long_ton
     UK_ton_force = force_long_ton
 @end
 
 @group AvoirdupoisUS using Avoirdupois
-    US_hundredweight = short_hunderdweight = US_cwt
+    US_hundredweight = short_hundredweight = US_cwt
     US_ton = short_ton = ton
     US_ton_force = force_short_ton = ton_force = force_ton
 @end

--- a/pint/definitions.py
+++ b/pint/definitions.py
@@ -123,10 +123,10 @@ class UnitDefinition(Definition):
                 modifiers = {}
 
             converter = ParserHelper.from_string(converter)
-            if all(_is_dim(key) for key in converter.keys()):
-                self.is_base = True
-            elif not any(_is_dim(key) for key in converter.keys()):
+            if not any(_is_dim(key) for key in converter.keys()):
                 self.is_base = False
+            elif all(_is_dim(key) for key in converter.keys()):
+                self.is_base = True
             else:
                 raise ValueError('Cannot mix dimensions and units in the same definition. '
                                  'Base units must be referenced only to dimensions. '

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -171,12 +171,12 @@ class BaseRegistry(meta.with_metaclass(_Meta)):
     def _after_init(self):
         """This should be called after all __init__
         """
+        self.define(UnitDefinition('pi', 'π', (), ScaleConverter(math.pi)))
+
         if self._filename == '':
             self.load_definitions('default_en.txt', True)
         elif self._filename is not None:
             self.load_definitions(self._filename)
-
-        self.define(UnitDefinition('pi', 'π', (), ScaleConverter(math.pi)))
 
         self._build_cache()
         self._initialized = True
@@ -832,9 +832,7 @@ class BaseRegistry(meta.with_metaclass(_Meta)):
         token_type = token[0]
         token_text = token[1]
         if token_type == NAME:
-            if token_text == 'pi':
-                return self.Quantity(math.pi)
-            elif token_text == 'dimensionless':
+            if token_text == 'dimensionless':
                 return 1 * self.dimensionless
             elif token_text in values:
                 return self.Quantity(values[token_text])

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -562,6 +562,8 @@ class TestCompatibleUnits(QuantityTestCase):
     def test_get_base_units(self):
         ureg = UnitRegistry()
         self.assertEqual(ureg.get_base_units(''), (1, ureg.Unit('')))
+        self.assertEqual(ureg.get_base_units('pi'), (math.pi, ureg.Unit('')))
+        self.assertEqual(ureg.get_base_units('ln10'), (math.log(10), ureg.Unit('')))
         self.assertEqual(ureg.get_base_units('meter'), ureg.get_base_units(ParserHelper(meter=1)))
 
     def test_get_compatible_units(self):


### PR DESCRIPTION
There is something strange going on with dimensionless units/numbers:

```
>>> ureg.get_base_units('pi')
(3.141592653589793, <Unit('dimensionless')>)
>>> ureg.get_base_units('fine_structure_constant')
(1.0, <Unit('fine_structure_constant')>)
```

It seems dimensionless units defined in a file are interpreted as base units, while `pi` is hard-coded and interpreted correctly as a number. I think this is because for an empty list both `all()` and `not any()` are true. The fix is just changing the order of the tests, such that when a unit has no dimensions the `not any()` test passes first and the unit is marked as not-base. After the fix:

```
>>> ureg.get_base_units('pi')
(3.141592653589793, <Unit('dimensionless')>)
>>> ureg.get_base_units('fine_structure_constant')
(0.0072973525698, <Unit('dimensionless')>)
```

In addition, the hard-coded definition of `pi` is better done *before* loading the file definitions, I believe, so `pi` can be used in defining base units for `@system`, and also to allow redefining `pi` in a file, if desired. This also required removing the special treatment for `pi` in `_eval_token()`, which I don't think is need anyway.

Finally, I applied some corrections to the default definitions: Added `ln10` = ln(10), just to test the above fix with a number not subject to updates. Fixed the `deka-` prefix. Made the `acre_foot` consisent, I don't think it should use the survey foot for area times the international foot. Fixed the dry barrell, which I see everywhere defined as 7056 in^3, not 7065. Fixed spelling of "hundredweight" (if it was intentional, I still find it weird that the long and short ones are misspelled differently).