### PR TITLE
Update to new SI definition and CODATA 2018

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,6 +19,7 @@ Other contributors, listed alphabetically, are:
 * Felix Hummel <felix@felixhummel.de>
 * Francisco Couzo <franciscouzo@gmail.com>
 * Giel van Schijndel <me@mortis.eu>
+* Ignacio Fdez. Galván <jellby@yahoo.com>
 * James Rowe <jnrowe@gmail.com>
 * Jim Turner <jturner314@gmail.com>
 * Joel B. Mohler <joel@kiwistrawberry.us>

--- a/pint/constants_en.txt
+++ b/pint/constants_en.txt
@@ -57,7 +57,7 @@ atomic_mass_constant = 1.66053906660e-27 kg = m_u                               
 electron_mass = 9.1093837015e-31 kg = m_e = atomic_unit_of_mass = a_u_mass                 # (28)
 proton_mass = 1.67262192369e-27 kg = m_p                                                   # (51)
 neutron_mass = 1.67492749804e-27 kg = m_n                                                  # (95)
-lattice_spacing_of_Si = 1.920155716 m = d_220                                              # (32)
+lattice_spacing_of_Si = 1.920155716e-10 m = d_220                                          # (32)
 K_alpha_Cu_d_220 = 0.80232719                                                              # (22)
 K_alpha_Mo_d_220 = 0.36940604                                                              # (19)
 K_alpha_W_d_220 = 0.108852175                                                              # (98)

--- a/pint/constants_en.txt
+++ b/pint/constants_en.txt
@@ -50,7 +50,7 @@ wien_frequency_displacement_law_constant = wien_u * k / h
 # The choice of measured constants is based on convenience and on available uncertainty.
 # The uncertainty in the last significant digits is given in parentheses as a comment.
 
-newtonian_constant_of_gravitation = 6.67408e-11 m^3/(kg s^2) = = gravitational_constant    # (15)
+newtonian_constant_of_gravitation = 6.67408e-11 m^3/(kg s^2) = _ = gravitational_constant  # (15)
 rydberg_constant = 1.0973731568160e7 * m^-1 = R_∞ = R_inf                                  # (21)
 electron_g_factor = -2.00231930436256 = g_e                                                # (35)
 atomic_mass_constant = 1.66053906660e-27 kg = m_u                                          # (50)

--- a/pint/constants_en.txt
+++ b/pint/constants_en.txt
@@ -1,53 +1,73 @@
 # Default Pint constants definition file
 # Based on the International System of Units
 # Language: english
-# Source: http://physics.nist.gov/cuu/Constants/Table/allascii.txt
-# :copyright: 2013 by Pint Authors, see AUTHORS for more details.
+# Source: https://physics.nist.gov/cuu/Constants/
+#         https://physics.nist.gov/PhysRefData/XrayTrans/Html/search.html
+# :copyright: 2013,2019 by Pint Authors, see AUTHORS for more details.
 
-ln10 = 2.302585092994046
+#### MATHEMATICAL CONSTANTS ####
+# As computed by Maxima with fpprec:50
 
-speed_of_light = 299792458 * meter / second = c
-standard_gravity = 9.806650 * meter / second ** 2 = g_0 = g_n = gravity
-vacuum_permeability = 4 * pi * 1e-7 * newton / ampere ** 2 = mu_0 = magnetic_constant
-vacuum_permittivity = 1 / (mu_0 * c **2 ) = epsilon_0 = electric_constant
-Z_0 = mu_0 * c = impedance_of_free_space = characteristic_impedance_of_vacuum
+#pi    = 3.1415926535897932384626433832795028841971693993751 = π  # pi
+tansec = 4.8481368111333441675396429478852851658848753880815e-6   # tangent of 1 arc-second ~ arc_second/radian
+ln10   = 2.3025850929940456840179914546843642076011014886288      # natural logarithm of 10
+wien_x = 4.9651142317442763036987591313228939440555849867973      # solution to (x-5)*exp(x)+5 = 0 => x = W(5/exp(5))+5
+wien_u = 2.8214393721220788934031913302944851953458817440731      # solution to (u-3)*exp(u)+3 = 0 => u = W(3/exp(3))+3
 
-# 0.000 000 29 e-34
-planck_constant = 6.62606957e-34 J s = h
-hbar = planck_constant / (2 * pi) = ħ
+#### DEFINED EXACT CONSTANTS ####
 
-# 0.000 80 e-11
-newtonian_constant_of_gravitation = 6.67384e-11 m^3 kg^-1 s^-2
+speed_of_light = 299792458 m/s = c = c_0                      # since 1983
+planck_constant = 6.62607015e-34 J s = h                      # since May 2019
+elementary_charge = 1.602176634e-19 C = e                     # since May 2019
+avogadro_number = 6.02214076e23                               # since May 2019
+boltzmann_constant = 1.380649e-23 J K^-1 = k = k_B            # since May 2019
+standard_gravity = 9.80665 m/s^2 = g_0 = g0 = g_n = gravity   # since 1901
+standard_atmosphere = 1.01325e5 Pa = atm = atmosphere         # since 1954
+conventional_josephson_constant = 4.835979e14 Hz / V = K_J90  # since Jan 1990
+conventional_von_klitzing_constant = 2.5812807e4 ohm = R_K90  # since Jan 1990
 
-# 0.000 000 035 e-19
-# elementary_charge = 1.602176565e-19 C = e
+#### DERIVED EXACT CONSTANTS ####
+# Floating-point conversion may introduce inaccuracies
 
-# 0.000 0075
-molar_gas_constant = 8.3144621 J mol^-1 K^-1 = R
+zeta = c / (cm/s) = ζ
+dirac_constant = h / (2 * π) = ħ = hbar = atomic_unit_of_action = a_u_action
+avogadro_constant = avogadro_number * mol^-1 = N_A
+molar_gas_constant = k * N_A = R
+faraday_constant = e * N_A
+conductance_quantum = 2 * e ** 2 / h = G_0
+magnetic_flux_quantum = h / (2 * e) = Φ_0 = Phi_0
+josephson_constant = 2 * e / h = K_J
+von_klitzing_constant = h / e ** 2 = R_K
+stefan_boltzmann_constant = 2 / 15 * π ** 5 * k ** 4 / (h ** 3 * c ** 2) = σ = sigma
+first_radiation_constant = 2 * π * h * c ** 2 = c_1
+second_radiation_constant = h * c / k = c_2
+wien_wavelength_displacement_law_constant = h * c / (k * wien_x)
+wien_frequency_displacement_law_constant = wien_u * k / h
 
-# 0.000 000 0024 e-3
-fine_structure_constant = 7.2973525698e-3
+#### MEASURED CONSTANTS ####
+# Recommended CODATA-2018 values
+# To some extent, what is measured and what is derived is a bit arbitrary.
+# The choice of measured constants is based on convenience and on available uncertainty.
+# The uncertainty in the last significant digits is given in parentheses as a comment.
 
-# 0.000 000 27 e23
-avogadro_number = 6.02214129e23 mol^-1 =N_A
+newtonian_constant_of_gravitation = 6.67408e-11 m^3/(kg s^2) = = gravitational_constant    # (15)
+rydberg_constant = 1.0973731568160e7 * m^-1 = R_∞ = R_inf                                  # (21)
+electron_g_factor = -2.00231930436256 = g_e                                                # (35)
+atomic_mass_constant = 1.66053906660e-27 kg = m_u                                          # (50)
+electron_mass = 9.1093837015e-31 kg = m_e = atomic_unit_of_mass = a_u_mass                 # (28)
+proton_mass = 1.67262192369e-27 kg = m_p                                                   # (51)
+neutron_mass = 1.67492749804e-27 kg = m_n                                                  # (95)
+lattice_spacing_of_Si = 1.920155716 m = d_220                                              # (32)
+K_alpha_Cu_d_220 = 0.80232719                                                              # (22)
+K_alpha_Mo_d_220 = 0.36940604                                                              # (19)
+K_alpha_W_d_220 = 0.108852175                                                              # (98)
 
-# 0.000 0013 e-23
-boltzmann_constant = 1.3806488e-23 J K^-1 = k
+#### DERIVED CONSTANTS ####
 
-# 0.000 021 e-8
-stefan_boltzmann_constant = 5.670373e-8 W m^-2 K^-4 = σ
-
-# 0.000 0053 e10
-wien_frequency_displacement_law_constant = 5.8789254e10 Hz K^-1
-
-# 0.000 055
-rydberg_constant = 10973731.568539 m^-1
-
-# 0.000 000 40 e-31
-electron_mass = 9.10938291e-31 kg = m_e
-
-# 0.000 000 074 e-27
-neutron_mass = 1.674927351e-27 kg = m_n
-
-# 0.000 000 074 e-27
-proton_mass = 1.672621777e-27 kg = m_p
+fine_structure_constant = (2 * h * R_inf / (m_e * c)) ** 0.5 = α = alpha
+vacuum_permeability = 2 * α * h / (e ** 2 * c) = µ_0 = mu_0 = mu0 = magnetic_constant
+vacuum_permittivity = e ** 2 / (2 * α * h * c) = ε_0 = epsilon_0 = eps_0 = eps0 = electric_constant
+impedance_of_free_space = 2 * α * h / e ** 2 = Z_0 = characteristic_impedance_of_vacuum
+coulomb_constant = α * hbar * c / e ** 2 = k_C
+classical_electron_radius = α * hbar / (m_e * c) = r_e
+thomson_cross_section = 8 / 3 * π * r_e ** 2 = σ_e = sigma_e

--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -1,12 +1,15 @@
 # Default Pint units definition file
 # Based on the International System of Units
 # Language: english
-# :copyright: 2013 by Pint Authors, see AUTHORS for more details.
+# :copyright: 2013,2019 by Pint Authors, see AUTHORS for more details.
 
 @defaults
     group = international
     system = mks
 @end
+
+
+#### PREFIXES ####
 
 # decimal prefixes
 yocto- = 1e-24 = y-
@@ -40,89 +43,149 @@ exbi- = 2**60 = Ei-
 zebi- = 2**70 = Zi-
 yobi- = 2**80 = Yi-
 
-# reference
+# extra_prefixes
+semi- = 0.5 = = demi-
+sesqui- = 1.5
+
+
+#### BASE UNITS ####
+
 meter = [length] = m = metre
 second = [time] = s = sec
 ampere = [current] = A = amp
 candela = [luminosity] = cd = candle
 gram = [mass] = g
 mole = [substance] = mol
-kelvin = [temperature]; offset: 0 = K = degK
+kelvin = [temperature]; offset: 0 = K = degK = °K = degree_Kelvin = degreeK  # older names supported for compatibility
 radian = [] = rad
+neper = [] = Np
 bit = []
 count = []
 
+
+#### CONSTANTS ####
+
 @import constants_en.txt
 
-# acceleration
-[acceleration] = [length] / [time] ** 2
+
+#### UNITS ####
+# Common and less common, grouped by quantity.
+# Conversion factors are exact (except when noted),
+# although floating-point conversion may introduce inaccuracies
 
 # Angle
-turn = 2 * pi * radian = revolution = cycle = circle
-degree = pi / 180 * radian = deg = arcdeg = arcdegree = angular_degree
-arcminute = arcdeg / 60 = arcmin = arc_minute = angular_minute
-arcsecond = arcmin / 60 =  arcsec = arc_second = angular_second
+turn = 2 * π * radian = = revolution = cycle = circle
+degree = π / 180 * radian = deg = arcdeg = arcdegree = angular_degree
+arcminute = degree / 60 = arcmin = arc_minute = angular_minute
+arcsecond = arcminute / 60 = arcsec = arc_second = angular_second
+milliarcsecond = 1e-3 * arcsecond = mas
+grade = π / 200 * radian = grad = gon
+mil = π / 32000 * radian
+
+# Solid angle
 steradian = radian ** 2 = sr
+square_degree = (π / 180) ** 2 * sr = sq_deg = sqdeg
+
+# Logarithmic ratio
+bel = 0.5 * ln10 * neper
+
+# Information
+byte = 8 * bit = B = octet
+baud = bit / second = Bd = bps
+
+# Length
+angstrom = 1e-10 * meter = Å = ångström = Å
+micron = micrometer = µ
+fermi = femtometer = fm
+light_year = speed_of_light * julian_year = ly = lightyear
+astronomical_unit = 149597870700 * meter = au  # since Aug 2012
+parsec = 1 / tansec * astronomical_unit = pc
+nautical_mile = 1852 * meter = nmi
+bohr = hbar / (alpha * m_e * c) = a_0 = a0 = bohr_radius = atomic_unit_of_length = a_u_length
+x_unit_Cu = K_alpha_Cu_d_220 * d_220 / 1537.4 = Xu_Cu
+x_unit_Mo = K_alpha_Mo_d_220 * d_220 / 707.831 = Xu_Mo
+angstrom_star = K_alpha_W_d_220 * d_220 / 0.2090100 = Å_star
+planck_length = (hbar * gravitational_constant / c ** 3) ** 0.5
+
+# Mass
+metric_ton = 1e3 * kilogram = t = tonne
+unified_atomic_mass_unit = atomic_mass_constant = u = amu
+dalton = atomic_mass_constant = Da
+grain = 64.79891 * milligram = gr
+gamma_mass = microgram
+carat = 200 * milligram = ct = karat
+planck_mass = (hbar * c / gravitational_constant) ** 0.5
+
+# Time
+minute = 60 * second = min
+hour = 60 * minute = hr
+day = 24 * hour = d
+week = 7 * day
+fortnight = 2 * week
+year = 365.25 * day = a = yr = julian_year
+month = year / 12
+decade = 10 * year
+century = 100 * year = = centuries
+millennium = 1e3 * year = = millennia
+eon = 1e9 * year
+shake = 1e-8 * second
+svedberg = 1e-13 * second
+atomic_unit_of_time = hbar / E_h = a_u_time
+gregorian_year = 365.2425 * day
+sidereal_year = 365.256363004 * day                # approximate, as of J2000 epoch
+tropical_year = 365.242190402 * day                # approximate, as of J2000 epoch
+common_year = 365 * day
+leap_year = 366 * day
+sidereal_day = day / 1.00273790935079524           # approximate
+sidereal_month = 27.32166155 * day                 # approximate
+tropical_month = 27.321582 * day                   # approximate
+synodic_month = 29.530589 * day = = lunar_month    # approximate
+planck_time = (hbar * gravitational_constant / c ** 5) ** 0.5
+
+# Temperature
+degC = kelvin; offset: 273.15 = °C = celsius = degree_Celsius = degreeC
+degR = 5 / 9 * kelvin; offset: 0 = °R = rankine = degree_Rankine = degreeR
+degF = 5 / 9 * kelvin; offset: 233.15 + 200 / 9 = °F = fahrenheit = degree_Fahrenheit = degreeF
+degRe = 4 / 5 * kelvin; offset: 273.15 = °Re = reaumur = degree_Reaumur = degreeRe = degree_Réaumur = réaumur
+atomic_unit_of_temperature = E_h / k = a_u_temp
+planck_temperature = (hbar * c ** 5 / gravitational_constant / k ** 2) ** 0.5
 
 # Area
 [area] = [length] ** 2
-are = 100 * m**2
-barn = 1e-28 * m ** 2 = b
-cmil = 5.067075e-10 * m ** 2 = circular_mils
-darcy = 9.869233e-13 * m ** 2
+are = 100 * meter ** 2
+barn = 1e-28 * meter ** 2 = b
+darcy = centipoise * centimeter ** 2 / (second * atmosphere)
 hectare = 100 * are = ha
 
-# Concentration
-[concentration] = [substance] / [volume]
-molar = mol / (1e-3 * m ** 3) = M
+# Volume
+[volume] = [length] ** 3
+liter = decimeter ** 3 = l = L = litre
+cubic_centimeter = centimeter ** 3 = cc
+lambda = microliter = λ
+stere = meter ** 3
 
-# Activity
-[activity] = [substance] / [time]
-katal = mole / second = kat
+# Frequency
+[frequency] = 1 / [time]
+hertz = 1 / second = Hz
+revolutions_per_minute = revolution / minute = rpm
+counts_per_second = count / second = cps
 
-# EM
-esu = 1 * erg**0.5 * centimeter**0.5 = statcoulombs = statC = franklin = Fr
-esu_per_second = 1 * esu / second = statampere
-ampere_turn = 1 * A
-gilbert = 10 / (4 * pi ) * ampere_turn
-coulomb = ampere * second = C
-volt = joule / coulomb = V
-farad = coulomb / volt = F
-ohm = volt / ampere = Ω
-siemens = ampere / volt = S = mho
-weber = volt * second = Wb
-tesla = weber / meter ** 2 = T
-henry = weber / ampere = H
-elementary_charge = 1.602176487e-19 * coulomb = e
-chemical_faraday = 9.64957e4 * coulomb
-physical_faraday = 9.65219e4 * coulomb
-faraday =  96485.3399 * coulomb = C12_faraday
-gamma = 1e-9 * tesla
-gauss = 1e-4 * tesla
-maxwell = 1e-8 * weber = mx
-oersted = 1000 / (4 * pi) * A / m = Oe
-statfarad = 1.112650e-12 * farad = statF = stF
-stathenry = 8.987554e11 * henry = statH = stH
-statmho = 1.112650e-12 * siemens = statS = stS
-statohm = 8.987554e11 * ohm
-statvolt = 2.997925e2 * volt = statV = stV
-unit_pole = 1.256637e-7 * weber
+# Wavenumber
+[wavenumber] = 1 / [length]
+reciprocal_centimeter = 1 / cm = cm_1 = kayser
 
-# Energy
-[energy] = [force] * [length]
-joule = newton * meter = J
-erg = dyne * centimeter
-btu = 1.05505585262e3 * joule = Btu = BTU = british_thermal_unit
-electron_volt = 1.60217653e-19 * J = eV
-quadrillion_btu = 10**15 * btu = quad
-thm = 100000 * BTU = therm = EC_therm
-calorie = 4.184 * joule = cal = thermochemical_calorie
-international_steam_table_calorie = 4.1868 * joule
-ton_TNT = 4.184e9 * joule = tTNT
-US_therm = 1.054804e8 * joule
-watt_hour = watt * hour = Wh = watthour
-hartree = 4.35974394e-18 * joule = = Eh = E_h = hartree_energy
-toe = 41.868e9 * joule = tonne_of_oil_equivalent
+# Velocity
+[velocity] = [length] / [time] = [speed]
+knot = nautical_mile / hour = kt = knot_international = international_knot
+mile_per_hour = mile / hour = mph = MPH
+kilometer_per_hour = kilometer / hour = kph = KPH
+kilometer_per_second = kilometer / second = kps
+meter_per_second = meter / second = mps
+foot_per_second = foot / second = fps
+
+# Acceleration
+[acceleration] = [velocity] / [time]
+galileo = centimeter / second ** 2 = Gal
 
 # Force
 [force] = [mass] * [acceleration]
@@ -130,158 +193,487 @@ newton = kilogram * meter / second ** 2 = N
 dyne = gram * centimeter / second ** 2 = dyn
 force_kilogram = g_0 * kilogram = kgf = kilogram_force = pond
 force_gram = g_0 * gram = gf = gram_force
-force_ounce = g_0 * ounce = ozf = ounce_force
-force_pound = g_0 * lb = lbf = pound_force
-force_metric_ton = g_0 * t = metric_ton_force = force_t = t_force
-poundal = lb * feet / second ** 2 = pdl
-kip = 1000*lbf
+force_metric_ton = g_0 * metric_ton = tf = metric_ton_force = force_t = t_force
+atomic_unit_of_force = E_h / a_0 = a_u_force
 
-# Frequency
-[frequency] = 1 / [time]
-hertz = 1 / second = Hz = rps
-revolutions_per_minute = revolution / minute = rpm
-counts_per_second = count / second = cps
-
-# Heat
-#RSI = degK * meter ** 2 / watt
-#clo = 0.155 * RSI = clos
-#R_value = foot ** 2 * degF * hour / btu
-
-# Information
-byte = 8 * bit = B = octet
-baud = bit / second = Bd = bps
-
-# Irradiance
-peak_sun_hour = 1000 * watt_hour / meter**2 = PSH
-langley = thermochemical_calorie / centimeter**2 = Langley
-
-# Length
-angstrom = 1e-10 * meter = Å = ångström = Å
-parsec = 3.08568025e16 * meter = pc
-light_year = speed_of_light * julian_year = ly = lightyear
-astronomical_unit = 149597870691 * meter = au
-
-# Mass
-carat = 200 * milligram
-metric_ton = 1000 * kilogram = t = tonne
-atomic_mass_unit = 1.660538782e-27 * kilogram =  u = amu = dalton = Da
-bag = 94 * lb
-
-# Textile
-denier =  gram / (9000 * meter)
-tex = gram / (1000 * meter)
-dtex = decitex
-
-# These are Indirect yarn numbering systems (length/unit mass)
-jute = lb / (14400 * yd) = Tj
-Ne = 1/590.5 / tex
-Nm = 1/1000 / tex
-
-@context textile
-    # Allow switching between Direct count system (i.e. tex) and
-    # Indirect count system (i.e. Ne, Nm)
-    [mass] / [length] <-> [length] / [mass]: 1 / value
-@end
-
-# Photometry
-lumen = candela * steradian = lm
-lux = lumen / meter ** 2 = lx
+# Energy
+[energy] = [force] * [length]
+joule = newton * meter = J
+erg = dyne * centimeter
+watt_hour = watt * hour = Wh = watthour
+electron_volt = e * volt = eV
+rydberg = h * c * R_inf = Ry
+hartree = 2 * rydberg = E_h = Eh = hartree_energy = atomic_unit_of_energy = a_u_energy
+calorie = 4.184 * joule = cal = thermochemical_calorie = cal_th
+international_calorie = 4.1868 * joule = cal_it = international_steam_table_calorie
+fifteen_degree_calorie = 4.1855 * joule = cal_15
+british_thermal_unit = 1055.056 * joule = Btu = BTU = Btu_iso
+international_british_thermal_unit = 1e3 * pound / kilogram * degR / kelvin * international_calorie = Btu_it
+thermochemical_british_thermal_unit = 1e3 * pound / kilogram * degR / kelvin * calorie = Btu_th
+quadrillion_Btu = 1e15 * Btu = quad
+therm = 1e5 * Btu = thm = EC_therm
+US_therm = 1.054804e8 * joule  # approximate, no exact definition
+ton_TNT = 1e9 * calorie = tTNT
+tonne_of_oil_equivalent = 1e10 * international_calorie = toe
+atmosphere_liter = atmosphere * liter = atm_l
 
 # Power
 [power] = [energy] / [time]
-watt = joule / second = W = volt_ampere = VA
-horsepower = 33000 * ft * lbf / min = hp = UK_horsepower = British_horsepower
-boiler_horsepower = 33475 * btu / hour
-metric_horsepower =  75 * force_kilogram * meter / second
-electric_horsepower = 746 * watt
-hydraulic_horsepower = 550 * feet * lbf / second
-refrigeration_ton = 12000 * btu / hour = ton_of_refrigeration
+watt = joule / second = W
+volt_ampere = volt * ampere = VA
+horsepower = 550 * foot * force_pound / second = hp = UK_horsepower = hydraulic_horsepower
+boiler_horsepower = 33475 * Btu / hour                            # unclear which Btu
+metric_horsepower = 75 * force_kilogram * meter / second
+electrical_horsepower = 746 * watt
+refrigeration_ton = 12e3 * Btu / hour = = ton_of_refrigeration  # approximate, no exact definition
+standard_liter_per_minute = atmosphere * liter / minute = slpm = slm
+conventional_watt_90 = K_J90 ** 2 * R_K90 / (K_J ** 2 * R_K) * watt = W_90
+
+# Density (as auxiliary for pressure)
+[density] = [mass] / [volume]
+mercury = 13.5951 * kilogram / liter = Hg = Hg_0C = Hg_32F = conventional_mercury
+water = 1.0 * kilogram / liter = H2O = conventional_water
+mercury_60F = 13.5568 * kilogram / liter = Hg_60F   # approximate
+water_39F = 0.999972 * kilogram / liter = water_4C  # approximate
+water_60F = 0.999001 * kilogram / liter             # approximate
 
 # Pressure
 [pressure] = [force] / [area]
-Hg = gravity * 13.59510 * gram / centimeter ** 3 = mercury = conventional_mercury
-mercury_60F = gravity * 13.5568 * gram / centimeter ** 3
-H2O = gravity * 1000 * kilogram / meter ** 3 = h2o = water = conventional_water
-water_4C = gravity * 999.972 * kilogram / meter ** 3 = water_39F
-water_60F = gravity * 999.001 * kilogram / m ** 3
 pascal = newton / meter ** 2 = Pa
-bar = 100000 * pascal
-atmosphere = 101325 * pascal = atm = standard_atmosphere
-technical_atmosphere = kilogram * gravity / centimeter ** 2 = at
+barye = dyne / centimeter ** 2 = Ba = barie = barad = barrie = baryd
+bar = 1e5 * pascal
+technical_atmosphere = kilogram * g_0 / centimeter ** 2 = at
 torr = atm / 760
-pound_force_per_square_inch = pound * gravity / inch ** 2 = psi
+pound_force_per_square_inch = force_pound / inch ** 2 = psi
 kip_per_square_inch = kip / inch ** 2 = ksi
-barye = 0.1 * newton / meter ** 2 = barie = barad = barrie = baryd = Ba
-mm_Hg = millimeter * Hg = mmHg = millimeter_Hg = millimeter_Hg_0C
-cm_Hg = centimeter * Hg = cmHg = centimeter_Hg
-in_Hg = inch * Hg = inHg = inch_Hg = inch_Hg_32F
-inch_Hg_60F = inch * mercury_60F
-inch_H2O_39F = inch * water_39F
-inch_H2O_60F = inch * water_60F
-footH2O = ft * water
-cmH2O = centimeter * water
-foot_H2O = ft * water = ftH2O
-standard_liter_per_minute = 1.68875 * Pa * m ** 3 / s = slpm = slm
+millimeter_Hg = millimeter * Hg * g_0 = mmHg = mm_Hg = millimeter_Hg_0C
+centimeter_Hg = centimeter * Hg * g_0 = cmHg = cm_Hg = centimeter_Hg_0C
+inch_Hg = inch * Hg * g_0 = inHg = in_Hg = inch_Hg_32F
+inch_Hg_60F = inch * Hg_60F * g_0
+inch_H2O_39F = inch * water_39F * g_0
+inch_H2O_60F = inch * water_60F * g_0
+foot_H2O = foot * water * g_0 = ftH2O = feet_H2O
+centimeter_H2O = centimeter * water * g_0 = cmH2O = cm_H2O
 
-# Radiation
-Bq = Hz = becquerel
-curie = 3.7e10 * Bq = Ci
-rutherford = 1e6*Bq = Rd
-Gy = joule / kilogram = gray = Sv = sievert
-rem = 1e-2 * sievert
-rads = 1e-2 * gray
-roentgen = 2.58e-4 * coulomb / kilogram
-
-# Temperature
-degC = kelvin; offset: 273.15 = celsius
-degR = 5 / 9 * kelvin; offset: 0 = rankine
-degF = 5 / 9 * kelvin; offset: 255.372222 = fahrenheit
-
-# Time
-minute = 60 * second = min
-hour = 60 * minute = hr
-day = 24 * hour
-week = 7 * day
-fortnight = 2 * week
-year = 31556925.9747 * second
-month = year / 12
-shake = 1e-8 * second
-sidereal_day = day / 1.00273790935079524
-sidereal_hour = sidereal_day / 24
-sidereal_minute = sidereal_hour / 60
-sidereal_second = sidereal_minute / 60
-sidereal_year = 366.25636042 * sidereal_day
-sidereal_month = 27.321661 * sidereal_day
-tropical_month = 27.321661 * day
-synodic_month = 29.530589 * day = lunar_month
-common_year = 365 * day
-leap_year = 366 * day
-julian_year = 365.25 * day
-gregorian_year = 365.2425 * day
-millenium = 1000 * year = millenia = milenia = milenium
-eon = 1e9 * year
-work_year = 2056 * hour
-work_month = work_year / 12
-
-# Velocity
-[speed] = [length] / [time]
-nautical_mile = 1852 m = nmi # exact
-knot = nautical_mile / hour = kt = knot_international = international_knot = nautical_miles_per_hour
-mph = mile / hour = MPH
-kph = kilometer / hour = KPH
+# Torque
+[torque] = [force] * [length]
+foot_pound = foot * force_pound = ft_lb = footpound
 
 # Viscosity
 [viscosity] = [pressure] * [time]
-poise = 1e-1 * Pa * second = P
-stokes = 1e-4 * meter ** 2 / second = St
-rhe = 10 / (Pa * s)
+poise = 0.1 * Pa * second = P
+reyn = psi * second
 
-# Volume
-[volume] = [length] ** 3
-liter = 1e-3 * m ** 3 = l = L = litre
-cc = centimeter ** 3 = cubic_centimeter
-stere = meter ** 3
+# Kinematic viscosity
+[kinematic_viscosity] = [area] / [time]
+stokes = centimeter ** 2 / second = St
 
+# Fluidity
+[fluidity] = 1 / [viscosity]
+rhe = 1 / poise
+
+# Amount of substance
+particle = 1 / N_A = = molec = molecule
+
+# Concentration
+[concentration] = [substance] / [volume]
+molar = mole / liter = M
+
+# Catalytic activity
+[activity] = [substance] / [time]
+katal = mole / second = kat
+enzyme_unit = micromole / minute = U = enzymeunit
+
+# Entropy
+[entropy] = [energy] / [temperature]
+clausius = calorie / kelvin = Cl
+
+# Molar entropy
+[molar_entropy] = [entropy] / [substance]
+entropy_unit = calorie / kelvin / mole = eu
+
+# Radiation
+becquerel = counts_per_second = Bq
+curie = 3.7e10 * becquerel = Ci
+rutherford = 1e6 * becquerel = Rd
+gray = joule / kilogram = Gy
+sievert = joule / kilogram = Sv
+rads = 0.01 * gray
+rem = 0.01 * sievert
+roentgen = 2.58e-4 * coulomb / kilogram = = röntgen  # approximate, depends on medium
+
+# Heat transimission
+[heat_transmission] = [energy] / [area]
+peak_sun_hour = 1e3 * watt_hour / meter ** 2 = PSH
+langley = thermochemical_calorie / centimeter ** 2 = Ly
+
+# Luminance
+[luminance] = [luminosity] / [area]
+nit = candela / meter ** 2
+stilb = candela / centimeter ** 2
+lambert = 1 / π * candela / centimeter ** 2
+
+# Luminous flux
+[luminous_flux] = [luminosity]
+lumen = candela * steradian = lm
+
+# Illuminance
+[illuminance] = [luminous_flux] / [area]
+lux = lumen / meter ** 2 = lx
+
+# Current
+biot = 10 * ampere = Bi
+abampere = biot = abA
+atomic_unit_of_current = e / atomic_unit_of_time = a_u_current
+mean_international_ampere = mean_international_volt / mean_international_ohm = A_it
+US_international_ampere = US_international_volt / US_international_ohm = A_US
+conventional_ampere_90 = K_J90 * R_K90 / (K_J * R_K) * ampere = A_90
+planck_current = (c ** 6 / gravitational_constant / k_C) ** 0.5
+
+# Charge
+[charge] = [current] * [time]
+coulomb = ampere * second = C
+abcoulomb = 10 * C = abC
+faraday = e * N_A * mole
+conventional_coulomb_90 = K_J90 * R_K90 / (K_J * R_K) * coulomb = C_90
+
+# Electric potential
+[electric_potential] = [energy] / [charge]
+volt = joule / coulomb = V
+abvolt = 1e-8 * volt = abV
+mean_international_volt = 1.00034 * volt = V_it  # approximate
+US_international_volt = 1.00033 * volt = V_US    # approximate
+conventional_volt_90 = K_J90 / K_J * volt = V_90
+
+# Electric field
+[electric_field] = [electric_potential] / [length]
+
+# Electric displacement field
+[electric_displacement_field] = [charge] / [area]
+
+# Resistance
+[resistance] = [electric_potential] / [current]
+ohm = volt / ampere = Ω
+abohm = 1e-9 * ohm = abΩ
+mean_international_ohm = 1.00049 * ohm = Ω_it = ohm_it  # approximate
+US_international_ohm = 1.000495 * ohm = Ω_US = ohm_US   # approximate
+conventional_ohm_90 = R_K / R_K90 * ohm = Ω_90 = ohm_90
+
+# Resistivity
+[resistivity] = [resistance] * [length]
+
+# Conductance
+[conductance] = [current] / [electric_potential]
+siemens = ampere / volt = S = mho
+absiemens = 1e9 * siemens = abS = abmho
+
+# Capacitance
+[capacitance] = [charge] / [electric_potential]
+farad = coulomb / volt = F
+abfarad = 1e9 * farad = abF
+conventional_farad_90 = R_K90 / R_K * farad = F_90
+
+# Inductance
+[inductance] = [magnetic_flux] / [current]
+henry = weber / ampere = H
+abhenry = 1e-9 * henry = abH
+conventional_henry_90 = R_K / R_K90 * henry = H_90
+
+# Magnetic flux
+[magnetic_flux] = [electric_potential] * [time]
+weber = volt * second = Wb
+unit_pole = µ_0 * biot * centimeter
+
+# Magnetic field
+[magnetic_field] = [magnetic_flux] / [area]
+tesla = weber / meter ** 2 = T
+gamma = 1e-9 * tesla = γ
+
+# Magnetomotive force
+[magnetomotive_force] = [current]
+ampere_turn = ampere = At
+biot_turn = biot
+gilbert = 1 / (4 * π) * biot_turn = Gb
+
+# Magnetic field strength
+[magnetic_field_strength] = [current] / [length]
+
+# Electric dipole moment
+[electric_dipole] = [charge] * [length]
+debye = 1e-9 / ζ * coulomb * angstrom = D  # formally 1 D = 1e-10 Fr*Å, but we generally want to use it outside the Gaussian context
+
+# Electric quadrupole moment
+[electric_quadrupole] = [charge] * [area]
+buckingham = debye * angstrom
+
+# Magnetic dipole moment
+[magnetic_dipole] = [current] * [area]
+bohr_magneton = e * hbar / (2 * m_e) = µ_B = mu_B
+nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
+
+
+#### UNIT GROUPS ####
+# Mostly for length, area, volume, mass, force
+# (customary or specialized units)
+
+@group USCSLengthInternational
+    thou = 1e-3 * inch = th = mil_length
+    inch = yard / 36 = in = international_inch = inches = international_inches
+    hand = 4 * inch
+    foot = yard / 3 = ft = international_foot = feet = international_feet
+    yard = 0.9144 * meter = yd = international_yard  # since Jul 1959
+    mile = 1760 * yard = mi = international_mile
+
+    circular_mil = π / 4 * mil_length ** 2 = cmil
+    square_inch = inch ** 2 = sq_in = square_inches
+    square_foot = foot ** 2 = sq_ft = square_feet
+    square_yard = yard ** 2 = sq_yd
+    square_mile = mile ** 2 = sq_mi
+
+    cubic_inch = in ** 3 = cu_in
+    cubic_foot = ft ** 3 = cu_ft = cubic_feet
+    cubic_yard = yd ** 3 = cu_yd
+@end
+
+@group USCSLengthSurvey
+    link = 1e-2 * chain = li = survey_link
+    survey_foot = 1200 / 3937 * meter = sft
+    fathom = 6 * survey_foot
+    rod = 16.5 * survey_foot = rd = pole = perch
+    chain = 4 * rod
+    furlong = 40 * rod = fur
+    cables_length = 120 * fathom
+    survey_mile = 5280 * survey_foot = smi = us_statute_mile
+    league = 3 * survey_mile
+
+    square_rod = rod ** 2 = sq_rod = sq_pole = sq_perch
+    acre = 10 * chain ** 2
+    square_survey_mile = survey_mile ** 2 = = section
+    square_league = league ** 2
+
+    acre_foot = acre * survey_foot = = acre_feet
+@end
+
+@group USCSDryVolume
+    dry_pint = bushel / 64 = dpi = US_dry_pint
+    dry_quart = bushel / 32 = dqt = US_dry_quart
+    dry_gallon = bushel / 8 = dgal = US_dry_gallon
+    peck = bushel / 4 = pk
+    bushel = 2150.42 cubic_inch = bu
+    dry_barrel = 7056 cubic_inch = = US_dry_barrel
+@end
+
+@group USCSLiquidVolume
+    minim = pint / 7680
+    fluid_dram = pint / 128 = fldr = fluidram = US_fluid_dram = US_liquid_dram
+    fluid_ounce = pint / 16 = floz = US_fluid_ounce = US_liquid_ounce
+    gill = pint / 4 = gi = liquid_gill = US_liquid_gill
+    pint = quart / 2 = pt = liquid_pint = US_pint
+    fifth = gallon / 5 = = US_liquid_fifth
+    quart = gallon / 4 = qt = liquid_quart = US_liquid_quart
+    gallon = 231 * cubic_inch = gal = liquid_gallon = US_liquid_gallon
+@end
+
+@group USCSVolumeOther
+    teaspoon = fluid_ounce / 6 = tsp
+    tablespoon = fluid_ounce / 2 = tbsp
+    shot = 3 * tablespoon = jig = US_shot
+    cup = pint / 2 = cp = liquid_cup = US_liquid_cup
+    barrel = 31.5 * gallon = bbl
+    oil_barrel = 42 * gallon = oil_bbl
+    beer_barrel = 31 * gallon = beer_bbl
+    hogshead = 63 * gallon
+@end
+
+@group Avoirdupois
+    dram = pound / 256 = dr = avoirdupois_dram = avdp_dram = drachm
+    ounce = pound / 16 = oz = avoirdupois_ounce = avdp_ounce
+    pound = 7e3 * grain = lb = avoirdupois_pound = avdp_pound
+    stone = 14 * pound
+    quarter = 28 * stone
+    bag = 94 * pound
+    hundredweight = 100 * pound = cwt = short_hundredweight
+    long_hundredweight = 112 * pound
+    ton = 2e3 * pound = = short_ton
+    long_ton = 2240 * pound
+    slug = g_0 * pound * second ** 2 / foot
+
+    force_ounce = g_0 * ounce = ozf = ounce_force
+    force_pound = g_0 * pound = lbf = pound_force
+    force_ton = g_0 * ton = = ton_force = force_short_ton = short_ton_force
+    force_long_ton = g_0 * long_ton = = long_ton_force
+    kip = 1e3 * force_pound
+    poundal = pound * foot / second ** 2 = pdl
+@end
+
+@group AvoirdupoisUK using Avoirdupois
+    UK_hundredweight = long_hundredweight = UK_cwt
+    UK_ton = long_ton
+    UK_force_ton = force_long_ton = = UK_ton_force
+@end
+
+@group AvoirdupoisUS using Avoirdupois
+    US_hundredweight = hundredweight = US_cwt
+    US_ton = ton
+    US_force_ton = force_ton = = US_ton_force
+@end
+
+@group Troy
+    pennyweight = 24 * grain = dwt
+    troy_ounce = 480 * grain = toz = ozt
+    troy_pound = 12 * troy_ounce = tlb = lbt
+@end
+
+@group Apothecary
+    scruple = 20 * grain
+    apothecary_dram = 3 * scruple = ap_dr
+    apothecary_ounce = 8 * apothecary_dram = ap_oz
+    apothecary_pound = 12 * apothecary_ounce = ap_lb
+@end
+
+@group ImperialVolume
+    imperial_minim = imperial_fluid_ounce / 480
+    imperial_fluid_scruple = imperial_fluid_ounce / 24
+    imperial_fluid_drachm = imperial_fluid_ounce / 8 = imperial_fldr = imperial_fluid_dram
+    imperial_fluid_ounce = imperial_pint / 20 = imperial_floz = UK_fluid_ounce
+    imperial_gill = imperial_pint / 4 = imperial_gi = UK_gill
+    imperial_cup = imperial_pint / 2 = imperial_cp = UK_cup
+    imperial_pint = imperial_gallon / 8 = imperial_pt = UK_pint
+    imperial_quart = imperial_gallon / 4 = imperial_qt = UK_quart
+    imperial_gallon = 4.54609 * liter = imperial_gal = UK_gallon
+    imperial_peck = 2 * imperial_gallon = imperial_pk = UK_pk
+    imperial_bushel = 8 * imperial_gallon = imperial_bu = UK_bushel
+    imperial_barrel = 36 * imperial_gallon = imperial_bbl = UK_bbl
+@end
+
+@group Printer
+    pica = inch / 6 = = printers_pica
+    point = pica / 12 = pp = printers_point = big_point = bp
+    didot = 1 / 2660 * m
+    cicero = 12 * didot
+    tex_point = inch / 72.27
+    tex_pica = 12 * tex_point
+    tex_didot = 1238 / 1157 * tex_point
+    tex_cicero = 12 * tex_didot
+    scaled_point = tex_point / 65536
+    css_pixel = inch / 96 = px
+
+    pixel = [printing_unit] = = dot = pel = picture_element
+    pixels_per_centimeter = pixel / cm = PPCM
+    pixels_per_inch = pixel / inch = dots_per_inch = PPI = ppi = DPI = printers_dpi
+    bits_per_pixel = bit / pixel = bpp
+@end
+
+@group Textile
+    tex = gram / kilometer = Tt
+    dtex = decitex
+    denier = gram / (9 * kilometer) = Td
+    jute = pound / (14400 * yard) = Tj
+    aberdeen = jute = Ta
+
+    number_english = 840 * yard / pound = Ne = NeC = ECC
+    number_meter = kilometer / kilogram = Nm
+@end
+
+
+#### CGS ELECTROMAGNETIC UNITS ####
+
+# === Gaussian system of units ===
+@group Gaussian
+    franklin = erg ** 0.5 * centimeter ** 0.5 = Fr = statcoulomb = statC = esu
+    statvolt = erg / franklin = statV
+    statampere = franklin / second = statA
+    gauss = dyne / franklin = G
+    maxwell = gauss * centimeter ** 2 = Mx
+    oersted = dyne / maxwell = Oe = ørsted
+    statohm = statvolt / statampere = statΩ
+    statfarad = franklin / statvolt = statF
+    statmho = statampere / statvolt
+@end
+# Note this system is not commensurate with SI, as ε_0 and µ_0 disappear;
+# some quantities with different dimensions in SI have the same
+# dimensions in the Gaussian system (e.g. [Mx] = [Fr], but [Wb] != [C]),
+# and therefore the conversion factors depend on the context (not in pint sense)
+[gaussian_charge] = [length] ** 1.5 * [mass] ** 0.5 / [time]
+[gaussian_current] = [gaussian_charge] / [time]
+[gaussian_electric_potential] = [gaussian_charge] / [length]
+[gaussian_electric_field] = [gaussian_electric_potential] / [length]
+[gaussian_electric_displacement_field] = [gaussian_charge] / [area]
+[gaussian_electric_flux] = [gaussian_charge]
+[gaussian_electric_dipole] = [gaussian_charge] * [length]
+[gaussian_electric_quadrupole] = [gaussian_charge] * [area]
+[gaussian_magnetic_field] = [force] / [gaussian_charge]
+[gaussian_magnetic_field_strength] = [gaussian_magnetic_field]
+[gaussian_magnetic_flux] = [gaussian_magnetic_field] * [area]
+[gaussian_magnetic_dipole] = [energy] / [gaussian_magnetic_field]
+[gaussian_resistance] = [gaussian_electric_potential] / [gaussian_current]
+[gaussian_resistivity] = [gaussian_resistance] * [length]
+[gaussian_capacitance] = [gaussian_charge] / [gaussian_electric_potential]
+[gaussian_inductance] = [gaussian_electric_potential] * [time] / [gaussian_current]
+[gaussian_conductance] = [gaussian_current] / [gaussian_electric_potential]
+@context Gaussian = Gau
+    [gaussian_charge] -> [charge]: value / k_C ** 0.5
+    [charge] -> [gaussian_charge]: value * k_C ** 0.5
+    [gaussian_current] -> [current]: value / k_C ** 0.5
+    [current] -> [gaussian_current]: value * k_C ** 0.5
+    [gaussian_electric_potential] -> [electric_potential]: value * k_C ** 0.5
+    [electric_potential] -> [gaussian_electric_potential]: value / k_C ** 0.5
+    [gaussian_electric_field] -> [electric_field]: value * k_C ** 0.5
+    [electric_field] -> [gaussian_electric_field]: value / k_C ** 0.5
+    [gaussian_electric_displacement_field] -> [electric_displacement_field]: value / (4 * π / ε_0) ** 0.5
+    [electric_displacement_field] -> [gaussian_electric_displacement_field]: value * (4 * π / ε_0) ** 0.5
+    [gaussian_electric_dipole] -> [electric_dipole]: value / k_C ** 0.5
+    [electric_dipole] -> [gaussian_electric_dipole]: value * k_C ** 0.5
+    [gaussian_electric_quadrupole] -> [electric_quadrupole]: value / k_C ** 0.5
+    [electric_quadrupole] -> [gaussian_electric_quadrupole]: value * k_C ** 0.5
+    [gaussian_magnetic_field] -> [magnetic_field]: value / (4 * π / µ_0) ** 0.5
+    [magnetic_field] -> [gaussian_magnetic_field]: value * (4 * π / µ_0) ** 0.5
+    [gaussian_magnetic_flux] -> [magnetic_flux]: value / (4 * π / µ_0) ** 0.5
+    [magnetic_flux] -> [gaussian_magnetic_flux]: value * (4 * π / µ_0) ** 0.5
+    [gaussian_magnetic_field_strength] -> [magnetic_field_strength]: value / (4 * π * µ_0) ** 0.5
+    [magnetic_field_strength] -> [gaussian_magnetic_field_strength]: value * (4 * π * µ_0) ** 0.5
+    [gaussian_magnetic_dipole] -> [magnetic_dipole]: value * (4 * π / µ_0) ** 0.5
+    [magnetic_dipole] -> [gaussian_magnetic_dipole]: value / (4 * π / µ_0) ** 0.5
+    [gaussian_resistance] -> [resistance]: value * k_C
+    [resistance] -> [gaussian_resistance]: value / k_C
+    [gaussian_resistivity] -> [resistivity]: value * k_C
+    [resistivity] -> [gaussian_resistivity]: value / k_C
+    [gaussian_capacitance] -> [capacitance]: value / k_C
+    [capacitance] -> [gaussian_capacitance]: value * k_C
+    [gaussian_inductance] -> [inductance]: value * k_C
+    [inductance] -> [gaussian_inductance]: value / k_C
+    [gaussian_conductance] -> [conductance]: value / k_C
+    [conductance] -> [gaussian_conductance]: value * k_C
+@end
+
+# === ESU system of units ===
+#   (where different from Gaussian)
+#   See note for Gaussian system too
+@group ESU using Gaussian
+    statweber = statvolt * second = statWb
+    stattesla = statweber / centimeter ** 2 = statT
+    stathenry = statweber / statampere = statH
+@end
+[esu_charge] = [length] ** 1.5 * [mass] ** 0.5 / [time]
+[esu_current] = [esu_charge] / [time]
+[esu_electric_potential] = [esu_charge] / [length]
+[esu_magnetic_flux] = [esu_electric_potential] * [time]
+[esu_magnetic_field] = [esu_magnetic_flux] / [area]
+[esu_magnetic_field_strength] = [esu_current] / [length]
+[esu_magnetic_dipole] = [esu_current] * [area]
+@context ESU = esu
+    [esu_magnetic_field] -> [magnetic_field]: value * k_C ** 0.5
+    [magnetic_field] -> [esu_magnetic_field]: value / k_C ** 0.5
+    [esu_magnetic_flux] -> [magnetic_flux]: value * k_C ** 0.5
+    [magnetic_flux] -> [esu_magnetic_flux]: value / k_C ** 0.5
+    [esu_magnetic_field_strength] -> [magnetic_field_strength]: value / (4 * π / ε_0) ** 0.5
+    [magnetic_field_strength] -> [esu_magnetic_field_strength]: value * (4 * π / ε_0) ** 0.5
+    [esu_magnetic_dipole] -> [magnetic_dipole]: value / k_C ** 0.5
+    [magnetic_dipole] -> [esu_magnetic_dipole]: value * k_C ** 0.5
+@end
+
+
+#### CONVERSION CONTEXTS ####
 
 @context(n=1) spectroscopy = sp
     # n index of refraction of the medium.
@@ -289,12 +681,19 @@ stere = meter ** 3
     [frequency] -> [energy]: planck_constant * value
     [energy] -> [frequency]: value / planck_constant
     # allow wavenumber / kayser
-    1 / [length] <-> [length]: 1 / value
+    [wavenumber] <-> [length]: 1 / value
 @end
 
 @context boltzmann
     [temperature] -> [energy]: boltzmann_constant * value
     [energy] -> [temperature]: value / boltzmann_constant
+@end
+
+@context energy
+    [energy] -> [energy] / [substance]: value * N_A
+    [energy] / [substance] -> [energy]: value / N_A
+    [energy] -> [mass]: value / c ** 2
+    [mass] -> [energy]: value * c ** 2
 @end
 
 @context(mw=0,volume=0,solvent_mass=0) chemistry = chem
@@ -306,7 +705,7 @@ stere = meter ** 3
     [substance] -> [mass]: value * mw
     [mass] -> [substance]: value / mw
 
-    # moles/volume -> mass/volume and moles/mass -> mass / mass
+    # moles/volume -> mass/volume and moles/mass -> mass/mass
     # require the  molecular weight
     [substance] / [volume] -> [mass] / [volume]: value * mw
     [mass] / [volume] -> [substance] / [volume]: value / mw
@@ -327,139 +726,14 @@ stere = meter ** 3
 
 @end
 
-# Most of the definitions that follows are derived from:
-# See http://www.nist.gov/pml/wmd/pubs/hb44.cfm
-@group USCSLengthInternational
-    inch = yard / 36 = in = international_inch = inches = international_inches
-    foot = yard / 3 = ft = international_foot = feet = international_feet
-    yard = 0.9144 metres = yd = international_yard
-    mile = 1760 yard = mi = international_mile
-
-    square_inch = 1 inch ** 2 = sq_in = square_inches
-    square_foot = 1 foot ** 2 = sq_ft = square_feet
-    square_yard = 1 yard ** 2 = sq_yd
-    square_mile = 1 mile ** 2 = sq_mi
-
-    cubic_inch = 1 in ** 3 = cu_in
-    cubic_foot = 1 ft ** 3 = cu_ft = cubic_feet
-    cubic_yard = 1 yd ** 3 = cu_yd
+@context textile
+    # Allow switching between Direct count system (i.e. tex) and
+    # Indirect count system (i.e. Ne, Nm)
+    [mass] / [length] <-> [length] / [mass]: 1 / value
 @end
 
-@group USCSLengthSurvey
-    link = 0.66 survey_foot = li = survey_link
-    survey_foot = foot / 0.999998 = sft
-    rod = 16.5 survey_foot = rd = pole = perch
-    chain = 66 survey_foot
-    survey_mile = 5280 survey_foot
 
-    acre = 43560 survey_foot ** 2
-    square_rod = 1 rod ** 2 = sq_rod = sq_pole = sq_perch
-
-    fathom = 6 survey_foot
-    us_statute_mile = 5280 survey_foot
-    league = 3 us_statute_mile
-    furlong = us_statute_mile / 8
-
-    acre_foot = acre * survey_foot = acre_feet
-@end
-
-@group USCSDryVolume
-    dry_pint = 33.6003125 cubic_inch  = dpi = US_dry_pint
-    dry_quart = 2 dry_pint = dqt = US_dry_quart
-    dry_gallon = 8 dry_pint = dgal = US_dry_gallon
-    peck = 16 dry_pint = pk
-    bushel = 64 dry_pint = bu
-    dry_barrel = 7056 cubic_inch = US_dry_barrel
-@end
-
-@group USCSLiquidVolume
-    minim = liquid_pint / 7680
-    fluid_dram = liquid_pint / 128 = fldr = fluidram = US_fluid_dram
-    fluid_ounce = liquid_pint / 16 = floz = US_fluid_ounce = US_liquid_ounce
-    gill = liquid_pint / 4 = gi = liquid_gill = US_liquid_gill
-
-    pint = 28.875 cubic_inch = pt = liquid_pint = US_pint
-
-    quart = 2 liquid_pint = qt = liquid_quart = US_liquid_quart
-    gallon = 8 liquid_pint = gal = liquid_gallon = US_liquid_gallon
-@end
-
-@group USCSVolumeOther
-    teaspoon = tablespoon / 3 = tsp
-    tablespoon = floz / 2 = tbsp = Tbsp = Tblsp = tblsp = tbs = Tbl
-    shot = 3 * tablespoon = jig = US_shot
-    cup = 8 fluid_ounce = cp = liquid_cup = US_liquid_cup
-    barrel = 31.5 * gallon = bbl
-    oil_barrel = 42 * gallon = oil_bbl
-    beer_barrel = 31 * gallon = beer_bbl
-    hogshead = 63 * gallon
-@end
-
-@group Avoirdupois
-    grain = avdp_pound / 7000 = gr
-    drachm = pound / 256 = dr = avoirdupois_dram = avdp_dram = dram
-    ounce = pound / 16 = oz = avoirdupois_ounce = avdp_ounce
-    pound = 453.59237 gram = lb = avoirdupois_pound = avdp_pound
-
-    short_hundredweight = 100 avoirdupois_pound = ch_cwt
-    long_hundredweight = 112 avoirdupois_pound = lg_cwt
-    short_ton = 2000 avoirdupois_pound
-    long_ton = 2240 avoirdupois_pound
-    force_short_ton = short_ton * g_0 = short_ton_force
-    force_long_ton = long_ton * g_0 = long_ton_force
-@end
-
-@group Troy
-    pennyweight = 24 grain = dwt
-    troy_ounce = 480 grain = toz
-    troy_pound = 12 troy_ounce = tlb
-@end
-
-@group Apothecary
-    scruple = 20 grain
-    apothecary_dram = 3 scruple = ap_dr
-    apothecary_ounce = 8 apothecary_dram = ap_oz
-    apothecary_pound = 12 apothecary_ounce = ap_lb
-@end
-
-@group AvoirdupoisUK using Avoirdupois
-    stone = 14 pound
-    quarter = 28 stone
-    UK_hundredweight = long_hundredweight = UK_cwt
-    UK_ton = long_ton
-    UK_ton_force = force_long_ton
-@end
-
-@group AvoirdupoisUS using Avoirdupois
-    US_hundredweight = short_hundredweight = US_cwt
-    US_ton = short_ton = ton
-    US_ton_force = force_short_ton = ton_force = force_ton
-@end
-
-@group Printer
-    # Length
-    pixel = [printing_unit] = dot = px = pel = picture_element
-    pixels_per_centimeter = pixel / cm = PPCM
-    pixels_per_inch = pixel / inch = dots_per_inch = PPI = ppi = DPI = printers_dpi
-    bits_per_pixel = bit / pixel = bpp
-
-    point = yard / 216 / 12 = pp = printers_point
-    thou = yard / 36000 = th = mil
-    pica = yard / 216 = P̸ = printers_pica
-@end
-
-@group ImperialVolume
-    imperial_fluid_ounce = imperial_pint / 20 = imperial_floz = UK_fluid_ounce
-    imperial_fluid_drachm = imperial_fluid_ounce / 8 = imperial_fluid_dram
-    imperial_gill = imperial_pint / 4 = imperial_gi = UK_gill
-    imperial_cup = imperial_pint / 2 = imperial_cp = UK_cup
-    imperial_pint = 568.26125 * milliliter = imperial_pt = UK_pint
-    imperial_quart = 2 * imperial_pint = imperial_qt = UK_quart
-    imperial_gallon = 8 * imperial_pint = imperial_gal = UK_gallon
-    imperial_peck = 16 * imperial_pint = imperial_pk = UK_pk
-    imperial_bushel = 64 * imperial_pint = imperial_bu = UK_bushel
-    imperial_barrel = 288 * imperial_pint = imperial_bbl = UK_bbl
-@end
+#### SYSTEMS OF UNITS ####
 
 @system mks using international
     meter
@@ -467,10 +741,28 @@ stere = meter ** 3
     second
 @end
 
-@system cgs using international
+@system cgs using international, Gaussian, ESU
     centimeter
     gram
     second
+@end
+
+@system atomic using international
+    # based on unit m_e, e, hbar, k_C, k
+    bohr: meter
+    electron_mass: gram
+    atomic_unit_of_time: second
+    atomic_unit_of_current: ampere
+    atomic_unit_of_temperature: kelvin
+@end
+
+@system Planck using international
+    # based on unit c, gravitational_constant, hbar, k_C, k
+    planck_length: meter
+    planck_mass: gram
+    planck_time: second
+    planck_current: ampere
+    planck_temperature: kelvin
 @end
 
 @system imperial using ImperialVolume, USCSLengthInternational, AvoirdupoisUK

--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -44,7 +44,7 @@ zebi- = 2**70 = Zi-
 yobi- = 2**80 = Yi-
 
 # extra_prefixes
-semi- = 0.5 = = demi-
+semi- = 0.5 = _ = demi-
 sesqui- = 1.5
 
 
@@ -74,7 +74,7 @@ count = []
 # although floating-point conversion may introduce inaccuracies
 
 # Angle
-turn = 2 * π * radian = = revolution = cycle = circle
+turn = 2 * π * radian = _ = revolution = cycle = circle
 degree = π / 180 * radian = deg = arcdeg = arcdegree = angular_degree
 arcminute = degree / 60 = arcmin = arc_minute = angular_minute
 arcsecond = arcminute / 60 = arcsec = arc_second = angular_second
@@ -125,8 +125,8 @@ fortnight = 2 * week
 year = 365.25 * day = a = yr = julian_year
 month = year / 12
 decade = 10 * year
-century = 100 * year = = centuries
-millennium = 1e3 * year = = millennia
+century = 100 * year = _ = centuries
+millennium = 1e3 * year = _ = millennia
 eon = 1e9 * year
 shake = 1e-8 * second
 svedberg = 1e-13 * second
@@ -139,14 +139,14 @@ leap_year = 366 * day
 sidereal_day = day / 1.00273790935079524           # approximate
 sidereal_month = 27.32166155 * day                 # approximate
 tropical_month = 27.321582 * day                   # approximate
-synodic_month = 29.530589 * day = = lunar_month    # approximate
+synodic_month = 29.530589 * day = _ = lunar_month  # approximate
 planck_time = (hbar * gravitational_constant / c ** 5) ** 0.5
 
 # Temperature
-degC = kelvin; offset: 273.15 = °C = celsius = degree_Celsius = degreeC
-degR = 5 / 9 * kelvin; offset: 0 = °R = rankine = degree_Rankine = degreeR
-degF = 5 / 9 * kelvin; offset: 233.15 + 200 / 9 = °F = fahrenheit = degree_Fahrenheit = degreeF
-degRe = 4 / 5 * kelvin; offset: 273.15 = °Re = reaumur = degree_Reaumur = degreeRe = degree_Réaumur = réaumur
+degree_Celsius = kelvin; offset: 273.15 = °C = celsius = degC = degreeC
+degree_Rankine = 5 / 9 * kelvin; offset: 0 = °R = rankine = degR = degreeR
+degree_Fahrenheit = 5 / 9 * kelvin; offset: 233.15 + 200 / 9 = °F = fahrenheit = degF = degreeF
+degree_Reaumur = 4 / 5 * kelvin; offset: 273.15 = °Re = reaumur = degRe = degreeRe = degree_Réaumur = réaumur
 atomic_unit_of_temperature = E_h / k = a_u_temp
 planck_temperature = (hbar * c ** 5 / gravitational_constant / k ** 2) ** 0.5
 
@@ -225,7 +225,7 @@ horsepower = 550 * foot * force_pound / second = hp = UK_horsepower = hydraulic_
 boiler_horsepower = 33475 * Btu / hour                            # unclear which Btu
 metric_horsepower = 75 * force_kilogram * meter / second
 electrical_horsepower = 746 * watt
-refrigeration_ton = 12e3 * Btu / hour = = ton_of_refrigeration  # approximate, no exact definition
+refrigeration_ton = 12e3 * Btu / hour = _ = ton_of_refrigeration  # approximate, no exact definition
 standard_liter_per_minute = atmosphere * liter / minute = slpm = slm
 conventional_watt_90 = K_J90 ** 2 * R_K90 / (K_J ** 2 * R_K) * watt = W_90
 
@@ -273,7 +273,7 @@ stokes = centimeter ** 2 / second = St
 rhe = 1 / poise
 
 # Amount of substance
-particle = 1 / N_A = = molec = molecule
+particle = 1 / N_A = _ = molec = molecule
 
 # Concentration
 [concentration] = [substance] / [volume]
@@ -300,7 +300,7 @@ gray = joule / kilogram = Gy
 sievert = joule / kilogram = Sv
 rads = 0.01 * gray
 rem = 0.01 * sievert
-roentgen = 2.58e-4 * coulomb / kilogram = = röntgen  # approximate, depends on medium
+roentgen = 2.58e-4 * coulomb / kilogram = _ = röntgen  # approximate, depends on medium
 
 # Heat transimission
 [heat_transmission] = [energy] / [area]
@@ -448,10 +448,10 @@ nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
 
     square_rod = rod ** 2 = sq_rod = sq_pole = sq_perch
     acre = 10 * chain ** 2
-    square_survey_mile = survey_mile ** 2 = = section
+    square_survey_mile = survey_mile ** 2 = _ = section
     square_league = league ** 2
 
-    acre_foot = acre * survey_foot = = acre_feet
+    acre_foot = acre * survey_foot = _ = acre_feet
 @end
 
 @group USCSDryVolume
@@ -460,7 +460,7 @@ nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
     dry_gallon = bushel / 8 = dgal = US_dry_gallon
     peck = bushel / 4 = pk
     bushel = 2150.42 cubic_inch = bu
-    dry_barrel = 7056 cubic_inch = = US_dry_barrel
+    dry_barrel = 7056 cubic_inch = _ = US_dry_barrel
 @end
 
 @group USCSLiquidVolume
@@ -469,7 +469,7 @@ nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
     fluid_ounce = pint / 16 = floz = US_fluid_ounce = US_liquid_ounce
     gill = pint / 4 = gi = liquid_gill = US_liquid_gill
     pint = quart / 2 = pt = liquid_pint = US_pint
-    fifth = gallon / 5 = = US_liquid_fifth
+    fifth = gallon / 5 = _ = US_liquid_fifth
     quart = gallon / 4 = qt = liquid_quart = US_liquid_quart
     gallon = 231 * cubic_inch = gal = liquid_gallon = US_liquid_gallon
 @end
@@ -494,14 +494,14 @@ nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
     bag = 94 * pound
     hundredweight = 100 * pound = cwt = short_hundredweight
     long_hundredweight = 112 * pound
-    ton = 2e3 * pound = = short_ton
+    ton = 2e3 * pound = _ = short_ton
     long_ton = 2240 * pound
     slug = g_0 * pound * second ** 2 / foot
 
     force_ounce = g_0 * ounce = ozf = ounce_force
     force_pound = g_0 * pound = lbf = pound_force
-    force_ton = g_0 * ton = = ton_force = force_short_ton = short_ton_force
-    force_long_ton = g_0 * long_ton = = long_ton_force
+    force_ton = g_0 * ton = _ = ton_force = force_short_ton = short_ton_force
+    force_long_ton = g_0 * long_ton = _ = long_ton_force
     kip = 1e3 * force_pound
     poundal = pound * foot / second ** 2 = pdl
 @end
@@ -509,13 +509,13 @@ nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
 @group AvoirdupoisUK using Avoirdupois
     UK_hundredweight = long_hundredweight = UK_cwt
     UK_ton = long_ton
-    UK_force_ton = force_long_ton = = UK_ton_force
+    UK_force_ton = force_long_ton = _ = UK_ton_force
 @end
 
 @group AvoirdupoisUS using Avoirdupois
     US_hundredweight = hundredweight = US_cwt
     US_ton = ton
-    US_force_ton = force_ton = = US_ton_force
+    US_force_ton = force_ton = _ = US_ton_force
 @end
 
 @group Troy
@@ -547,7 +547,7 @@ nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
 @end
 
 @group Printer
-    pica = inch / 6 = = printers_pica
+    pica = inch / 6 = _ = printers_pica
     point = pica / 12 = pp = printers_point = big_point = bp
     didot = 1 / 2660 * m
     cicero = 12 * didot
@@ -558,7 +558,7 @@ nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
     scaled_point = tex_point / 65536
     css_pixel = inch / 96 = px
 
-    pixel = [printing_unit] = = dot = pel = picture_element
+    pixel = [printing_unit] = _ = dot = pel = picture_element
     pixels_per_centimeter = pixel / cm = PPCM
     pixels_per_inch = pixel / inch = dots_per_inch = PPI = ppi = DPI = printers_dpi
     bits_per_pixel = bit / pixel = bpp
@@ -734,6 +734,16 @@ nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
 
 
 #### SYSTEMS OF UNITS ####
+
+@system SI
+    second
+    meter
+    kilogram
+    ampere
+    kelvin
+    mole
+    candela
+@end
 
 @system mks using international
     meter

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -40,10 +40,10 @@ class TestIssues(QuantityTestCase):
 
     def test_issue29(self):
         ureg = UnitRegistry()
-        t = 4 * ureg('mM')
+        t = 4 * ureg('mW')
         self.assertEqual(t.magnitude, 4)
-        self.assertEqual(t._units, UnitsContainer(millimolar=1))
-        self.assertAlmostEqual(t.to('mole / liter'), 4e-3 * ureg('M'))
+        self.assertEqual(t._units, UnitsContainer(milliwatt=1))
+        self.assertEqual(t.to('joule / second'), 4e-3 * ureg('W'))
 
     def test_issue52(self):
         u1 = UnitRegistry()

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -43,7 +43,7 @@ class TestIssues(QuantityTestCase):
         t = 4 * ureg('mM')
         self.assertEqual(t.magnitude, 4)
         self.assertEqual(t._units, UnitsContainer(millimolar=1))
-        self.assertEqual(t.to('mole / liter'), 4e-3 * ureg('M'))
+        self.assertAlmostEqual(t.to('mole / liter'), 4e-3 * ureg('M'))
 
     def test_issue52(self):
         u1 = UnitRegistry()
@@ -127,7 +127,7 @@ class TestIssues(QuantityTestCase):
         except:
             self.assertTrue(False, 'Error while trying to get base units for {}'.format(va))
 
-        boltmk = 1.3806488e-23*ureg.J/ureg.K
+        boltmk = 1.380649e-23*ureg.J/ureg.K
         vb = 2. * boltmk * T / m
 
         self.assertQuantityAlmostEqual(va.to_base_units(), vb.to_base_units())

--- a/pint/xtranslated.txt
+++ b/pint/xtranslated.txt
@@ -1,22 +1,14 @@
 
 # a few unit definitions added to use the translations by unicode cldr
 
-dietary_calorie = 1000 * calorie = Calorie
+dietary_calorie = 1000 * calorie = Cal = Calorie
 metric_cup = liter / 4
-mps = meter / second
-square_inch = inch ** 2 = sq_in
-square_mile = mile ** 2 = sq_mile
 square_meter = kilometer ** 2 = sq_m
 square_kilometer = kilometer ** 2 = sq_km
 mile_scandinavian = 10000 * meter
-century = 100 * year
 cubic_mile = 1 * mile ** 3 = cu_mile = cubic_miles
-cubic_yard = 1 * yard ** 3 = cu_yd = cubic_yards
-cubic_foot = 1 * foot ** 3 = cu_ft = cubic_feet
-cubic_inch = 1 * inch ** 3 = cu_in = cubic_inches
 cubic_meter = 1 * meter ** 3 = cu_m
 cubic_kilometer = 1 * kilometer ** 3 = cu_km
-karat = [purity] = Karat
 
 [consumption] = [volume] / [length]
 liter_per_kilometer = liter / kilometer


### PR DESCRIPTION
The SI has been redefined, by giving exact values to the Planck, Boltzmann and Avogadro constants, and the elementary charge. There are also new recommended values for other constants (CODATA 2018).

I've rewritten the `constants-en.txt` and `default-en.txt` according to these changes and also, I believe, for a better structure. The most significant changes:

* All units and constants defined from a few "experimental" values.
* For as much as I could find them, all factors are exact, except when noted. Floating point representation can introduce inaccuracies, though.
* US and imperial units may have changed their "reference" (to what I considered is most reasonable or authoritative), in practice values stay the same within floating point errors.
* Added some units and quantities.
* Fixed some units like Nm or au and parsec.
* Set the default Btu to the "ISO" Btu, and the default year to the Julian year (as recommended by the IAU)
* Defined units of the Gaussian system consistently, which makes them have different dimensionality from the corresponding SI units. Added a Gaussian context to allow conversions (with some caveats).
* Removed some units for which I could find no definition or reasonable use: chemical_faraday, physical_faraday, sidereal_hour, sidereal_minute, sidereal_second, work_year, work_month (they can of course be added back, hopefully with a better formal definition).
* Added atomic and Planck systems.
* Rearranged the order of units to "importance" (kind of) or field, rather than alphabetic.

I'm happy to undo some of the changes if they are considered undesirable. Note if/when #809 is accepted, I'd like to apply some minor fixes here.


Had to modify a couple of tests:

* For some reason (floating point errors, I guess), 4 mM -> mole/liter is no longer equal to 4e-3 M, only "almost equal".
* Updated the value of the Boltzmann constant in a test, a difference of 1.45e-5 % seems to be too much.