### PR TITLE
Atomic units for intensity and electric field

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -321,6 +321,10 @@ lumen = candela * steradian = lm
 [illuminance] = [luminous_flux] / [area]
 lux = lumen / meter ** 2 = lx
 
+# Intensity
+[intensity] = [power] / [area]
+atomic_unit_of_intensity = 0.5 * ε_0 * c * atomic_unit_of_electric_field ** 2 = a_u_intensity
+
 # Current
 biot = 10 * ampere = Bi
 abampere = biot = abA
@@ -347,6 +351,7 @@ conventional_volt_90 = K_J90 / K_J * volt = V_90
 
 # Electric field
 [electric_field] = [electric_potential] / [length]
+atomic_unit_of_electric_field = e * k_C / a_0 ** 2 = a_u_electric_field
 
 # Electric displacement field
 [electric_displacement_field] = [charge] / [area]


### PR DESCRIPTION
Thanks for a cool project!

When working with atomic systems subject to laser fields it is common to write the intensity of the laser fields in units of `W/cm^2`, but when doing numerical simulations the laser fields are almost always defined in atomic units. I've therefore added the atomic unit for the electric field and the atomic unit for intensity as defined in the book "Atoms in Intense Laser Fields" by Joachain et al. equations (1.1) and (1.2).

```python
>>> import pint
>>> ureg = pint.UnitRegistry()
>>> ureg.Quantity(1, ureg.a_u_electric_field)
<Quantity(1, 'atomic_unit_of_electric_field')>
>>> ureg.Quantity(1, ureg.a_u_electric_field).to(ureg.volt / ureg.cm)
<Quantity(5142206747.6231785, 'volt / centimeter')>
>>> ureg.Quantity(1, ureg.a_u_electric_field).to(ureg.volt / ureg.cm) / 1e9  # Should be ~ 5.1e9 V/cm
<Quantity(5.142206747623178, 'volt / centimeter')>
>>> ureg.Quantity(1, ureg.a_u_intensity)
<Quantity(1, 'atomic_unit_of_intensity')>
>>> ureg.Quantity(1, ureg.a_u_intensity).to(ureg.watt / ureg.cm ** 2)
<Quantity(3.5094455205664776e+16, 'watt / centimeter ** 2')>
>>> ureg.Quantity(1, ureg.a_u_intensity).to(ureg.watt / ureg.cm ** 2) / 1e16  # Should be ~ 3.5e16 W/cm^2
<Quantity(3.5094455205664774, 'watt / centimeter ** 2')>
```

I'd be happy to add tests for these quantities if this is requested, but I was a little unsure as to where they should go.