### PR TITLE
Preserve caches on context switch v2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,7 +15,7 @@ Pint Changelog
 - TODO #913
 - TODO #911
 - Prevent 1500x slowdown when using .to() with a context
-  (Issue #909, Thanks Guido Imperiale)
+  (Issues #909 and #923, Thanks Guido Imperiale)
 - **BREAKING CHANGE**:
   Drop support for Python < 3.6, numpy < 1.14, and uncertainties < 3.0;
   if you still need them, please install pint 0.9.

--- a/pint/context.py
+++ b/pint/context.py
@@ -221,7 +221,7 @@ class ContextChain(ChainMap):
         To facilitate the identification of the context with the matching rule,
         the *relation_to_context* dictionary of the context is used.
         """
-        self._contexts = list(contexts) + self._contexts
+        self._contexts = list(reversed(contexts)) + self._contexts
         self.maps = [ctx.relation_to_context for ctx in reversed(contexts)] + self.maps
         self._graph = None
 

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -1137,7 +1137,7 @@ class ContextRegistry(BaseRegistry):
         return context
 
     def _build_cache(self):
-        key = self._active_ctx.context_ids()
+        key = self._active_ctx.hashable()
         try:
             self._cache = self._caches[key]
         except KeyError:


### PR DESCRIPTION
Fix bug in #909 where, every time a context is reactivated, it creates a brand new entry in UnitRegistry._caches - thus not only nullifying the whole point of the PR, but also creating a nasty memory leak for users that invoke ``.to`` with an inline context many times.

Not sure what went wrong with the first PR - if I rerun the included benchmark, it doesn't reproduce the same results anymore and clearly shows that nothing is cached.

Same benchmark with this PR:
```python
import pint
ureg = pint.UnitRegistry()
src = ureg('1 m')
dst = ureg.Unit('km')
%timeit src.to(dst)
%timeit -n 1 -r 1 src.to(dst, 'chemistry')
%timeit src.to(dst, 'chemistry')
ureg.enable_contexts('chemistry')
%timeit src.to(dst)
```
29.9 µs ± 1.4 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
57.3 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
76.9 µs ± 1.69 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
43.7 µs ± 955 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)