### PR TITLE
Fix autoreducedimension conversion

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -559,7 +559,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
                 if unit1 != unit2:
                     power = self._REGISTRY._get_dimensionality_ratio(unit1, unit2)
                     if power:
-                        newunits = newunits.add(unit2, exp / power).remove(unit1)
+                        newunits = newunits.add(unit2, exp / power).remove([unit1])
                         break
 
         return self.ito(newunits)

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -1132,11 +1132,11 @@ class NonMultiplicativeRegistry(BaseRegistry):
         # clean src from offset units by converting to reference
         if src_offset_unit:
             value = self._units[src_offset_unit].converter.to_reference(value, inplace)
-
-        src = src.remove([src_offset_unit])
+            src = src.remove([src_offset_unit])
 
         # clean dst units from offset units
-        dst = dst.remove([dst_offset_unit])
+        if dst_offset_unit:
+            dst = dst.remove([dst_offset_unit])
 
         # Convert non multiplicative units to the dst.
         value = super()._convert(value, src, dst, inplace, False)

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -670,6 +670,13 @@ class TestIssues(QuantityTestCase):
         assert a != b
         assert a != c
 
+    def test_issue902(self):
+        ureg = UnitRegistry(auto_reduce_dimensions=True)
+        velocity = 1 * ureg.m / ureg.s
+        cross_section = 1 * ureg.um ** 2
+        result = cross_section / velocity
+        assert result == 1e-12 * ureg.m * ureg.s
+
     def test_issue912(self):
         """pprint.pformat() invokes sorted() on large sets and frozensets and graciously
         handles TypeError, but not generic Exceptions. This test will fail if

--- a/pint/util.py
+++ b/pint/util.py
@@ -286,7 +286,7 @@ class UnitsContainer(Mapping):
         if newval:
             new._d[key] = newval
         else:
-            new._d.pop(key, None)
+            new._d.pop(key)
         new._hash = None
         return new
 
@@ -296,7 +296,7 @@ class UnitsContainer(Mapping):
         """
         new = self.copy()
         for k in keys:
-            new._d.pop(k, None)
+            new._d.pop(k)
         new._hash = None
         return new
 


### PR DESCRIPTION
* use iterable in function
* Raise an error when trying to remove non existing key
* Add test in test_issues.py
* Update registry.py to remove unit when unit exists

Closes #902