### PR TITLE
Missing conversion definition when mutating context transformations.

### DIFF
--- a/pint/registry.py
+++ b/pint/registry.py
@@ -1102,7 +1102,8 @@ class ContextRegistry(BaseRegistry):
         for ctx in ctxs:
             if getattr(ctx, '_checked', False):
                 continue
-            for (src, dst), func in ctx.funcs.items():
+            funcs_copy = dict(ctx.funcs)
+            for (src, dst), func in funcs_copy.items():
                 src_ = self._get_dimensionality(src)
                 dst_ = self._get_dimensionality(dst)
                 if src != src_ or dst != dst_:


### PR DESCRIPTION
Thanks for the library, we use it at our company and it's proven
really helpful so far. We are currently moving to Python 3.7 which
made me spot a potential bug in the `BaseRegistry` class (some
of our tests failed when upgrading).

Everything runs fine in Python 3.5, but in 3.7, we are getting a
`DimensionalityError` resulting from the ill-definition of a conversion.
Root cause is that we are mutating context transformations while
iterating over it.

This PR aims to avoid this potential problem. Since we modify the
transformations dictionary structure while iterating over it, we may
fail to iterate over all entries.

Explanation: "Iterating views while adding or deleting entries in the
dictionary may raise a `RuntimeError` or fail to iterate over all
entries"

https://docs.python.org/3/library/stdtypes.html#dictionary-view-objects

This is my first time contributing to Pint, so please let me know if
something needs to be improved / changed.