### PR TITLE
Use context manager for assertWarns and fix DeprecationWarning

### DIFF
--- a/pint/testsuite/parameterized.py
+++ b/pint/testsuite/parameterized.py
@@ -32,6 +32,11 @@ from functools import wraps
 import collections
 import unittest
 
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
+
 def add_metaclass(metaclass):
     """Class decorator for creating a class with a metaclass."""
     def wrapper(cls):
@@ -69,7 +74,7 @@ class ParameterizedTestCaseMetaClass(type):
         new_class_dict = {}
 
         for attr_name, attr_value in list(class_dict.items()):
-            if isinstance(attr_value, collections.Callable) and hasattr(attr_value, 'param_names'):
+            if isinstance(attr_value, Callable) and hasattr(attr_value, 'param_names'):
                 # print("Processing attr_name = %r; attr_value = %r" % (
                 #     attr_name, attr_value))
 

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -383,7 +383,7 @@ class TestQuantity(QuantityTestCase):
         self.assertFalse(u_array_2.u == u_array_ref_reversed.u)
 
         u_array_3 = self.Q_.from_sequence(u_seq_reversed, units='g')
-        self.assertTrue(all(u_array_3 == u_array_ref_reversed))        
+        self.assertTrue(all(u_array_3 == u_array_ref_reversed))
         self.assertTrue(u_array_3.u == u_array_ref_reversed.u)
 
         with self.assertRaises(ValueError):
@@ -454,7 +454,8 @@ class TestQuantityToCompact(QuantityTestCase):
     def test_nonnumeric_magnitudes(self):
         ureg = self.ureg
         x = "some string"*ureg.m
-        self.assertRaises(RuntimeError, self.compareQuantity_compact(x,x))
+        with self.assertWarns(RuntimeWarning):
+            self.compareQuantity_compact(x,x)
 
 class TestQuantityBasicMath(QuantityTestCase):
 

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -454,8 +454,11 @@ class TestQuantityToCompact(QuantityTestCase):
     def test_nonnumeric_magnitudes(self):
         ureg = self.ureg
         x = "some string"*ureg.m
-        with self.assertWarns(RuntimeWarning):
-            self.compareQuantity_compact(x,x)
+        if PYTHON3:
+            with self.assertWarns(RuntimeWarning):
+                self.compareQuantity_compact(x,x)
+        else:
+            self.assertRaises(RuntimeError, self.compareQuantity_compact(x,x))
 
 class TestQuantityBasicMath(QuantityTestCase):
 


### PR DESCRIPTION
* Fix `DeprecationWarning` to use collections.abc
* Starting from Python 3.8 `assertRaises` no longer accepts a None with https://github.com/python/cpython/pull/8623 . So use a context manager and assert for `RuntimeWarning`

This fix unblock fedora to package the library for Python 3.8 : https://bugzilla.redhat.com/show_bug.cgi?id=1706212

Thanks