### PR TITLE
use packaging.version.parse instead of StrictVersion for version checking

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -19,7 +19,7 @@ import operator
 import re
 import warnings
 
-from distutils.version import StrictVersion
+from pkg_resources.extern.packaging.version import LegacyVersion
 
 from .formatting import (remove_custom_flags, siunitx_format_unit, ndarray_to_latex,
                          ndarray_to_latex_parts)
@@ -988,7 +988,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
     def __matmul__(self, other):
         # Use NumPy ufunc (existing since 1.16) for matrix multiplication
-        if StrictVersion(NUMPY_VER) >= StrictVersion('1.16'):
+        if LegacyVersion(NUMPY_VER) >= LegacyVersion('1.16'):
             return np.matmul(self, other)
         else:
             return NotImplemented

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -19,7 +19,7 @@ import operator
 import re
 import warnings
 
-from pkg_resources.extern.packaging.version import LegacyVersion
+from pkg_resources.extern.packaging import version
 
 from .formatting import (remove_custom_flags, siunitx_format_unit, ndarray_to_latex,
                          ndarray_to_latex_parts)
@@ -988,7 +988,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
     def __matmul__(self, other):
         # Use NumPy ufunc (existing since 1.16) for matrix multiplication
-        if LegacyVersion(NUMPY_VER) >= LegacyVersion('1.16'):
+        if version.parse(NUMPY_VER) >= version.parse('1.16'):
             return np.matmul(self, other)
         else:
             return NotImplemented

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'Programming Language :: Python :: 3.8',
     ],
     python_requires='>=3.6',
+    install_requires=['setuptools'],
     extras_require={
         'numpy': ['numpy >= 1.14'],
         'uncertainties': ['uncertainties >= 3.0'],


### PR DESCRIPTION
fixes #872

`distutils.version.StrictVersion` cannot parse numpy development versions like `1.19.0.dev0+578f4e7`. `LooseVersion` is able to parse the version, but it compares
```python
>>> LooseVersion("1.19.0.dev0+578f4e7") < LooseVersion("1.19")
False
```
Using `pkg_resources.extern.packaging.version.parse` instead makes this work as expected. Since `setup.py` requires `setuptools`, I think it being installed is a reasonable assumption?