### PR TITLE
Reimplement _Quantity.__iter__ to return an iterator

### DIFF
--- a/pint/matplotlib.py
+++ b/pint/matplotlib.py
@@ -13,6 +13,8 @@ from __future__ import absolute_import
 
 import matplotlib.units
 
+from .util import iterable, sized
+
 
 class PintAxisInfo(matplotlib.units.AxisInfo):
     """Support default axis and tick labeling and default limits."""
@@ -31,7 +33,7 @@ class PintConverter(matplotlib.units.ConversionInterface):
 
     def convert(self, value, unit, axis):
         """Convert :`Quantity` instances for matplotlib to use."""
-        if hasattr(value,"__iter__"):
+        if iterable(value):
             return [self._convert_value(v, unit, axis) for v in value]
         else:
             return self._convert_value(value, unit, axis)
@@ -51,7 +53,7 @@ class PintConverter(matplotlib.units.ConversionInterface):
     @staticmethod
     def default_units(x, axis):
         """Get the default unit to use for the given combination of unit and axis."""
-        if hasattr(x,"__iter__") and len(x) > 0:
+        if iterable(x) and sized(x):
             return getattr(x[0], 'units', None)
         return getattr(x, 'units', None)
 

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -235,6 +235,10 @@ class TestNumpyMethods(QuantityTestCase):
         for q, v in zip(self.q.flatten(), [1, 2, 3, 4]):
             self.assertEqual(q, v * self.ureg.m)
 
+    def test_iterable(self):
+        self.assertTrue(np.iterable(self.q))
+        self.assertFalse(np.iterable(1 * self.ureg.m))
+
     def test_reversible_op(self):
         """
         """

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -392,6 +392,19 @@ class TestQuantity(QuantityTestCase):
         u_array_5 = self.Q_.from_list(u_seq)
         self.assertTrue(all(u_array_5 == u_array_ref))
 
+    @helpers.requires_numpy()
+    def test_iter(self):
+        # Verify that iteration gives element as Quantity with same units
+        x = self.Q_([0, 1, 2, 3], 'm')
+        self.assertQuantityEqual(next(iter(x)), self.Q_(0, 'm'))
+
+    def test_notiter(self):
+        # Verify that iter() crashes immediately, without needing to draw any
+        # element from it, if the magnitude isn't iterable
+        x = self.Q_(1, 'm')
+        with self.assertRaises(TypeError):
+            iter(x)
+
 
 class TestQuantityToCompact(QuantityTestCase):
 

--- a/pint/testsuite/test_util.py
+++ b/pint/testsuite/test_util.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 from pint.testsuite import BaseTestCase, QuantityTestCase
 from pint.util import (string_preprocessor, find_shortest_path, matrix_to_string,
                        transpose, tokenizer, find_connected_nodes, ParserHelper,
-                       UnitsContainer, to_units_container)
+                       UnitsContainer, to_units_container, iterable, sized)
 
 
 class TestUnitsContainer(QuantityTestCase):
@@ -333,3 +333,22 @@ class TestMatrix(BaseTestCase):
     def test_transpose(self):
 
         self.assertEqual(transpose([[1, 2], [3, 4]]), [[1, 3], [2, 4]])
+
+
+class TestOtherUtils(BaseTestCase):
+
+    def test_iterable(self):
+
+        # Test with list, string, generator, and scalar
+        self.assertTrue(iterable([0, 1, 2, 3]))
+        self.assertTrue(iterable('test'))
+        self.assertTrue(iterable((i for i in range(5))))
+        self.assertFalse(iterable(0))
+
+    def test_sized(self):
+
+        # Test with list, string, generator, and scalar
+        self.assertTrue(sized([0, 1, 2, 3]))
+        self.assertTrue(sized('test'))
+        self.assertFalse(sized((i for i in range(5))))
+        self.assertFalse(sized(0))

--- a/pint/util.py
+++ b/pint/util.py
@@ -810,3 +810,32 @@ class BlockIterator(SourceIterator):
         return lineno, line
 
     next = __next__
+
+
+def iterable(y):
+    """Check whether or not an object can be iterated over.
+
+    Vendored from numpy under the terms of the BSD 3-Clause License. (Copyright
+    (c) 2005-2019, NumPy Developers.)
+
+    :param value: Input object.
+    :param type: object
+    """
+    try:
+        iter(y)
+    except TypeError:
+        return False
+    return True
+
+
+def sized(y):
+    """Check whether or not an object has a defined length.
+
+    :param value: Input object.
+    :param type: object
+    """
+    try:
+        len(y)
+    except TypeError:
+        return False
+    return True


### PR DESCRIPTION
This PR implements the fix suggested by @crusaderky in https://github.com/hgrecco/pint/issues/751#issuecomment-542920002. Also, adds a test using `np.iterable()`.

- Closes #751 
- Closes #760 
- Should resolve the `TypeError`s in #881 (not sure if it should close it though, since it looks like there were also some extra warnings to be resolved)