### PR TITLE
ufunc calls with mixed args and upcast types

### DIFF
--- a/pint/compat.py
+++ b/pint/compat.py
@@ -147,6 +147,10 @@ if not HAS_BABEL:
 
 
 def is_upcast_type(other):
+    """ check if the type object is a upcast type
+
+    :param other: type
+    """
     # Check if class name is in preset list
     return other.__name__ in ("PintArray", "Series", "DataArray")
 

--- a/pint/compat.py
+++ b/pint/compat.py
@@ -148,7 +148,7 @@ if not HAS_BABEL:
 
 def is_upcast_type(other):
     # Check if class name is in preset list
-    return other.__class__.__name__ in ("PintArray", "Series", "DataArray")
+    return other.__name__ in ("PintArray", "Series", "DataArray")
 
 
 def eq(first, second, check_all):

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -95,7 +95,7 @@ def ireduce_dimensions(f):
 def check_implemented(f):
     def wrapped(self, *args, **kwargs):
         other = args[0]
-        if is_upcast_type(other):
+        if is_upcast_type(type(other)):
             return NotImplemented
         # pandas often gets to arrays of quantities [ Q_(1,"m"), Q_(2,"m")]
         # and expects Quantity * array[Quantity] should return NotImplemented

--- a/pint/testsuite/test_babel.py
+++ b/pint/testsuite/test_babel.py
@@ -41,7 +41,7 @@ class TestBabel(BaseTestCase):
         self.assertEqual(time.format_babel(locale="ro", length="short"), "8.0 s")
         acceleration = distance / time ** 2
         self.assertEqual(
-            acceleration.format_babel(length="long"), "0.375 mètre par seconde²",
+            acceleration.format_babel(length="long"), "0.375 mètre par seconde²"
         )
         mks = ureg.get_system("mks")
         self.assertEqual(mks.format_babel(locale="fr_FR"), "métrique")


### PR DESCRIPTION
This fixes an issue with calling ufuncs with mixed args including upcast types: Calling a bivariate ufunc like `np.maximum(da, 0 * ureg.m)` resulted in `pint` trying to work with upcast types because `__array_ufunc__` works with type objects while `is_upcast_type` checked object instances.

- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
