### PR TITLE
WIP: floordiv, mod, divmod #943

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1094,6 +1094,12 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     __div__ = __truediv__
     __rdiv__ = __rtruediv__
     __idiv__ = __itruediv__
+    
+    def __ceil__(self):
+        return self.__floordiv__(1) + self.__class__(1, self._units)
+
+    def __floor__(self):
+        return self.__floordiv__(1)
 
     def __ifloordiv__(self, other):
         if self._check(other):

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -717,23 +717,23 @@ class TestQuantityBasicMath(QuantityTestCase):
         b = self.Q_("3*second")
         self.assertRaises(DimensionalityError, op.floordiv, a, b)
         self.assertRaises(DimensionalityError, op.floordiv, 3, b)
-        self.assertRaises(DimensionalityError, op.floordiv, a, 3)
         self.assertRaises(DimensionalityError, op.ifloordiv, a, b)
         self.assertRaises(DimensionalityError, op.ifloordiv, 3, b)
-        self.assertRaises(DimensionalityError, op.ifloordiv, a, 3)
         func(op.floordiv, unit * 10.0, "4.2*meter/meter", 2, unit)
         func(op.floordiv, "10*meter", "4.2*inch", 93, unit)
+        func(op.floordiv, unit * 10.0, 3, 3 * unit, unit)
+        func(op.ifloordiv, unit * 10, 3, 3 * unit, unit)
 
     def _test_quantity_mod(self, unit, func):
         a = self.Q_("10*meter")
         b = self.Q_("3*second")
         self.assertRaises(DimensionalityError, op.mod, a, b)
         self.assertRaises(DimensionalityError, op.mod, 3, b)
-        self.assertRaises(DimensionalityError, op.mod, a, 3)
         self.assertRaises(DimensionalityError, op.imod, a, b)
         self.assertRaises(DimensionalityError, op.imod, 3, b)
-        self.assertRaises(DimensionalityError, op.imod, a, 3)
         func(op.mod, unit * 10.0, "4.2*meter/meter", 1.6, unit)
+        func(op.mod, unit * 10.0, 3, 1 * unit, unit)
+        func(op.imod, unit * 10.0, 3, 1 * unit, unit)
 
     def _test_quantity_ifloordiv(self, unit, func):
         func(op.ifloordiv, 10.0, "4.2*meter/meter", 2, unit)
@@ -782,7 +782,7 @@ class TestQuantityBasicMath(QuantityTestCase):
         b = self.Q_("3*second")
         self.assertRaises(DimensionalityError, divmod, a, b)
         self.assertRaises(DimensionalityError, divmod, 3, b)
-        self.assertRaises(DimensionalityError, divmod, a, 3)
+        self._test_quantity_divmod_one("10*meter", 3)
 
     def _test_numeric(self, unit, ifunc):
         self._test_quantity_add_sub(unit, self._test_not_inplace)


### PR DESCRIPTION
- [ ] Closes #943
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

...

This is surely the wrong way to do this:
The `hasattr(obj, 'dimensionless')` check is probably not correct?

IDK how to get math.floor to return a quantity. Modifying `__float__` to return a non-Quantity float results in further errors.

Why is floordiv returning 10.0 in TestQuantityBasicMath.test_nparray?

[@pytest.mark.parametrize](https://docs.pytest.org/en/latest/parametrize.html) might make it easier to identify the test failures by creating named test cases for each combination. There's probably a historical or a technical reason for the current approach?

This is already beyond my level of comprehension of the pint internal API. I'd be grateful for any help or "just move" https://stackoverflow.com/questions/14947789/github-clone-from-pull-request
