### PR TITLE
Remove eval from Definitions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@ Pint Changelog
 0.10 (unreleased)
 -----------------
 
+- Removed eval usage when creating UnitDefinition and PrefixDefinition from string.
+  (Issue #942)
 - Added `fmt_locale` argument to registry.
   (Issue #904)
 - Better error message when Babel is not installed.

--- a/pint/definitions.py
+++ b/pint/definitions.py
@@ -13,6 +13,21 @@ from .errors import DefinitionSyntaxError
 from .util import ParserHelper, UnitsContainer, _is_dim
 
 
+class _NotNumeric(Exception):
+
+    def __init__(self, value):
+        self.value = value
+
+
+def numeric_parse(s):
+    ph = ParserHelper.from_string(s)
+
+    if len(ph):
+        raise _NotNumeric(s)
+
+    return ph.scale
+
+
 class Definition:
     """Base class for definitions.
 
@@ -94,7 +109,11 @@ class PrefixDefinition(Definition):
 
     def __init__(self, name, symbol, aliases, converter):
         if isinstance(converter, str):
-            converter = ScaleConverter(eval(converter))
+            try:
+                converter = ScaleConverter(numeric_parse(converter))
+            except _NotNumeric as ex:
+                raise ValueError(f'Prefix definition must contain only numbers, not {ex.value}')
+
         aliases = tuple(alias.strip("-") for alias in aliases)
         if symbol:
             symbol = symbol.strip("-")
@@ -114,10 +133,16 @@ class UnitDefinition(Definition):
         if isinstance(converter, str):
             if ";" in converter:
                 [converter, modifiers] = converter.split(";", 2)
-                modifiers = dict(
-                    (key.strip(), eval(value))
-                    for key, value in (part.split(":") for part in modifiers.split(";"))
-                )
+
+                try:
+                    modifiers = dict(
+                        (key.strip(), numeric_parse(value))
+                        for key, value in (part.split(":") for part in modifiers.split(";"))
+                    )
+                except _NotNumeric as ex:
+                    raise ValueError(f'Prefix definition must contain only numbers, not {ex.value}')
+
+
             else:
                 modifiers = {}
 

--- a/pint/definitions.py
+++ b/pint/definitions.py
@@ -112,7 +112,7 @@ class PrefixDefinition(Definition):
                 converter = ScaleConverter(numeric_parse(converter))
             except _NotNumeric as ex:
                 raise ValueError(
-                    f"Prefix definition must contain only numbers, not {ex.value}"
+                    f"Prefix definition ('{name}') must contain only numbers, not {ex.value}"
                 )
 
         aliases = tuple(alias.strip("-") for alias in aliases)
@@ -144,7 +144,7 @@ class UnitDefinition(Definition):
                     )
                 except _NotNumeric as ex:
                     raise ValueError(
-                        f"Prefix definition must contain only numbers, not {ex.value}"
+                        f"Unit definition ('{name}') must contain only numbers in modifier, not {ex.value}"
                     )
 
             else:

--- a/pint/definitions.py
+++ b/pint/definitions.py
@@ -14,7 +14,6 @@ from .util import ParserHelper, UnitsContainer, _is_dim
 
 
 class _NotNumeric(Exception):
-
     def __init__(self, value):
         self.value = value
 
@@ -112,7 +111,9 @@ class PrefixDefinition(Definition):
             try:
                 converter = ScaleConverter(numeric_parse(converter))
             except _NotNumeric as ex:
-                raise ValueError(f'Prefix definition must contain only numbers, not {ex.value}')
+                raise ValueError(
+                    f"Prefix definition must contain only numbers, not {ex.value}"
+                )
 
         aliases = tuple(alias.strip("-") for alias in aliases)
         if symbol:
@@ -137,11 +138,14 @@ class UnitDefinition(Definition):
                 try:
                     modifiers = dict(
                         (key.strip(), numeric_parse(value))
-                        for key, value in (part.split(":") for part in modifiers.split(";"))
+                        for key, value in (
+                            part.split(":") for part in modifiers.split(";")
+                        )
                     )
                 except _NotNumeric as ex:
-                    raise ValueError(f'Prefix definition must contain only numbers, not {ex.value}')
-
+                    raise ValueError(
+                        f"Prefix definition must contain only numbers, not {ex.value}"
+                    )
 
             else:
                 modifiers = {}

--- a/pint/testsuite/test_definitions.py
+++ b/pint/testsuite/test_definitions.py
@@ -19,6 +19,9 @@ class TestDefinition(BaseTestCase):
             Definition.from_string("[x] = [time] * meter")
 
     def test_prefix_definition(self):
+
+        self.assertRaises(ValueError, Definition.from_string, "m- = 1e-3 k")
+
         for definition in ("m- = 1e-3", "m- = 10**-3", "m- = 0.001"):
             x = Definition.from_string(definition)
             self.assertIsInstance(x, PrefixDefinition)
@@ -84,6 +87,12 @@ class TestDefinition(BaseTestCase):
         self.assertIsInstance(x.converter, ScaleConverter)
         self.assertEqual(x.converter.scale, 6.28)
         self.assertEqual(x.reference, UnitsContainer(radian=1))
+
+        self.assertRaises(
+            ValueError,
+            Definition.from_string,
+            "degF = 9 / 5 * kelvin; offset: 255.372222 bla",
+        )
 
     def test_dimension_definition(self):
         x = DimensionDefinition("[time]", "", (), converter="")


### PR DESCRIPTION
- [x] Closes #942
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] ~~Documented in docs/ as appropriate~~
- [x] Added an entry to the CHANGES file
