### PR TITLE
added automatic developer reference using sphinx - solve #827

### DIFF
--- a/docs/developers_reference.rst
+++ b/docs/developers_reference.rst
@@ -1,0 +1,120 @@
+===================
+Developer reference
+===================
+
+Pint
+====
+
+.. automodule:: pint.babel_names
+    :members:
+
+.. automodule:: pint.context
+    :members:
+
+.. automodule:: pint.converters
+    :members:
+
+.. automodule:: pint.definitions
+    :members:
+
+.. automodule:: pint.errors
+    :members:
+
+.. automodule:: pint.formatting
+    :members:
+
+.. automodule:: pint.matplotlib
+    :members:
+
+.. automodule:: pint.measurement
+    :members:
+
+.. automodule:: pint.pint_eval
+    :members:
+
+.. automodule:: pint.quantity
+    :members:
+
+.. automodule:: pint.registry
+    :members:
+
+.. automodule:: pint.registry_helpers
+    :members:
+
+.. automodule:: pint.systems
+    :members:
+
+.. automodule:: pint.unit
+    :members:
+
+.. automodule:: pint.util
+    :members:
+
+.. automodule:: pint.compat.chainmap
+    :members:
+
+.. automodule:: pint.compat.lrucache
+    :members:
+
+.. automodule:: pint.compat.meta
+    :members:
+
+.. automodule:: pint.compat.tokenize
+    :members:
+
+.. automodule:: pint.testsuite.helpers
+    :members:
+
+.. automodule:: pint.testsuite.parametrized
+    :members:
+
+.. automodule:: pint.testsuite.test_babel
+    :members:
+
+.. automodule:: pint.testsuite.test_contexts
+    :members:
+
+.. automodule:: pint.testsuite.test_converters
+    :members:
+
+.. automodule:: pint.testsuite.test_definitions
+    :members:
+
+.. automodule:: pint.testsuite.test_errors
+    :members:
+
+.. automodule:: pint.testsuite.test_formatter
+    :members:
+
+.. automodule:: pint.testsuite.test_infer_base_unit
+    :members:
+
+.. automodule:: pint.testsuite.test_issues
+    :members:
+
+.. automodule:: pint.testsuite.test_measurements
+    :members:
+
+.. automodule:: pint.testsuite.test_numpy
+    :members:
+
+.. automodule:: pint.testsuite.test_pint_eval
+    :members:
+
+.. automodule:: pint.testsuite.test_pitheorem
+    :members:
+
+.. automodule:: pint.testsuite.test_quantity
+    :members:
+
+.. automodule:: pint.testsuite.test_systems
+    :members:
+
+.. automodule:: pint.testsuite.test_umath
+    :members:
+
+.. automodule:: pint.testsuite.test_unit
+    :members:
+
+.. automodule:: pint.testsuite.test_util
+    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -138,6 +138,7 @@ More information
 .. toctree::
     :maxdepth: 1
 
+    developers_reference
     contributing
     faq
 


### PR DESCRIPTION
This pull request adds a page "developers reference" to the documentation. It includes automatically generated information about all modules of the pint package.
Sphinx compiles the docstrings to well designed descriptions.