### PR TITLE
lazy precision fix

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -195,7 +195,7 @@ planck_time = (hbar * gravitational_constant / c ** 5) ** 0.5
 # Temperature
 degree_Celsius = kelvin; offset: 273.15 = °C = celsius = degC = degreeC
 degree_Rankine = 5 / 9 * kelvin; offset: 0 = °R = rankine = degR = degreeR
-degree_Fahrenheit = 5 / 9 * kelvin; offset: 233.15 + 200 / 9 = °F = fahrenheit = degF = degreeF
+degree_Fahrenheit = degree_Rankine; offset: 241.15 = °F = fahrenheit = degF = degreeF
 degree_Reaumur = 4 / 5 * kelvin; offset: 273.15 = °Re = reaumur = degRe = degreeRe = degree_Réaumur = réaumur
 atomic_unit_of_temperature = E_h / k = a_u_temp
 planck_temperature = (hbar * c ** 5 / gravitational_constant / k ** 2) ** 0.5

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -501,11 +501,18 @@ class TestIssues(QuantityTestCase):
             self.assertEqual(np.float128(a/b), 1000.)
 
     def test_issue252(self):
-        ur = UnitRegistry()
-        q = ur("3 F")
+        ureg = UnitRegistry()
+        q = ureg("3 F")
         t = copy.deepcopy(q)
-        u = t.to(ur.mF)
-        self.assertQuantityEqual(q.to(ur.mF), u)
+        u = t.to(ureg.mF)
+        self.assertQuantityEqual(q.to(ureg.mF), u)
+
+    def test_issue290(self):
+        ureg = UnitRegistry()
+        q=self.Q_(32, ureg.degF).to('degK')
+        assertTrue(abs(q.m- 273.15)<1e-8)
+        q=self.Q_(0, ureg.degC).to('degF')
+        assertTrue(abs(q.m- 32)<1e-8)
 
     def test_issue323(self):
         from fractions import Fraction as F


### PR DESCRIPTION
Fixes https://github.com/hgrecco/pint/issues/290

```
q(32, ureg.degF).to('degK').m
273.15
```

```
print(q(32.1, ureg.degF).to('degC'))
print(q(32.01, ureg.degF).to('degC'))
print(q(32.001, ureg.degF).to('degC'))
print(q(32.0001, ureg.degF).to('degC'))
print(q(32.00001, ureg.degF).to('degC'))
print(q(32.000001, ureg.degF).to('degC'))
print(q(32.0000001, ureg.degF).to('degC'))
print(q(32.00000001, ureg.degF).to('degC'))
print(q(32.000000001, ureg.degF).to('degC'))
print(q(32.0000000001, ureg.degF).to('degC'))

0.10000000000002274 degree_Celsius
0.010000000000047748 degree_Celsius
0.0010000000000331966 degree_Celsius
0.00010000000003174137 degree_Celsius
1.0000000031595846e-05 degree_Celsius
9.999999974752427e-07 degree_Celsius
1.0000002248489182e-07 degree_Celsius
1.0000007932831068e-08 degree_Celsius
1.0000462680181954e-09 degree_Celsius
1.000444171950221e-10 degree_Celsius
```
