### PR TITLE
Reimplement cumulative product NumPy functions

### DIFF
--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -184,7 +184,30 @@ def implements(numpy_func_string, func_type):
 
 
 def implement_func(func_type, func_str, input_units=None, output_unit=None):
-    """Add default-behavior NumPy function/ufunc to the handled list."""
+    """Add default-behavior NumPy function/ufunc to the handled list.
+
+    Parameters
+    ----------
+    func_type : str
+        "function" for NumPy functions, "ufunc" for NumPy ufuncs
+    func_str : str
+        String representing the name of the NumPy function/ufunc to add
+    input_units : pint.Unit or str or None
+        Parameter to control how the function downcasts to magnitudes of arguments. If
+        `pint.Unit`, converts all args and kwargs to this unit before downcasting to
+        magnitude. If "all_consistent", converts all args and kwargs to the unit of the
+        first Quantity in args and kwargs before downcasting to magnitude. If some
+        other string, the string is parsed as a unit, and all args and kwargs are
+        converted to that unit. If None, units are stripped without conversion.
+    output_unit : pint.Unit or str or None
+        Parameter to control the unit of the output. If `pint.Unit`, output is wrapped
+        with that unit. If "match_input", output is wrapped with the unit of the first
+        Quantity in args and kwargs. If a string representing a unit operation defined
+        in `get_op_output_unit`, output is wrapped by the unit determined by
+        `get_op_output_unit`. If some other string, the string is parsed as a unit,
+        which becomes the unit of the output. If None, the bare magnitude is returned.
+
+    """
     # If NumPy is not available, do not attempt implement that which does not exist
     if np is None:
         return

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -51,7 +51,8 @@ def _get_first_input_units(args, kwargs={}):
 def convert_arg(arg, pre_calc_units):
     """Convert quantities and sequences of quantities to pre_calc_units and strip units.
 
-    Helper function for convert_to_consistent_units.
+    Helper function for convert_to_consistent_units. pre_calc_units must be given as a pint
+    Unit or None.
     """
     if pre_calc_units is not None:
         if _is_quantity(arg):
@@ -199,10 +200,16 @@ def implement_func(func_type, func_str, input_units=None, output_unit=None):
                 *args, pre_calc_units=first_input_units, **kwargs
             )
         else:
+            if isinstance(input_units, str):
+                # Conversion requires Unit, not str
+                pre_calc_units = first_input_units._REGISTRY.parse_units(input_units)
+            else:
+                pre_calc_units = input_units
+
             # Match all input args/kwargs to input_units, or if input_units is None,
             # simply strip units
             stripped_args, stripped_kwargs = convert_to_consistent_units(
-                *args, pre_calc_units=input_units, **kwargs
+                *args, pre_calc_units=pre_calc_units, **kwargs
             )
 
         # Determine result through base numpy function on stripped arguments

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -290,6 +290,9 @@ class TestNumpyMathematicalFunctions(TestNumpyMethods):
         self.assertRaises(DimensionalityError, np.cumproduct, self.q)
         self.assertQuantityEqual(np.cumprod(self.q / self.ureg.m), [1, 2, 6, 24])
         self.assertQuantityEqual(np.cumproduct(self.q / self.ureg.m), [1, 2, 6, 24])
+        self.assertQuantityEqual(
+            np.cumprod(self.q / self.ureg.m, axis=1), [[1, 2], [3, 12]]
+        )
 
     @helpers.requires_array_function_protocol()
     def test_nancumprod_numpy_func(self):


### PR DESCRIPTION
This PR resolves two issues from #905 that were identified in #939:

First, `convert_arg` in `numpy_func.py` presumes `pre_calc_units` is a `Unit` or `None`, but there are instances where it was passed a string by way of `inputs_units` in `implement_func`. Now, any `inputs_units` as a string are converted to a `Unit` before being passed to `convert_to_consistent_units`.

Second, the cumulative product functions were using `implement_func` with `input_units` set to something other than `None`, which was incorrect, since these functions have arguments that should not have units (namely `axis`). These functions have been reimplemented accordingly.

- [x] Closes #939 
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- ~~Documented in docs/ as appropriate~~
- ~~Added an entry to the CHANGES file~~ (fixup to previous change: #905)
