### PR TITLE
copy.deepcopy(UnitRegistry())

### DIFF
--- a/pint/registry.py
+++ b/pint/registry.py
@@ -195,8 +195,11 @@ class BaseRegistry(meta.with_metaclass(_Meta)):
             self._defaults[k.strip()] = v.strip()
 
     def __getattr__(self, item):
-        if item[0] == '_':
-            return super(BaseRegistry, self).__getattribute__(item)
+        # Double-underscore attributes are tricky to detect because they are
+        # automatically prefixed with the class name - which may be a subclass of self
+        if item.startswith('_') or item.endswith('__'):
+            # Generate AttributeError
+            return object.__getattr__(self, item)
         return self.Unit(item)
 
     def __getitem__(self, item):

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -47,7 +47,8 @@ from tokenize import NUMBER, NAME
 
 from . import registry_helpers
 from .context import Context, ContextChain
-from .util import (logger, pi_theorem, solve_dependencies, ParserHelper,
+from .util import (getattr_maybe_raise,
+                   logger, pi_theorem, solve_dependencies, ParserHelper,
                    string_preprocessor, find_connected_nodes,
                    find_shortest_path, UnitsContainer, _is_dim,
                    to_units_container, SourceIterator)
@@ -195,11 +196,7 @@ class BaseRegistry(meta.with_metaclass(_Meta)):
             self._defaults[k.strip()] = v.strip()
 
     def __getattr__(self, item):
-        # Double-underscore attributes are tricky to detect because they are
-        # automatically prefixed with the class name - which may be a subclass of self
-        if item.startswith('_') or item.endswith('__'):
-            # Generate AttributeError
-            return object.__getattr__(self, item)
+        getattr_maybe_raise(self, item)
         return self.Unit(item)
 
     def __getitem__(self, item):

--- a/pint/systems.py
+++ b/pint/systems.py
@@ -15,7 +15,7 @@ import re
 
 from .definitions import Definition, UnitDefinition
 from .errors import DefinitionSyntaxError, RedefinitionError
-from .util import to_units_container, SharedRegistryObject, SourceIterator, logger
+from .util import to_units_container, getattr_maybe_raise, SharedRegistryObject, SourceIterator, logger
 from .babel_names import _babel_systems
 from pint.compat import Loc
 
@@ -232,6 +232,7 @@ class _Group(SharedRegistryObject):
         return grp
 
     def __getattr__(self, item):
+        getattr_maybe_raise(self, item)
         return self._REGISTRY
 
 
@@ -297,9 +298,7 @@ class _System(SharedRegistryObject):
         return list(self.members)
 
     def __getattr__(self, item):
-        if item == "__setstate__":
-            raise AttributeError(item)
-
+        getattr_maybe_raise(self, item)
         u = getattr(self._REGISTRY, self.name + '_' + item, None)
         if u is not None:
             return u
@@ -443,6 +442,7 @@ class Lister(object):
         return list(self.d.keys())
 
     def __getattr__(self, item):
+        getattr_maybe_raise(self, item)
         return self.d[item]
 
 

--- a/pint/systems.py
+++ b/pint/systems.py
@@ -297,6 +297,9 @@ class _System(SharedRegistryObject):
         return list(self.members)
 
     def __getattr__(self, item):
+        if item == "__setstate__":
+            raise AttributeError(item)
+
         u = getattr(self._REGISTRY, self.name + '_' + item, None)
         if u is not None:
             return u

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -694,3 +694,24 @@ class TestIssuesNP(QuantityTestCase):
     def test_issue783(self):
         ureg = UnitRegistry()
         assert not ureg('g') == []
+
+    def test_issue856(self):
+        ph1 = ParserHelper(scale=123)
+        ph2 = copy.deepcopy(ph1)
+        assert ph2.scale == ph1.scale
+
+        ureg1 = UnitRegistry()
+        ureg2 = copy.deepcopy(ureg1)
+        # Very basic functionality test
+        assert ureg2('1 t').to('kg').magnitude == 1000
+
+    @unittest.expectedFailure
+    def test_issue856b(self):
+        # Test that, after a deepcopy(), the two UnitRegistries are
+        # independent from each other
+        ureg1 = UnitRegistry()
+        ureg2 = copy.deepcopy(ureg1)
+        ureg1.define('test123 = 123 kg')
+        ureg2.define('test123 = 456 kg')
+        assert ureg1('1 test123').to('kg').magnitude == 123
+        assert ureg2('1 test123').to('kg').magnitude == 456

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -668,11 +668,7 @@ class TestIssuesNP(QuantityTestCase):
         self.assertEqual(velocity.check('[length] / [time]'), True)
         self.assertEqual(velocity.check('1 / [time] * [length]'), True)
 
-    def test_issue783(self):
-        ureg = UnitRegistry()
-        assert not ureg('g') == []
-
-    def test_issue(self):
+    def test_issue655b(self):
         import math
         try:
             from inspect import signature
@@ -695,4 +691,6 @@ class TestIssuesNP(QuantityTestCase):
         t = pendulum_period(l, moon_gravity)
         self.assertAlmostEqual(t, Q_('4.928936075204336 second'))
 
-
+    def test_issue783(self):
+        ureg = UnitRegistry()
+        assert not ureg('g') == []

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -690,7 +690,6 @@ class TestIssues(QuantityTestCase):
         # Very basic functionality test
         assert ureg2('1 t').to('kg').magnitude == 1000
 
-    @unittest.expectedFailure
     def test_issue856b(self):
         # Test that, after a deepcopy(), the two UnitRegistries are
         # independent from each other

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -45,6 +45,80 @@ class TestIssues(QuantityTestCase):
         self.assertEqual(t._units, UnitsContainer(milliwatt=1))
         self.assertEqual(t.to('joule / second'), 4e-3 * ureg('W'))
 
+    @unittest.expectedFailure
+    @helpers.requires_numpy()
+    def test_issue37(self):
+        x = np.ma.masked_array([1, 2, 3], mask=[True, True, False])
+        ureg = UnitRegistry()
+        q = ureg.meter * x
+        self.assertIsInstance(q, ureg.Quantity)
+        np.testing.assert_array_equal(q.magnitude, x)
+        self.assertEqual(q.units, ureg.meter.units)
+        q = x * ureg.meter
+        self.assertIsInstance(q, ureg.Quantity)
+        np.testing.assert_array_equal(q.magnitude, x)
+        self.assertEqual(q.units, ureg.meter.units)
+
+        m = np.ma.masked_array(2 * np.ones(3,3))
+        qq = q * m
+        self.assertIsInstance(qq, ureg.Quantity)
+        np.testing.assert_array_equal(qq.magnitude, x * m)
+        self.assertEqual(qq.units, ureg.meter.units)
+        qq = m * q
+        self.assertIsInstance(qq, ureg.Quantity)
+        np.testing.assert_array_equal(qq.magnitude, x * m)
+        self.assertEqual(qq.units, ureg.meter.units)
+
+    @unittest.expectedFailure
+    @helpers.requires_numpy()
+    def test_issue39(self):
+        x = np.matrix([[1, 2, 3], [1, 2, 3], [1, 2, 3]])
+        ureg = UnitRegistry()
+        q = ureg.meter * x
+        self.assertIsInstance(q, ureg.Quantity)
+        np.testing.assert_array_equal(q.magnitude, x)
+        self.assertEqual(q.units, ureg.meter.units)
+        q = x * ureg.meter
+        self.assertIsInstance(q, ureg.Quantity)
+        np.testing.assert_array_equal(q.magnitude, x)
+        self.assertEqual(q.units, ureg.meter.units)
+
+        m = np.matrix(2 * np.ones(3,3))
+        qq = q * m
+        self.assertIsInstance(qq, ureg.Quantity)
+        np.testing.assert_array_equal(qq.magnitude, x * m)
+        self.assertEqual(qq.units, ureg.meter.units)
+        qq = m * q
+        self.assertIsInstance(qq, ureg.Quantity)
+        np.testing.assert_array_equal(qq.magnitude, x * m)
+        self.assertEqual(qq.units, ureg.meter.units)
+
+    @helpers.requires_numpy()
+    def test_issue44(self):
+        ureg = UnitRegistry()
+        x = 4. * ureg.dimensionless
+        np.sqrt(x)
+        self.assertQuantityAlmostEqual(np.sqrt([4.] * ureg.dimensionless), [2.] * ureg.dimensionless)
+        self.assertQuantityAlmostEqual(np.sqrt(4. * ureg.dimensionless), 2. * ureg.dimensionless)
+
+    def test_issue45(self):
+        import math
+        ureg = UnitRegistry()
+        self.assertAlmostEqual(math.sqrt(4 * ureg.m/ureg.cm), math.sqrt(4 * 100))
+        self.assertAlmostEqual(float(ureg.V / ureg.mV), 1000.)
+
+    @helpers.requires_numpy()
+    def test_issue45b(self):
+        ureg = UnitRegistry()
+        self.assertAlmostEqual(np.sin([np.pi/2] * ureg.m / ureg.m ), np.sin([np.pi/2] * ureg.dimensionless))
+        self.assertAlmostEqual(np.sin([np.pi/2] * ureg.cm / ureg.m ), np.sin([np.pi/2] * ureg.dimensionless * 0.01))
+
+    def test_issue50(self):
+        ureg = UnitRegistry()
+        Q_ = ureg.Quantity
+        self.assertEqual(Q_(100), 100 * ureg.dimensionless)
+        self.assertEqual(Q_('100'), 100 * ureg.dimensionless)
+
     def test_issue52(self):
         u1 = UnitRegistry()
         u2 = UnitRegistry()
@@ -86,6 +160,11 @@ class TestIssues(QuantityTestCase):
             self.assertRaises(TypeError, Q_, value)
             self.assertRaises(TypeError, Q_, value, 'meter')
 
+    def test_issue62(self):
+        ureg = UnitRegistry()
+        m = ureg('m**0.5')
+        self.assertEqual(str(m.units), 'meter ** 0.5')
+
     def test_issue66(self):
         ureg = UnitRegistry()
         self.assertEqual(ureg.get_dimensionality(UnitsContainer({'[temperature]': 1})),
@@ -106,6 +185,46 @@ class TestIssues(QuantityTestCase):
         ureg = UnitRegistry()
         q = ureg('m').to(ureg('in'))
         self.assertEqual(q, ureg('m').to('in'))
+
+    @helpers.requires_numpy()
+    def test_issue74(self):
+        ureg = UnitRegistry()
+        v1 = np.asarray([1., 2., 3.])
+        v2 = np.asarray([3., 2., 1.])
+        q1 = v1 * ureg.ms
+        q2 = v2 * ureg.ms
+
+        np.testing.assert_array_equal(q1 < q2, v1 < v2)
+        np.testing.assert_array_equal(q1 > q2, v1 > v2)
+
+        np.testing.assert_array_equal(q1 <= q2, v1 <= v2)
+        np.testing.assert_array_equal(q1 >= q2, v1 >= v2)
+
+        q2s = np.asarray([0.003, 0.002, 0.001]) * ureg.s
+        v2s = q2s.to('ms').magnitude
+
+        np.testing.assert_array_equal(q1 < q2s, v1 < v2s)
+        np.testing.assert_array_equal(q1 > q2s, v1 > v2s)
+
+        np.testing.assert_array_equal(q1 <= q2s, v1 <= v2s)
+        np.testing.assert_array_equal(q1 >= q2s, v1 >= v2s)
+
+    @helpers.requires_numpy()
+    def test_issue75(self):
+        ureg = UnitRegistry()
+        v1 = np.asarray([1., 2., 3.])
+        v2 = np.asarray([3., 2., 1.])
+        q1 = v1 * ureg.ms
+        q2 = v2 * ureg.ms
+
+        np.testing.assert_array_equal(q1 == q2, v1 == v2)
+        np.testing.assert_array_equal(q1 != q2, v1 != v2)
+
+        q2s = np.asarray([0.003, 0.002, 0.001]) * ureg.s
+        v2s = q2s.to('ms').magnitude
+
+        np.testing.assert_array_equal(q1 == q2s, v1 == v2s)
+        np.testing.assert_array_equal(q1 != q2s, v1 != v2s)
 
     @helpers.requires_uncertainties()
     def test_issue77(self):
@@ -205,45 +324,16 @@ class TestIssues(QuantityTestCase):
         self.assertQuantityAlmostEqual(x + y, 5.1 * ureg.meter)
         self.assertQuantityAlmostEqual(z, 5.1 * ureg.meter)
 
-    def test_issue523(self):
+    @helpers.requires_numpy_previous_than('1.10')
+    def test_issue94(self):
         ureg = UnitRegistry()
-        src, dst = UnitsContainer({'meter': 1}), UnitsContainer({'degF': 1})
-        value = 10.
-        convert = self.ureg.convert
-        self.assertRaises(DimensionalityError, convert, value, src, dst)
-        self.assertRaises(DimensionalityError, convert, value, dst, src)
+        v1 = np.array([5, 5]) * ureg.meter
+        v2 = 0.1 * ureg.meter
+        v3 = np.array([5, 5]) * ureg.meter
+        v3 += v2
 
-    def _test_issueXX(self):
-        ureg = UnitRegistry()
-        try:
-            ureg.convert(1, ureg.degC, ureg.kelvin * ureg.meter / ureg.nanometer)
-        except:
-            self.assertTrue(False,
-                            'Error while trying to convert {} to {}'.format(ureg.degC, ureg.kelvin * ureg.meter / ureg.nanometer))
-
-    def test_issue121(self):
-        sh = (2, 1)
-        ureg = UnitRegistry()
-        z, v = 0, 2.
-        self.assertEqual(z + v * ureg.meter, v * ureg.meter)
-        self.assertEqual(z - v * ureg.meter, -v * ureg.meter)
-        self.assertEqual(v * ureg.meter + z, v * ureg.meter)
-        self.assertEqual(v * ureg.meter - z, v * ureg.meter)
-
-        self.assertEqual(sum([v * ureg.meter, v * ureg.meter]), 2 * v * ureg.meter)
-
-    def test_issue105(self):
-        ureg = UnitRegistry()
-
-        func = ureg.parse_unit_name
-        val = list(func('meter'))
-        self.assertEqual(list(func('METER')), [])
-        self.assertEqual(val, list(func('METER', False)))
-
-        for func in (ureg.get_name, ureg.parse_expression):
-            val = func('meter')
-            self.assertRaises(AttributeError, func, 'METER')
-            self.assertEqual(val, func('METER', False))
+        np.testing.assert_array_equal((v1 + v2).magnitude, np.array([5.1, 5.1]))
+        np.testing.assert_array_equal(v3.magnitude, np.array([5, 5]))
 
     def test_issue104(self):
         ureg = UnitRegistry()
@@ -264,6 +354,75 @@ class TestIssues(QuantityTestCase):
         self.assertQuantityAlmostEqual(x[0], ureg.Quantity(1, 'meter'))
         self.assertQuantityAlmostEqual(summer(y), ureg.Quantity(3, 'meter'))
         self.assertQuantityAlmostEqual(y[0], ureg.Quantity(1, 'meter'))
+
+    def test_issue105(self):
+        ureg = UnitRegistry()
+
+        func = ureg.parse_unit_name
+        val = list(func('meter'))
+        self.assertEqual(list(func('METER')), [])
+        self.assertEqual(val, list(func('METER', False)))
+
+        for func in (ureg.get_name, ureg.parse_expression):
+            val = func('meter')
+            self.assertRaises(AttributeError, func, 'METER')
+            self.assertEqual(val, func('METER', False))
+
+    def test_issue121(self):
+        sh = (2, 1)
+        ureg = UnitRegistry()
+        z, v = 0, 2.
+        self.assertEqual(z + v * ureg.meter, v * ureg.meter)
+        self.assertEqual(z - v * ureg.meter, -v * ureg.meter)
+        self.assertEqual(v * ureg.meter + z, v * ureg.meter)
+        self.assertEqual(v * ureg.meter - z, v * ureg.meter)
+
+        self.assertEqual(sum([v * ureg.meter, v * ureg.meter]), 2 * v * ureg.meter)
+
+    @helpers.requires_numpy18()
+    def test_issue121b(self):
+        sh = (2, 1)
+        ureg = UnitRegistry()
+
+        z, v = 0, 2.
+        self.assertEqual(z + v * ureg.meter, v * ureg.meter)
+        self.assertEqual(z - v * ureg.meter, -v * ureg.meter)
+        self.assertEqual(v * ureg.meter + z, v * ureg.meter)
+        self.assertEqual(v * ureg.meter - z, v * ureg.meter)
+
+        self.assertEqual(sum([v * ureg.meter, v * ureg.meter]), 2 * v * ureg.meter)
+
+        z, v = np.zeros(sh), 2. * np.ones(sh)
+        self.assertQuantityEqual(z + v * ureg.meter, v * ureg.meter)
+        self.assertQuantityEqual(z - v * ureg.meter, -v * ureg.meter)
+        self.assertQuantityEqual(v * ureg.meter + z, v * ureg.meter)
+        self.assertQuantityEqual(v * ureg.meter - z, v * ureg.meter)
+
+        z, v = np.zeros((3, 1)), 2. * np.ones(sh)
+        for x, y in ((z, v),
+                     (z, v * ureg.meter),
+                     (v * ureg.meter, z)
+                     ):
+            try:
+                w = x + y
+                self.assertTrue(False, "ValueError not raised")
+            except ValueError:
+                pass
+            try:
+                w = x - y
+                self.assertTrue(False, "ValueError not raised")
+            except ValueError:
+                pass
+
+    @helpers.requires_numpy()
+    def test_issue127(self):
+        q = [1., 2., 3., 4.] * self.ureg.meter
+        q[0] = np.nan
+        self.assertNotEqual(q[0], 1.)
+        self.assertTrue(math.isnan(q[0].magnitude))
+        q[1] = float('NaN')
+        self.assertNotEqual(q[1], 2.)
+        self.assertTrue(math.isnan(q[1].magnitude))
 
     def test_issue170(self):
         Q_ = UnitRegistry().Quantity
@@ -316,193 +475,7 @@ class TestIssues(QuantityTestCase):
         else:
             ureg.Quantity(2, 'µm')
 
-@helpers.requires_numpy()
-class TestIssuesNP(QuantityTestCase):
-
-    FORCE_NDARRAY = False
-
-    @unittest.expectedFailure
-    def test_issue37(self):
-        x = np.ma.masked_array([1, 2, 3], mask=[True, True, False])
-        ureg = UnitRegistry()
-        q = ureg.meter * x
-        self.assertIsInstance(q, ureg.Quantity)
-        np.testing.assert_array_equal(q.magnitude, x)
-        self.assertEqual(q.units, ureg.meter.units)
-        q = x * ureg.meter
-        self.assertIsInstance(q, ureg.Quantity)
-        np.testing.assert_array_equal(q.magnitude, x)
-        self.assertEqual(q.units, ureg.meter.units)
-
-        m = np.ma.masked_array(2 * np.ones(3,3))
-        qq = q * m
-        self.assertIsInstance(qq, ureg.Quantity)
-        np.testing.assert_array_equal(qq.magnitude, x * m)
-        self.assertEqual(qq.units, ureg.meter.units)
-        qq = m * q
-        self.assertIsInstance(qq, ureg.Quantity)
-        np.testing.assert_array_equal(qq.magnitude, x * m)
-        self.assertEqual(qq.units, ureg.meter.units)
-
-    @unittest.expectedFailure
-    def test_issue39(self):
-        x = np.matrix([[1, 2, 3], [1, 2, 3], [1, 2, 3]])
-        ureg = UnitRegistry()
-        q = ureg.meter * x
-        self.assertIsInstance(q, ureg.Quantity)
-        np.testing.assert_array_equal(q.magnitude, x)
-        self.assertEqual(q.units, ureg.meter.units)
-        q = x * ureg.meter
-        self.assertIsInstance(q, ureg.Quantity)
-        np.testing.assert_array_equal(q.magnitude, x)
-        self.assertEqual(q.units, ureg.meter.units)
-
-        m = np.matrix(2 * np.ones(3,3))
-        qq = q * m
-        self.assertIsInstance(qq, ureg.Quantity)
-        np.testing.assert_array_equal(qq.magnitude, x * m)
-        self.assertEqual(qq.units, ureg.meter.units)
-        qq = m * q
-        self.assertIsInstance(qq, ureg.Quantity)
-        np.testing.assert_array_equal(qq.magnitude, x * m)
-        self.assertEqual(qq.units, ureg.meter.units)
-
-    def test_issue44(self):
-        ureg = UnitRegistry()
-        x = 4. * ureg.dimensionless
-        np.sqrt(x)
-        self.assertQuantityAlmostEqual(np.sqrt([4.] * ureg.dimensionless), [2.] * ureg.dimensionless)
-        self.assertQuantityAlmostEqual(np.sqrt(4. * ureg.dimensionless), 2. * ureg.dimensionless)
-
-    def test_issue45(self):
-        import math
-        ureg = UnitRegistry()
-        self.assertAlmostEqual(math.sqrt(4 * ureg.m/ureg.cm), math.sqrt(4 * 100))
-        self.assertAlmostEqual(float(ureg.V / ureg.mV), 1000.)
-
-    def test_issue45b(self):
-        ureg = UnitRegistry()
-        self.assertAlmostEqual(np.sin([np.pi/2] * ureg.m / ureg.m ), np.sin([np.pi/2] * ureg.dimensionless))
-        self.assertAlmostEqual(np.sin([np.pi/2] * ureg.cm / ureg.m ), np.sin([np.pi/2] * ureg.dimensionless * 0.01))
-
-    def test_issue50(self):
-        ureg = UnitRegistry()
-        Q_ = ureg.Quantity
-        self.assertEqual(Q_(100), 100 * ureg.dimensionless)
-        self.assertEqual(Q_('100'), 100 * ureg.dimensionless)
-
-    def test_issue62(self):
-        ureg = UnitRegistry()
-        m = ureg('m**0.5')
-        self.assertEqual(str(m.units), 'meter ** 0.5')
-
-    def test_issue74(self):
-        ureg = UnitRegistry()
-        v1 = np.asarray([1., 2., 3.])
-        v2 = np.asarray([3., 2., 1.])
-        q1 = v1 * ureg.ms
-        q2 = v2 * ureg.ms
-
-        np.testing.assert_array_equal(q1 < q2, v1 < v2)
-        np.testing.assert_array_equal(q1 > q2, v1 > v2)
-
-        np.testing.assert_array_equal(q1 <= q2, v1 <= v2)
-        np.testing.assert_array_equal(q1 >= q2, v1 >= v2)
-
-        q2s = np.asarray([0.003, 0.002, 0.001]) * ureg.s
-        v2s = q2s.to('ms').magnitude
-
-        np.testing.assert_array_equal(q1 < q2s, v1 < v2s)
-        np.testing.assert_array_equal(q1 > q2s, v1 > v2s)
-
-        np.testing.assert_array_equal(q1 <= q2s, v1 <= v2s)
-        np.testing.assert_array_equal(q1 >= q2s, v1 >= v2s)
-
-    def test_issue75(self):
-        ureg = UnitRegistry()
-        v1 = np.asarray([1., 2., 3.])
-        v2 = np.asarray([3., 2., 1.])
-        q1 = v1 * ureg.ms
-        q2 = v2 * ureg.ms
-
-        np.testing.assert_array_equal(q1 == q2, v1 == v2)
-        np.testing.assert_array_equal(q1 != q2, v1 != v2)
-
-        q2s = np.asarray([0.003, 0.002, 0.001]) * ureg.s
-        v2s = q2s.to('ms').magnitude
-
-        np.testing.assert_array_equal(q1 == q2s, v1 == v2s)
-        np.testing.assert_array_equal(q1 != q2s, v1 != v2s)
-
-    def test_issue93(self):
-        ureg = UnitRegistry()
-        x = 5 * ureg.meter
-        self.assertIsInstance(x.magnitude, int)
-        y = 0.1 * ureg.meter
-        self.assertIsInstance(y.magnitude, float)
-        z = 5 * ureg.meter
-        self.assertIsInstance(z.magnitude, int)
-        z += y
-        self.assertIsInstance(z.magnitude, float)
-
-        self.assertQuantityAlmostEqual(x + y, 5.1 * ureg.meter)
-        self.assertQuantityAlmostEqual(z, 5.1 * ureg.meter)
-
-    @helpers.requires_numpy_previous_than('1.10')
-    def test_issue94(self):
-        ureg = UnitRegistry()
-        v1 = np.array([5, 5]) * ureg.meter
-        v2 = 0.1 * ureg.meter
-        v3 = np.array([5, 5]) * ureg.meter
-        v3 += v2
-
-        np.testing.assert_array_equal((v1 + v2).magnitude, np.array([5.1, 5.1]))
-        np.testing.assert_array_equal(v3.magnitude, np.array([5, 5]))
-
-    @helpers.requires_numpy18()
-    def test_issue121(self):
-        sh = (2, 1)
-        ureg = UnitRegistry()
-
-        z, v = 0, 2.
-        self.assertEqual(z + v * ureg.meter, v * ureg.meter)
-        self.assertEqual(z - v * ureg.meter, -v * ureg.meter)
-        self.assertEqual(v * ureg.meter + z, v * ureg.meter)
-        self.assertEqual(v * ureg.meter - z, v * ureg.meter)
-
-        self.assertEqual(sum([v * ureg.meter, v * ureg.meter]), 2 * v * ureg.meter)
-
-        z, v = np.zeros(sh), 2. * np.ones(sh)
-        self.assertQuantityEqual(z + v * ureg.meter, v * ureg.meter)
-        self.assertQuantityEqual(z - v * ureg.meter, -v * ureg.meter)
-        self.assertQuantityEqual(v * ureg.meter + z, v * ureg.meter)
-        self.assertQuantityEqual(v * ureg.meter - z, v * ureg.meter)
-
-        z, v = np.zeros((3, 1)), 2. * np.ones(sh)
-        for x, y in ((z, v),
-                     (z, v * ureg.meter),
-                     (v * ureg.meter, z)
-                     ):
-            try:
-                w = x + y
-                self.assertTrue(False, "ValueError not raised")
-            except ValueError:
-                pass
-            try:
-                w = x - y
-                self.assertTrue(False, "ValueError not raised")
-            except ValueError:
-                pass
-
-    def test_issue127(self):
-        q = [1., 2., 3., 4.] * self.ureg.meter
-        q[0] = np.nan
-        self.assertNotEqual(q[0], 1.)
-        self.assertTrue(math.isnan(q[0].magnitude))
-        q[1] = float('NaN')
-        self.assertNotEqual(q[1], 2.)
-        self.assertTrue(math.isnan(q[1].magnitude))
-
+    @helpers.requires_numpy()
     def test_issue171_real_imag(self):
         qr = [1., 2., 3., 4.] * self.ureg.meter
         qi = [4., 3., 2., 1.] * self.ureg.meter
@@ -510,12 +483,14 @@ class TestIssuesNP(QuantityTestCase):
         self.assertQuantityEqual(q.real, qr)
         self.assertQuantityEqual(q.imag, qi)
 
+    @helpers.requires_numpy()
     def test_issue171_T(self):
         a = np.asarray([[1., 2., 3., 4.],[4., 3., 2., 1.]])
         q1 = a * self.ureg.meter
         q2 = a.T * self.ureg.meter
         self.assertQuantityEqual(q1.T, q2)
 
+    @helpers.requires_numpy()
     def test_issue250(self):
         a = self.ureg.V
         b = self.ureg.mV
@@ -553,11 +528,6 @@ class TestIssuesNP(QuantityTestCase):
         self.assertEqual('{0:~}'.format(1 * self.ureg('MiB')),
                          '1 MiB')
 
-    def test_issue482(self):
-        q = self.ureg.Quantity(1, self.ureg.dimensionless)
-        qe = np.exp(q)
-        self.assertIsInstance(qe, self.ureg.Quantity)
-
     def test_issue468(self):
         ureg = UnitRegistry()
 
@@ -570,12 +540,27 @@ class TestIssuesNP(QuantityTestCase):
         z = x * y
         self.assertEquals(z, ureg.Quantity(1., 'meter * kilogram'))
 
+    @helpers.requires_numpy()
+    def test_issue482(self):
+        q = self.ureg.Quantity(1, self.ureg.dimensionless)
+        qe = np.exp(q)
+        self.assertIsInstance(qe, self.ureg.Quantity)
+
+    @helpers.requires_numpy()
     def test_issue483(self):
         ureg = self.ureg
         a = np.asarray([1, 2, 3])
         q = [1, 2, 3] * ureg.dimensionless
         p = (q ** q).m
         np.testing.assert_array_equal(p, a ** a)
+
+    def test_issue523(self):
+        ureg = UnitRegistry()
+        src, dst = UnitsContainer({'meter': 1}), UnitsContainer({'degF': 1})
+        value = 10.
+        convert = self.ureg.convert
+        self.assertRaises(DimensionalityError, convert, value, src, dst)
+        self.assertRaises(DimensionalityError, convert, value, dst, src)
 
     def test_issue532(self):
         ureg = self.ureg
@@ -668,11 +653,7 @@ class TestIssuesNP(QuantityTestCase):
         self.assertEqual(velocity.check('[length] / [time]'), True)
         self.assertEqual(velocity.check('1 / [time] * [length]'), True)
 
-    def test_issue783(self):
-        ureg = UnitRegistry()
-        assert not ureg('g') == []
-
-    def test_issue(self):
+    def test_issue655b(self):
         import math
         try:
             from inspect import signature
@@ -694,6 +675,10 @@ class TestIssuesNP(QuantityTestCase):
         moon_gravity = Q_(1.625, 'm/s^2')
         t = pendulum_period(l, moon_gravity)
         self.assertAlmostEqual(t, Q_('4.928936075204336 second'))
+
+    def test_issue783(self):
+        ureg = UnitRegistry()
+        assert not ureg('g') == []
 
     def test_issue856(self):
         ph1 = ParserHelper(scale=123)

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -668,7 +668,11 @@ class TestIssuesNP(QuantityTestCase):
         self.assertEqual(velocity.check('[length] / [time]'), True)
         self.assertEqual(velocity.check('1 / [time] * [length]'), True)
 
-    def test_issue655b(self):
+    def test_issue783(self):
+        ureg = UnitRegistry()
+        assert not ureg('g') == []
+
+    def test_issue(self):
         import math
         try:
             from inspect import signature
@@ -690,10 +694,6 @@ class TestIssuesNP(QuantityTestCase):
         moon_gravity = Q_(1.625, 'm/s^2')
         t = pendulum_period(l, moon_gravity)
         self.assertAlmostEqual(t, Q_('4.928936075204336 second'))
-
-    def test_issue783(self):
-        ureg = UnitRegistry()
-        assert not ureg('g') == []
 
     def test_issue856(self):
         ph1 = ParserHelper(scale=123)

--- a/pint/unit.py
+++ b/pint/unit.py
@@ -64,7 +64,7 @@ class _Unit(PrettyIPython, SharedRegistryObject):
         return ret
 
     def __deepcopy__(self, memo):
-      ret = self.__class__(copy.deepcopy(self._units))
+      ret = self.__class__(copy.deepcopy(self._units, memo))
       ret.__used = self.__used
       return ret
 

--- a/pint/util.py
+++ b/pint/util.py
@@ -318,6 +318,13 @@ class UnitsContainer(Mapping):
             self._hash = hash(frozenset(self._d.items()))
         return self._hash
 
+    # Only needed by Python 2.7
+    def __getstate__(self):
+        return self._d, self._hash
+
+    def __setstate__(self, state):
+        self._d, self._hash = state
+
     def __eq__(self, other):
         if isinstance(other, UnitsContainer):
             # Not the same as hash(self); see ParserHelper.__hash__ and __eq__
@@ -488,6 +495,13 @@ class ParserHelper(UnitsContainer):
             mess = 'Only scale 1.0 ParserHelper instance should be considered hashable'
             raise ValueError(mess)
         return super(ParserHelper, self).__hash__()
+
+    # Only needed by Python 2.7
+    def __getstate__(self):
+        return self._d, self._hash, self.scale
+
+    def __setstate__(self, state):
+        self._d, self._hash, self.scale = state
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):

--- a/pint/util.py
+++ b/pint/util.py
@@ -309,13 +309,6 @@ class UnitsContainer(Mapping):
     def __hash__(self):
         return self._hash
 
-    def __getstate__(self):
-        return {'_d': self._d, '_hash': self._hash}
-
-    def __setstate__(self, state):
-        self._d = state['_d']
-        self._hash = state['_hash']
-
     def __eq__(self, other):
         if isinstance(other, UnitsContainer):
             other = other._d

--- a/pint/util.py
+++ b/pint/util.py
@@ -727,7 +727,7 @@ def getattr_maybe_raise(self, item):
     # Double-underscore attributes are tricky to detect because they are
     # automatically prefixed with the class name - which may be a subclass of self
     if item.startswith('_') or item.endswith('__'):
-        object.__getattr__(self, item)
+        raise AttributeError("%r object has no attribute %r" % (self, item))
 
 
 class SourceIterator(object):

--- a/pint/util.py
+++ b/pint/util.py
@@ -706,6 +706,16 @@ def fix_str_conversions(cls):
     return cls
 
 
+def getattr_maybe_raise(self, item):
+    """Helper function to invoke at the beginning of all overridden ``__getattr__``
+    methods. Raise AttributeError if the user tries to ask for a _ or __ attribute.
+    """
+    # Double-underscore attributes are tricky to detect because they are
+    # automatically prefixed with the class name - which may be a subclass of self
+    if item.startswith('_') or item.endswith('__'):
+        object.__getattr__(self, item)
+
+
 class SourceIterator(object):
     """Iterator to facilitate reading the definition files.
 


### PR DESCRIPTION
Closes #856 

Allow creating an independent copy of a UnitRegistry through deepcopy().
Also introduce several speedups in UnitsContainer and ParserHelper.