### PR TITLE
Improved babel experience

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,10 @@ Pint Changelog
 0.10 (unreleased)
 -----------------
 
+- Added `fmt_locale` argument to registry.
+  (Issue #904)
+- Better error message when Babel is not installed.
+  (Issue #899)
 - It is now possible to redefine units within a context, and use pint for currency
   conversions. Read
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -387,6 +387,10 @@ Finally, if Babel_ is installed you can translate unit names to any language
    >>> accel.format_babel(locale='fr_FR')
    '1.3 mètre par seconde²'
 
+You can also specify the format locale at u
+
+    >>> ureg = UnitRegistry(fmt_locale='fr_FR')
+
 
 Using Pint in your projects
 ---------------------------

--- a/pint/compat.py
+++ b/pint/compat.py
@@ -13,6 +13,18 @@ from io import BytesIO
 from numbers import Number
 
 
+def missing_dependency(package, display_name=None):
+    display_name = display_name or package
+
+    def _inner(*args, **kwargs):
+        raise Exception(
+            "This feature requires %s. Please install it by running:\n"
+            "pip install %s" % (display_name, package)
+        )
+
+    return _inner
+
+
 def tokenizer(input_string):
     for tokinfo in tokenize.tokenize(BytesIO(input_string.encode("utf-8")).readline):
         if tokinfo.type != tokenize.ENCODING:
@@ -121,12 +133,14 @@ try:
     from babel import Locale as Loc
     from babel import units as babel_units
 
+    babel_parse = Loc.parse
+
     HAS_BABEL = hasattr(babel_units, "format_unit")
 except ImportError:
     HAS_BABEL = False
 
 if not HAS_BABEL:
-    Loc = babel_units = None  # noqa: F811
+    babel_parse = babel_units = missing_dependency("Babel")  # noqa: F811
 
 # Define location of pint.Quantity in NEP-13 type cast hierarchy by defining upcast and
 # downcast/wrappable types

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -11,7 +11,7 @@
 import re
 
 from .babel_names import _babel_lengths, _babel_units
-from .compat import Loc
+from .compat import babel_parse
 
 __JOIN_REG_EXP = re.compile(r"\{\d*\}")
 
@@ -138,7 +138,7 @@ def formatter(
     for key, value in sorted(items):
         if locale and babel_length and babel_plural_form and key in _babel_units:
             _key = _babel_units[key]
-            locale = Loc.parse(locale)
+            locale = babel_parse(locale)
             unit_patterns = locale._data["unit_patterns"]
             compound_unit_patterns = locale._data["compound_unit_patterns"]
             plural = "one" if abs(value) <= 0 else babel_plural_form

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -24,9 +24,9 @@ from .compat import SKIP_ARRAY_FUNCTION_CHANGE_WARNING  # noqa: F401
 from .compat import (
     NUMPY_VER,
     BehaviorChangeWarning,
-    Loc,
     _to_magnitude,
     array_function_change_msg,
+    babel_parse,
     eq,
     is_upcast_type,
     ndarray,
@@ -334,7 +334,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         kwspec = dict(kwspec)
         if "length" in kwspec:
             kwspec["babel_length"] = kwspec.pop("length")
-        kwspec["locale"] = Loc.parse(kwspec["locale"])
+        kwspec["locale"] = babel_parse(kwspec.get("locale", self._REGISTRY.locale))
         kwspec["babel_plural_form"] = kwspec["locale"].plural_form(obj.magnitude)
         return "{} {}".format(
             format(obj.magnitude, remove_custom_flags(spec)),

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -334,7 +334,12 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         kwspec = dict(kwspec)
         if "length" in kwspec:
             kwspec["babel_length"] = kwspec.pop("length")
-        kwspec["locale"] = babel_parse(kwspec.get("locale", self._REGISTRY.fmt_locale))
+
+        loc = kwspec.get("locale", self._REGISTRY.fmt_locale)
+        if loc is None:
+            raise ValueError("Provide a `locale` value to localize translation.")
+
+        kwspec["locale"] = babel_parse(loc)
         kwspec["babel_plural_form"] = kwspec["locale"].plural_form(obj.magnitude)
         return "{} {}".format(
             format(obj.magnitude, remove_custom_flags(spec)),

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -334,7 +334,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         kwspec = dict(kwspec)
         if "length" in kwspec:
             kwspec["babel_length"] = kwspec.pop("length")
-        kwspec["locale"] = babel_parse(kwspec.get("locale", self._REGISTRY.locale))
+        kwspec["locale"] = babel_parse(kwspec.get("locale", self._REGISTRY.fmt_locale))
         kwspec["babel_plural_form"] = kwspec["locale"].plural_form(obj.magnitude)
         return "{} {}".format(
             format(obj.magnitude, remove_custom_flags(spec)),

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -149,7 +149,7 @@ class BaseRegistry(metaclass=RegistryMeta):
     :param preprocessors:
         list of callables which are iteratively ran on any input expression or unit
         string
-    :param locale:
+    :param fmt_locale:
         locale identifier string, used in `format_babel`
         string
     """
@@ -184,7 +184,7 @@ class BaseRegistry(metaclass=RegistryMeta):
         on_redefinition="warn",
         auto_reduce_dimensions=False,
         preprocessors=None,
-        locale="en_US",
+        fmt_locale="en_US",
     ):
         self._register_parsers()
         self._init_dynamic_classes()
@@ -200,7 +200,7 @@ class BaseRegistry(metaclass=RegistryMeta):
         self.auto_reduce_dimensions = auto_reduce_dimensions
 
         #: Default locale identifier string, used when calling format_babel without explicit locale.
-        self.locale = locale
+        self.fmt_locale = fmt_locale
 
         #: Map between name (string) and value (string) of defaults stored in the
         #: definitions file.

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -151,7 +151,6 @@ class BaseRegistry(metaclass=RegistryMeta):
         string
     :param fmt_locale:
         locale identifier string, used in `format_babel`
-        string
     """
 
     #: Map context prefix to function
@@ -1752,6 +1751,8 @@ class UnitRegistry(SystemRegistry, ContextRegistry, NonMultiplicativeRegistry):
     :param auto_reduce_dimensions: If True, reduce dimensionality on appropriate operations.
     :param preprocessors: list of callables which are iteratively ran on any input expression
                           or unit string
+    :param fmt_locale:
+        locale identifier string, used in `format_babel`
     """
 
     def __init__(
@@ -1764,6 +1765,7 @@ class UnitRegistry(SystemRegistry, ContextRegistry, NonMultiplicativeRegistry):
         system=None,
         auto_reduce_dimensions=False,
         preprocessors=None,
+        fmt_locale='en_US'
     ):
 
         super().__init__(
@@ -1775,6 +1777,7 @@ class UnitRegistry(SystemRegistry, ContextRegistry, NonMultiplicativeRegistry):
             system=system,
             auto_reduce_dimensions=auto_reduce_dimensions,
             preprocessors=preprocessors,
+            fmt_locale=fmt_locale
         )
 
     def pi_theorem(self, quantities):

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -149,6 +149,9 @@ class BaseRegistry(metaclass=RegistryMeta):
     :param preprocessors:
         list of callables which are iteratively ran on any input expression or unit
         string
+    :param locale:
+        locale identifier string, used in `format_babel`
+        string
     """
 
     #: Map context prefix to function
@@ -181,6 +184,7 @@ class BaseRegistry(metaclass=RegistryMeta):
         on_redefinition="warn",
         auto_reduce_dimensions=False,
         preprocessors=None,
+        locale="en_US",
     ):
         self._register_parsers()
         self._init_dynamic_classes()
@@ -194,6 +198,9 @@ class BaseRegistry(metaclass=RegistryMeta):
 
         #: Determines if dimensionality should be reduced on appropriate operations.
         self.auto_reduce_dimensions = auto_reduce_dimensions
+
+        #: Default locale identifier string, used when calling format_babel without explicit locale.
+        self.locale = locale
 
         #: Map between name (string) and value (string) of defaults stored in the
         #: definitions file.

--- a/pint/systems.py
+++ b/pint/systems.py
@@ -10,7 +10,7 @@
 
 import re
 
-from pint.compat import Loc
+from pint.compat import babel_parse
 
 from .babel_names import _babel_systems
 from .definitions import Definition, UnitDefinition
@@ -362,7 +362,7 @@ class System(SharedRegistryObject):
         """
         if locale and self.name in _babel_systems:
             name = _babel_systems[self.name]
-            locale = Loc.parse(locale)
+            locale = babel_parse(locale)
             return locale.measurement_systems[name]
         return self.name
 

--- a/pint/testsuite/test_babel.py
+++ b/pint/testsuite/test_babel.py
@@ -35,18 +35,13 @@ class TestBabel(BaseTestCase):
         ureg.load_definitions(os.path.join(dirname, "../xtranslated.txt"))
 
         distance = 24.0 * ureg.meter
-        self.assertEqual(
-            distance.format_babel(length="long"), "24.0 mètres"
-        )
+        self.assertEqual(distance.format_babel(length="long"), "24.0 mètres")
         time = 8.0 * ureg.second
-        self.assertEqual(
-            time.format_babel(length="long"), "8.0 secondes"
-        )
+        self.assertEqual(time.format_babel(length="long"), "8.0 secondes")
         self.assertEqual(time.format_babel(locale="ro", length="short"), "8.0 s")
         acceleration = distance / time ** 2
         self.assertEqual(
-            acceleration.format_babel(length="long"),
-            "0.375 mètre par seconde²",
+            acceleration.format_babel(length="long"), "0.375 mètre par seconde²",
         )
         mks = ureg.get_system("mks")
         self.assertEqual(mks.format_babel(locale="fr_FR"), "métrique")
@@ -54,6 +49,6 @@ class TestBabel(BaseTestCase):
     def test_nobabel(self):
         ureg = UnitRegistry()
         distance = 24.0 * ureg.meter
-        self.assertRaises(Exception,
-            distance.format_babel, locale="fr_FR", length="long"
+        self.assertRaises(
+            Exception, distance.format_babel, locale="fr_FR", length="long"
         )

--- a/pint/testsuite/test_babel.py
+++ b/pint/testsuite/test_babel.py
@@ -6,7 +6,7 @@ from pint.testsuite import BaseTestCase, helpers
 
 class TestBabel(BaseTestCase):
     @helpers.requires_babel()
-    def test_babel(self):
+    def test_format(self):
         ureg = UnitRegistry()
         dirname = os.path.dirname(__file__)
         ureg.load_definitions(os.path.join(dirname, "../xtranslated.txt"))
@@ -27,3 +27,33 @@ class TestBabel(BaseTestCase):
         )
         mks = ureg.get_system("mks")
         self.assertEqual(mks.format_babel(locale="fr_FR"), "métrique")
+
+    @helpers.requires_babel()
+    def test_registry_locale(self):
+        ureg = UnitRegistry(fmt_locale="fr_FR")
+        dirname = os.path.dirname(__file__)
+        ureg.load_definitions(os.path.join(dirname, "../xtranslated.txt"))
+
+        distance = 24.0 * ureg.meter
+        self.assertEqual(
+            distance.format_babel(length="long"), "24.0 mètres"
+        )
+        time = 8.0 * ureg.second
+        self.assertEqual(
+            time.format_babel(length="long"), "8.0 secondes"
+        )
+        self.assertEqual(time.format_babel(locale="ro", length="short"), "8.0 s")
+        acceleration = distance / time ** 2
+        self.assertEqual(
+            acceleration.format_babel(length="long"),
+            "0.375 mètre par seconde²",
+        )
+        mks = ureg.get_system("mks")
+        self.assertEqual(mks.format_babel(locale="fr_FR"), "métrique")
+
+    def test_nobabel(self):
+        ureg = UnitRegistry()
+        distance = 24.0 * ureg.meter
+        self.assertRaises(Exception,
+            distance.format_babel, locale="fr_FR", length="long"
+        )


### PR DESCRIPTION
   1. UnitRegistry now has an optional keyword argument (`locale`) that can be
      used to define the default value for `Quantity.format_babel` locale argument.
   2. When Babel is not installed, `Quantity.format_babel` display a nicer and
      more informative exception.

- [x] Closes #899, #904
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
