### PR TITLE
silence the escape sequence warnings

### DIFF
--- a/pint/context.py
+++ b/pint/context.py
@@ -22,10 +22,10 @@ from .util import (ParserHelper, UnitsContainer, string_types,
 from .errors import DefinitionSyntaxError
 
 #: Regex to match the header parts of a context.
-_header_re = re.compile('@context\s*(?P<defaults>\(.*\))?\s+(?P<name>\w+)\s*(=(?P<aliases>.*))*')
+_header_re = re.compile(r'@context\s*(?P<defaults>\(.*\))?\s+(?P<name>\w+)\s*(=(?P<aliases>.*))*')
 
 #: Regex to match variable names in an equation.
-_varname_re = re.compile('[A-Za-z_][A-Za-z0-9_]*')
+_varname_re = re.compile(r'[A-Za-z_][A-Za-z0-9_]*')
 
 
 def _expression_to_function(eq):

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -16,7 +16,7 @@ import re
 from .babel_names import _babel_units, _babel_lengths
 from pint.compat import babel_units, Loc, string_types
 
-__JOIN_REG_EXP = re.compile("\{\d*\}")
+__JOIN_REG_EXP = re.compile(r"\{\d*\}")
 
 
 def _join(fmt, iterable):

--- a/pint/systems.py
+++ b/pint/systems.py
@@ -40,7 +40,7 @@ class Group(SharedRegistryObject):
     """
 
     #: Regex to match the header parts of a definition.
-    _header_re = re.compile('@group\s+(?P<name>\w+)\s*(using\s(?P<used_groups>.*))*')
+    _header_re = re.compile(r'@group\s+(?P<name>\w+)\s*(using\s(?P<used_groups>.*))*')
 
     def __init__(self, name):
         """
@@ -263,7 +263,7 @@ class System(SharedRegistryObject):
     """
 
     #: Regex to match the header parts of a context.
-    _header_re = re.compile('@system\s+(?P<name>\w+)\s*(using\s(?P<used_groups>.*))*')
+    _header_re = re.compile(r'@system\s+(?P<name>\w+)\s*(using\s(?P<used_groups>.*))*')
 
     def __init__(self, name):
         """

--- a/pint/testsuite/helpers.py
+++ b/pint/testsuite/helpers.py
@@ -51,14 +51,14 @@ def requires_python3():
     return unittest.skipUnless(PYTHON3, 'Requires Python 3.X.')
 
 
-_number_re = '([-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)'
-_q_re = re.compile('<Quantity\(' + '\s*' + '(?P<magnitude>%s)' % _number_re +
-                   '\s*,\s*' + "'(?P<unit>.*)'" + '\s*' + '\)>')
+_number_re = r'([-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)'
+_q_re = re.compile(r'<Quantity\(' + r'\s*' + r'(?P<magnitude>%s)' % _number_re +
+                   r'\s*,\s*' + r"'(?P<unit>.*)'" + r'\s*' + r'\)>')
 
-_sq_re = re.compile('\s*' + '(?P<magnitude>%s)' % _number_re +
-                    '\s' + "(?P<unit>.*)")
+_sq_re = re.compile(r'\s*' + r'(?P<magnitude>%s)' % _number_re +
+                    r'\s' + r"(?P<unit>.*)")
 
-_unit_re = re.compile('<Unit\((.*)\)>')
+_unit_re = re.compile(r'<Unit\((.*)\)>')
 
 
 class PintOutputChecker(doctest.OutputChecker):

--- a/pint/testsuite/test_measurement.py
+++ b/pint/testsuite/test_measurement.py
@@ -57,7 +57,7 @@ class TestMeasurement(QuantityTestCase):
         self.assertEqual('{0:.1fL}'.format(m), r'\left(4.0 \pm 0.1\right)\ \mathrm{second}^{2}')
         self.assertEqual('{0:.1fH}'.format(m), '(4.0 &plusmn; 0.1) second<sup>2</sup>')
         self.assertEqual('{0:.1fC}'.format(m), '(4.0+/-0.1) second**2')
-        self.assertEqual('{0:.1fLx}'.format(m), '\SI[separate-uncertainty=true]{4.0(1)}{\second\squared}')
+        self.assertEqual('{0:.1fLx}'.format(m), r'\SI[separate-uncertainty=true]{4.0(1)}{\second\squared}')
 
     def test_format_paru(self):
         v, u = self.Q_(0.20, 's ** 2'), self.Q_(0.01, 's ** 2')
@@ -77,8 +77,8 @@ class TestMeasurement(QuantityTestCase):
         self.assertEqual('{0:.3uL}'.format(m), r'\left(0.2000 \pm 0.0100\right)\ \mathrm{second}^{2}')
         self.assertEqual('{0:.3uH}'.format(m), '(0.2000 &plusmn; 0.0100) second<sup>2</sup>')
         self.assertEqual('{0:.3uC}'.format(m), '(0.2000+/-0.0100) second**2')
-        self.assertEqual('{0:.3uLx}'.format(m), '\SI[separate-uncertainty=true]{0.2000(100)}{\second\squared}')
-        self.assertEqual('{0:.1uLx}'.format(m), '\SI[separate-uncertainty=true]{0.20(1)}{\second\squared}')
+        self.assertEqual('{0:.3uLx}'.format(m), r'\SI[separate-uncertainty=true]{0.2000(100)}{\second\squared}')
+        self.assertEqual('{0:.1uLx}'.format(m), r'\SI[separate-uncertainty=true]{0.20(1)}{\second\squared}')
 
     def test_format_percu(self):
         self.test_format_perce()


### PR DESCRIPTION
There are some regular expressions and tex strings that use strings like `\s`, which python tries to interpret as escape sequence and raises a warning upon failure. Marking all of these as raw strings silences this kind of warning for the test suite.