### PR TITLE
Auto-increase dev version

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,9 @@ Pint Changelog
 0.10 (unreleased)
 -----------------
 
+- Auto-increase package version at every commit when pint is installed from the git tip,
+  e.g. ``pip install git+https://github.com/hgrecco/pint.git``.
+  (Issue #930, Thanks Guido Imperiale)
 - Fix HTML (Jupyter Notebook) and LateX representation of some units
   (Issue #927, Thanks Guido Imperiale)
 - **BREAKING CHANGE**:

--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,7 @@ Pint Changelog
 -----------------
 
 - Auto-increase package version at every commit when pint is installed from the git tip,
-  e.g. ``pip install git+https://github.com/hgrecco/pint.git``.
+  e.g. pip install git+https://github.com/hgrecco/pint.git.
   (Issue #930, Thanks Guido Imperiale)
 - Fix HTML (Jupyter Notebook) and LateX representation of some units
   (Issue #927, Thanks Guido Imperiale)

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys
-
-try:
-    reload(sys).setdefaultencoding("UTF-8")
-except:
-    pass
-
-try:
-    from setuptools import setup
-except ImportError:
-    print('Please install or upgrade setuptools or pip to continue')
-    sys.exit(1)
-
 import codecs
+import subprocess
+
+from setuptools import setup
 
 
 def read(filename):
@@ -27,9 +17,28 @@ long_description = '\n\n'.join([read('README'),
 
 __doc__ = long_description
 
+
+version = "0.10"
+RELEASE_VERSION = False
+
+if not RELEASE_VERSION:
+    # Append incremental version number from git
+    try:
+        version += (
+            ".dev"
+            + subprocess.check_output(["git", "rev-list", "--count", "HEAD"])
+            .decode()
+            .strip()
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # The .git directory has been removed (likely by setup.py sdist),
+        # and/or git is not installed
+        version += ".dev0"
+
+
 setup(
     name='Pint',
-    version='0.10.dev0',
+    version=version,
     description='Physical quantities module',
     long_description=long_description,
     keywords='physical quantities unit conversion science',

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,16 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
-import codecs
 import subprocess
 
 from setuptools import setup
 
 
 def read(filename):
-    return codecs.open(filename, encoding='utf-8').read()
+    with open(filename) as fh:
+        return fh.read()
 
 
-long_description = '\n\n'.join([read('README'),
-                                read('AUTHORS'),
-                                read('CHANGES')])
-
+long_description = '\n\n'.join([read('README'), read('AUTHORS'), read('CHANGES')])
 __doc__ = long_description
 
 


### PR DESCRIPTION
A static version "0.10.dev0" is troublesome for developers who need to use the git tip of pint in their project. 

Namely, if one uses this conda requirements file:
```
name: test
channels:
  - defaults
dependencies:
  - python =3.7
  - pip
  - pip:
    - git+https://github.com/hgrecco/pint.git
```
it has been observed to cause pip to accidentally install an obsolete version of the package from the local cache. This is not a problem on cloud CI (where the environment is properly wiped clean every time) but it impacts Jenkins and personal dev boxes.

Also, a subsequent ``conda list`` command, as is typical in most CI scripts for the purpose of forensic analysis, will print a non-helpful '0.10.dev0'.


This PR replaces the static 'dev0' with an ever-increasing number fetched from git. Ahead of a release, whereas the maintainer before pushed a commit that changed the version to remove the .dev0 suffix, will now have to set the RELEASE_VERSION flag to true.

