### PR TITLE
Anonymous contexts

### DIFF
--- a/docs/contexts.rst
+++ b/docs/contexts.rst
@@ -188,7 +188,19 @@ functions. For example:
     >>> ureg = pint.UnitRegistry()
     >>> c = pint.Context('ab')
     >>> c.add_transformation('[length]', '[time]',
-    ...                      lambda ureg, x: ureg.speed_of_light / x)
+    ...                      lambda ureg, x: x / ureg.speed_of_light)
     >>> c.add_transformation('[time]', '[length]',
-    ...                      lambda ureg, x: ureg.speed_of_light * x)
+    ...                      lambda ureg, x: x * ureg.speed_of_light)
     >>> ureg.add_context(c)
+    >>> ureg("1 s").to("km", "ab")
+    299792.458 kilometer
+
+It is also possible to create anonymous contexts without invoking add_context:
+
+   >>> c = pint.Context()
+   ...
+   >>> ureg("1 s").to("km", c)
+   299792.458 kilometer
+   >>> with ureg.context(c):
+   ...     ureg("1 s").to("km")
+   299792.458 kilometer

--- a/docs/contexts.rst
+++ b/docs/contexts.rst
@@ -201,6 +201,3 @@ It is also possible to create anonymous contexts without invoking add_context:
    ...
    >>> ureg("1 s").to("km", c)
    299792.458 kilometer
-   >>> with ureg.context(c):
-   ...     ureg("1 s").to("km")
-   299792.458 kilometer

--- a/pint/context.py
+++ b/pint/context.py
@@ -62,7 +62,7 @@ class Context(object):
 
     """
 
-    def __init__(self, name, aliases=(), defaults=None):
+    def __init__(self, name=None, aliases=(), defaults=None):
 
         self.name = name
         self.aliases = aliases

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -1071,6 +1071,8 @@ class ContextRegistry(BaseRegistry):
 
         Notice that this method will NOT enable the context. Use `enable_contexts`.
         """
+        if not context.name:
+            raise ValueError("Can't add unnamed context to registry")
         if context.name in self._contexts:
             logger.warning('The name %s was already registered for another context.',
                            context.name)

--- a/pint/testsuite/test_contexts.py
+++ b/pint/testsuite/test_contexts.py
@@ -269,7 +269,6 @@ class TestContexts(QuantityTestCase):
         self.assertFalse(ureg._active_ctx)
         self.assertFalse(ureg._active_ctx.graph)
 
-
     def test_one_context(self):
         ureg = UnitRegistry()
 
@@ -287,7 +286,6 @@ class TestContexts(QuantityTestCase):
             self.assertEqual(ureg.get_compatible_units(q), meter_units | hertz_units)
         self.assertRaises(ValueError, q.to, 'Hz')
         self.assertEqual(ureg.get_compatible_units(q), meter_units)
-
 
     def test_multiple_context(self):
         ureg = UnitRegistry()
@@ -307,7 +305,6 @@ class TestContexts(QuantityTestCase):
             self.assertEqual(ureg.get_compatible_units(q), meter_units | hertz_units | ampere_units)
         self.assertRaises(ValueError, q.to, 'Hz')
         self.assertEqual(ureg.get_compatible_units(q), meter_units)
-
 
     def test_nested_context(self):
         ureg = UnitRegistry()
@@ -385,7 +382,6 @@ class TestContexts(QuantityTestCase):
         self.assertRaises(TypeError, q.to, 'Hz')
         ureg.disable_contexts(1)
 
-
     def test_context_with_arg_def(self):
 
         ureg = UnitRegistry()
@@ -420,7 +416,6 @@ class TestContexts(QuantityTestCase):
             with ureg.context('lc', n=2):
                 self.assertEqual(q.to('Hz'), s / 2)
             self.assertRaises(ValueError, q.to, 'Hz')
-
 
     def test_context_with_sharedarg_def(self):
 
@@ -461,6 +456,24 @@ class TestContexts(QuantityTestCase):
             self.assertEqual(q.to('ampere'), 3 * u)
             with ureg.context('lc', n=6):
                 self.assertEqual(q.to('Hz'), s / 6)
+
+    def test_anonymous_context(self):
+        ureg = UnitRegistry()
+        c = Context()
+        c.add_transformation(
+            '[length]', '[time]',
+            lambda ureg, x: (x / ureg.speed_of_light)
+        )
+        expect = ureg("1 m") / ureg.speed_of_light
+
+        out = ureg("1 m").to("s", c)
+        self.assertQuantityEqual(out, expect)
+
+        with ureg.context(c):
+            out = ureg("1 m").to("s")
+        self.assertQuantityEqual(out, expect)
+
+        self.assertRaises(ValueError, ureg.add_context, c)
 
     def _test_ctx(self, ctx):
         ureg = UnitRegistry()
@@ -628,7 +641,6 @@ class TestDefinedContexts(QuantityTestCase):
                     msg = '{} <-> {}'.format(a, b)
                     # assertAlmostEqualRelError converts second to first
                     self.assertQuantityAlmostEqual(b, a, rtol=0.01, msg=msg)
-
 
         for a, b in itertools.product(eq, eq):
             self.assertQuantityAlmostEqual(a.to(b.units, 'sp'), b, rtol=0.01)

--- a/pint/testsuite/test_contexts.py
+++ b/pint/testsuite/test_contexts.py
@@ -464,16 +464,22 @@ class TestContexts(QuantityTestCase):
             '[length]', '[time]',
             lambda ureg, x: (x / ureg.speed_of_light)
         )
-        expect = ureg("1 m") / ureg.speed_of_light
+        self.assertRaises(ValueError, ureg.add_context, c)
 
-        out = ureg("1 m").to("s", c)
+        x = ureg("1 m")
+        expect = x / ureg.speed_of_light
+        out = x.to("s", c)
         self.assertQuantityEqual(out, expect)
 
         with ureg.context(c):
-            out = ureg("1 m").to("s")
+            out = x.to("s")
         self.assertQuantityEqual(out, expect)
 
-        self.assertRaises(ValueError, ureg.add_context, c)
+        ureg.enable_contexts(c)
+        out = x.to("s")
+        self.assertQuantityEqual(out, expect)
+        ureg.disable_contexts(1)
+        self.assertRaises(errors.DimensionalityError, x.to, "s")
 
     def _test_ctx(self, ctx):
         ureg = UnitRegistry()


### PR DESCRIPTION
Allow creating ``pint.Context()`` without a name.
Also fixes a minor error in the documentation as discussed in #855.