### PR TITLE
Fix infinite recursion with NumPy array/scalar raised to quantity power

### DIFF
--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -396,7 +396,10 @@ def _frexp(x, *args, **kwargs):
 
 @implements("power", "ufunc")
 def _power(x1, x2):
-    return x1 ** x2
+    if _is_quantity(x1):
+        return x1 ** x2
+    else:
+        return x2.__rpow__(x1)
 
 
 def _add_subtract_handle_non_quantity_zero(x1, x2):

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1258,6 +1258,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
             if other == 1:
                 return self
             elif other == 0:
+                exponent = 0
                 units = UnitsContainer()
             else:
                 if not self._is_multiplicative:
@@ -1267,13 +1268,15 @@ class Quantity(PrettyIPython, SharedRegistryObject):
                         raise OffsetUnitCalculusError(self._units)
 
                 if getattr(other, "dimensionless", False):
-                    units = new_self._units ** other.to_root_units().magnitude
+                    exponent = other.to_root_units().magnitude
+                    units = new_self._units ** exponent
                 elif not getattr(other, "dimensionless", True):
                     raise DimensionalityError(other._units, "dimensionless")
                 else:
-                    units = new_self._units ** other
+                    exponent = _to_magnitude(other, self.force_ndarray)
+                    units = new_self._units ** exponent
 
-            magnitude = new_self._magnitude ** _to_magnitude(other, self.force_ndarray)
+            magnitude = new_self._magnitude ** exponent
             return self.__class__(magnitude, units)
 
     @check_implemented

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -402,6 +402,14 @@ class TestNumpyMathematicalFunctions(TestNumpyMethods):
             q2_cp = copy.copy(q)
             self.assertRaises(DimensionalityError, op_, q_cp, q2_cp)
 
+        self.assertQuantityEqual(
+            np.power(self.q, self.Q_(2)), self.Q_([[1, 4], [9, 16]], "m**2")
+        )
+        self.assertQuantityEqual(
+            self.q ** self.Q_(2), self.Q_([[1, 4], [9, 16]], "m**2")
+        )
+        self.assertNDArrayEqual(arr ** self.Q_(2), np.array([0, 1, 4]))
+
     @unittest.expectedFailure
     @helpers.requires_numpy()
     def test_exponentiation_array_exp_2(self):


### PR DESCRIPTION
After running the current master branch against MetPy's test suite, I found that #905 introduced an infinite recursion error when the base of the exponent was a NumPy array or scalar by naively deferring to standard exponentiation. There were also issues when both the base and power were Quantities. This PR resolves those issues and adds basic tests for those cases.

- ~~Closes~~ (no associated issue)
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- ~~Documented in docs/ as appropriate~~
- ~~Added an entry to the CHANGES file~~ (fixup to previous change: #905)
