### PR TITLE
Fixed the definition of RKM unit as gf / tex

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -626,7 +626,7 @@ nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
     denier = gram / (9 * kilometer) = den = Td
     jute = pound / (14400 * yard) = Tj
     aberdeen = jute = Ta
-    RKM = kgf * 1000 / tex
+    RKM  = gf / tex
 
     number_english = 840 * yard / pound = Ne = NeC = ECC
     number_meter = kilometer / kilogram = Nm

--- a/pint/testsuite/test_contexts.py
+++ b/pint/testsuite/test_contexts.py
@@ -673,6 +673,12 @@ class TestDefinedContexts(QuantityTestCase):
             msg = '{} <-> {}'.format(a, b)
             self.assertQuantityAlmostEqual(b, a, rtol=0.01, msg=msg)
 
+            # Check RKM <-> cN/tex conversion
+            self.assertQuantityAlmostEqual(1 * ureg.RKM, 0.980665 * ureg.cN / ureg.tex)
+            self.assertQuantityAlmostEqual((1/0.980665) * ureg.RKM, 1 * ureg.cN / ureg.tex)
+            self.assertAlmostEqual((1 * ureg.RKM).to(ureg.cN / ureg.tex).m, 0.980665)
+            self.assertAlmostEqual((1 * ureg.cN / ureg.tex).to(ureg.RKM).m, 1/0.980665)
+
     def test_decorator(self):
         ureg = self.ureg
 


### PR DESCRIPTION
In #802 I added an **wrong** RKM unit definition. This PR fixes the definition and also adds a numeric check in the testsuite.