### PR TITLE
[Quantity] Show proper location of UnitStrippedWarning

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1452,7 +1452,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         # Attributes starting with `__array_` are common attributes of NumPy ndarray.
         # They are requested by numpy functions.
         if item.startswith('__array_'):
-            warnings.warn("The unit of the quantity is stripped.", UnitStrippedWarning)
+            warnings.warn("The unit of the quantity is stripped.", UnitStrippedWarning, stacklevel=2)
             if isinstance(self._magnitude, ndarray):
                 return getattr(self._magnitude, item)
             else:


### PR DESCRIPTION
Users are interested where in their code they triggered the warning 
and not the original underlying implementation throwing the warning.
By setting the stacklevel accordingly, users see the line of their code, which
strips the warning.