### PR TITLE
Migrates docstring to Numpy docs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.10 (unreleased)
 -----------------
 
+- Moved docstrings to Numpy Docs
 - Added tests for immutability of the magnitude's type under common operations
   (Issue #956, Thanks Jon Thielen)
 - Switched test configuration to pytest and added tests of Pint's matplotlib support.

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -89,13 +89,13 @@ def time_task(name, stmt="pass", setup="pass", number=0, repeat=3, stmts="", bas
 
 def time_file(filename, name="", setup="", number=0, repeat=3):
     """Open a yaml benchmark file an time each statement,
-    
+
     yields a tuple with filename, task name, time in seconds.
 
     Parameters
     ----------
     filename :
-        
+
     name :
          (Default value = "")
     setup :

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -10,8 +10,22 @@ def time_stmt(stmt="pass", setup="pass", number=0, repeat=3):
     """Timer function with the same behaviour as running `python -m timeit `
     in the command line.
 
-    :return: elapsed time in seconds or NaN if the command failed.
-    :rtype: float
+    Parameters
+    ----------
+    stmt :
+         (Default value = "pass")
+    setup :
+         (Default value = "pass")
+    number :
+         (Default value = 0)
+    repeat :
+         (Default value = 3)
+
+    Returns
+    -------
+    float
+        elapsed time in seconds or NaN if the command failed.
+
     """
 
     t = Timer(stmt, setup)
@@ -75,8 +89,25 @@ def time_task(name, stmt="pass", setup="pass", number=0, repeat=3, stmts="", bas
 
 def time_file(filename, name="", setup="", number=0, repeat=3):
     """Open a yaml benchmark file an time each statement,
-
+    
     yields a tuple with filename, task name, time in seconds.
+
+    Parameters
+    ----------
+    filename :
+        
+    name :
+         (Default value = "")
+    setup :
+         (Default value = "")
+    number :
+         (Default value = 0)
+    repeat :
+         (Default value = 3)
+
+    Returns
+    -------
+
     """
     with open(filename, "r") as fp:
         tasks = yaml.load(fp)

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -12,13 +12,13 @@ def time_stmt(stmt="pass", setup="pass", number=0, repeat=3):
 
     Parameters
     ----------
-    stmt :
+    stmt : str
          (Default value = "pass")
-    setup :
+    setup : str
          (Default value = "pass")
-    number :
+    number : int
          (Default value = 0)
-    repeat :
+    repeat : int
          (Default value = 3)
 
     Returns

--- a/pint/__init__.py
+++ b/pint/__init__.py
@@ -61,8 +61,16 @@ def _unpickle(cls, *args):
     """Rebuild object upon unpickling.
     All units must exist in the application registry.
 
-    :param cls:
+    Parameters
+    ----------
+    cls :
         Quantity, Magnitude, or Unit
+    *args :
+        
+
+    Returns
+    -------
+
     """
     from .unit import UnitsContainer
 
@@ -81,7 +89,14 @@ def set_application_registry(registry):
     """Set the application registry, which is used for unpickling operations
     and when invoking pint.Quantity or pint.Unit directly.
 
-    :param registry: a UnitRegistry instance.
+    Parameters
+    ----------
+    registry :
+        a UnitRegistry instance.
+
+    Returns
+    -------
+
     """
     if not isinstance(registry, (LazyRegistry, UnitRegistry)):
         raise TypeError("Expected UnitRegistry; got %s" % type(registry))
@@ -95,15 +110,29 @@ def get_application_registry():
     invoked, return a registry built using :file:`defaults_en.txt` embedded in the pint
     package.
 
-    :param registry: a UnitRegistry instance.
+    Parameters
+    ----------
+    registry :
+        a UnitRegistry instance.
+
+    Returns
+    -------
+
     """
     return _APP_REGISTRY
 
 
 def test():
     """Run all tests.
-
+    
     :return: a :class:`unittest.TestResult` object
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
     from .testsuite import run
 

--- a/pint/__init__.py
+++ b/pint/__init__.py
@@ -63,13 +63,12 @@ def _unpickle(cls, *args):
 
     Parameters
     ----------
-    cls :
-        Quantity, Magnitude, or Unit
-    *args :
-        
+    cls : Quantity, Magnitude, or Unit
+    *args
 
     Returns
     -------
+    object of type cls
 
     """
     from .unit import UnitsContainer
@@ -91,11 +90,7 @@ def set_application_registry(registry):
 
     Parameters
     ----------
-    registry :
-        a UnitRegistry instance.
-
-    Returns
-    -------
+    registry : UnitRegistry
 
     """
     if not isinstance(registry, (LazyRegistry, UnitRegistry)):
@@ -110,29 +105,19 @@ def get_application_registry():
     invoked, return a registry built using :file:`defaults_en.txt` embedded in the pint
     package.
 
-    Parameters
-    ----------
-    registry :
-        a UnitRegistry instance.
-
     Returns
     -------
-
+    UnitRegistry
     """
     return _APP_REGISTRY
 
 
 def test():
     """Run all tests.
-    
-    :return: a :class:`unittest.TestResult` object
-
-    Parameters
-    ----------
 
     Returns
     -------
-
+    unittest.TestResult
     """
     from .testsuite import run
 

--- a/pint/compat.py
+++ b/pint/compat.py
@@ -153,38 +153,37 @@ if not HAS_BABEL:
 
 
 def is_upcast_type(other):
-    """check if the type object is a upcast type
+    """Check if the type object is a upcast type.
 
     Parameters
     ----------
-    other :
-        type
+    other : object
 
     Returns
     -------
-
+    bool
     """
     # Check if class name is in preset list
     return other.__name__ in ("PintArray", "Series", "DataArray")
 
 
-def eq(first, second, check_all):
-    """Comparison of scalars and arrays
+def eq(lhs, rhs, check_all):
+    """Comparison of scalars and arrays.
 
     Parameters
     ----------
-    first :
-        
-    second :
-        
-    check_all :
-        
+    lhs : object
+        left-hand side
+    rhs : object
+        right-hand side
+    check_all : bool
+        if True, reduce sequence to single bool.
 
     Returns
     -------
-
+    bool or array_like of bool
     """
-    out = first == second
+    out = lhs == rhs
     if check_all and isinstance(out, ndarray):
         return np.all(out)
     return out

--- a/pint/compat.py
+++ b/pint/compat.py
@@ -153,9 +153,16 @@ if not HAS_BABEL:
 
 
 def is_upcast_type(other):
-    """ check if the type object is a upcast type
+    """check if the type object is a upcast type
 
-    :param other: type
+    Parameters
+    ----------
+    other :
+        type
+
+    Returns
+    -------
+
     """
     # Check if class name is in preset list
     return other.__name__ in ("PintArray", "Series", "DataArray")
@@ -163,6 +170,19 @@ def is_upcast_type(other):
 
 def eq(first, second, check_all):
     """Comparison of scalars and arrays
+
+    Parameters
+    ----------
+    first :
+        
+    second :
+        
+    check_all :
+        
+
+    Returns
+    -------
+
     """
     out = first == second
     if check_all and isinstance(out, ndarray):

--- a/pint/context.py
+++ b/pint/context.py
@@ -36,8 +36,26 @@ class Context:
     """A specialized container that defines transformation functions from one
     dimension to another. Each Dimension are specified using a UnitsContainer.
     Simple transformation are given with a function taking a single parameter.
+    
+    
+    Conversion functions may take optional keyword arguments and the context
+    can have default values for these arguments.
+    
+    
+    Additionally, a context may host redefinitions:
+    
+    
+    A redefinition must be performed among units that already exist in the registry. It
+    cannot change the dimensionality of a unit. The symbol and aliases are automatically
+    inherited from the registry.
 
-        >>> from pint.util import UnitsContainer
+    Parameters
+    ----------
+
+    Returns
+    -------
+
+    >>> from pint.util import UnitsContainer
         >>> timedim = UnitsContainer({'[time]': 1})
         >>> spacedim = UnitsContainer({'[length]': 1})
         >>> def f(time):
@@ -47,10 +65,7 @@ class Context:
         >>> c.add_transformation(timedim, spacedim, f)
         >>> c.transform(timedim, spacedim, 2)
         6
-
-    Conversion functions may take optional keyword arguments and the context
-    can have default values for these arguments.
-
+    
         >>> def f(time, n):
         ...     'Time to length converter, n is the index of refraction of the material'
         ...     return 3. * time / n
@@ -58,14 +73,8 @@ class Context:
         >>> c.add_transformation(timedim, spacedim, f)
         >>> c.transform(timedim, spacedim, 2)
         2
-
-    Additionally, a context may host redefinitions:
-
+    
         >>> c.redefine("pound = 0.5 kg")
-
-    A redefinition must be performed among units that already exist in the registry. It
-    cannot change the dimensionality of a unit. The symbol and aliases are automatically
-    inherited from the registry.
     """
 
     def __init__(self, name=None, aliases=(), defaults=None):
@@ -94,8 +103,19 @@ class Context:
         """Creates a new context that shares the funcs dictionary with the
         original context. The default values are copied from the original
         context and updated with the new defaults.
-
+        
         If defaults is empty, return the same context.
+
+        Parameters
+        ----------
+        context :
+            
+        **defaults :
+            
+
+        Returns
+        -------
+
         """
         if defaults:
             newdef = dict(context.defaults, **defaults)
@@ -192,6 +212,19 @@ class Context:
 
     def add_transformation(self, src, dst, func):
         """Add a transformation function to the context.
+
+        Parameters
+        ----------
+        src :
+            
+        dst :
+            
+        func :
+            
+
+        Returns
+        -------
+
         """
         _key = self.__keytransform__(src, dst)
         self.funcs[_key] = func
@@ -199,6 +232,17 @@ class Context:
 
     def remove_transformation(self, src, dst):
         """Add a transformation function to the context.
+
+        Parameters
+        ----------
+        src :
+            
+        dst :
+            
+
+        Returns
+        -------
+
         """
         _key = self.__keytransform__(src, dst)
         del self.funcs[_key]
@@ -210,6 +254,21 @@ class Context:
 
     def transform(self, src, dst, registry, value):
         """Transform a value.
+
+        Parameters
+        ----------
+        src :
+            
+        dst :
+            
+        registry :
+            
+        value :
+            
+
+        Returns
+        -------
+
         """
         _key = self.__keytransform__(src, dst)
         return self.funcs[_key](registry, value, **self.defaults)
@@ -217,8 +276,16 @@ class Context:
     def redefine(self, definition: str) -> None:
         """Override the definition of a unit in the registry.
 
-        :param definition:
-            ``<unit> = <new definition>``, e.g. ``pound = 0.5 kg``
+        Parameters
+        ----------
+        definition :
+            unit> = <new definition>``, e.g. ``pound = 0.5 kg``
+        definition: str :
+            
+
+        Returns
+        -------
+
         """
         for line in definition.splitlines():
             d = Definition.from_string(line)
@@ -238,6 +305,13 @@ class Context:
         """Generate a unique hashable and comparable representation of self, which can
         be used as a key in a dict. This class cannot define ``__hash__`` because it is
         mutable, and the Python interpreter does cache the output of ``__hash__``.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         return (
             self.name,
@@ -251,6 +325,13 @@ class Context:
 class ContextChain(ChainMap):
     """A specialized ChainMap for contexts that simplifies finding rules
     to transform from one dimension to another.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __init__(self):
@@ -262,9 +343,18 @@ class ContextChain(ChainMap):
     def insert_contexts(self, *contexts):
         """Insert one or more contexts in reversed order the chained map.
         (A rule in last context will take precedence)
-
+        
         To facilitate the identification of the context with the matching rule,
         the *relation_to_context* dictionary of the context is used.
+
+        Parameters
+        ----------
+        *contexts :
+            
+
+        Returns
+        -------
+
         """
         self.contexts = list(reversed(contexts)) + self.contexts
         self.maps = [ctx.relation_to_context for ctx in reversed(contexts)] + self.maps
@@ -272,6 +362,15 @@ class ContextChain(ChainMap):
 
     def remove_contexts(self, n: int = None):
         """Remove the last n inserted contexts from the chain.
+
+        Parameters
+        ----------
+        n: int :
+             (Default value = None)
+
+        Returns
+        -------
+
         """
         del self.contexts[:n]
         del self.maps[:n]
@@ -285,8 +384,7 @@ class ContextChain(ChainMap):
 
     @property
     def graph(self):
-        """The graph relating
-        """
+        """The graph relating"""
         if self._graph is None:
             self._graph = defaultdict(set)
             for fr_, to_ in self:
@@ -297,7 +395,20 @@ class ContextChain(ChainMap):
         """Transform the value, finding the rule in the chained context.
         (A rule in last context will take precedence)
 
-        :raises: KeyError if the rule is not found.
+        Parameters
+        ----------
+        src :
+            
+        dst :
+            
+        registry :
+            
+        value :
+            
+
+        Returns
+        -------
+
         """
         return self[(src, dst)].transform(src, dst, registry, value)
 
@@ -305,5 +416,12 @@ class ContextChain(ChainMap):
         """Generate a unique hashable and comparable representation of self, which can
         be used as a key in a dict. This class cannot define ``__hash__`` because it is
         mutable, and the Python interpreter does cache the output of ``__hash__``.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         return tuple(ctx.hashable() for ctx in self.contexts)

--- a/pint/context.py
+++ b/pint/context.py
@@ -36,15 +36,15 @@ class Context:
     """A specialized container that defines transformation functions from one
     dimension to another. Each Dimension are specified using a UnitsContainer.
     Simple transformation are given with a function taking a single parameter.
-    
+
 
     Conversion functions may take optional keyword arguments and the context
     can have default values for these arguments.
-    
-    
+
+
     Additionally, a context may host redefinitions:
-    
-    
+
+
     A redefinition must be performed among units that already exist in the registry. It
     cannot change the dimensionality of a unit. The symbol and aliases are automatically
     inherited from the registry.
@@ -108,7 +108,7 @@ class Context:
         """Creates a new context that shares the funcs dictionary with the
         original context. The default values are copied from the original
         context and updated with the new defaults.
-        
+
         If defaults is empty, return the same context.
 
         Parameters
@@ -116,7 +116,7 @@ class Context:
         context : Context
             Original context.
         **defaults
-            
+
 
         Returns
         -------
@@ -298,7 +298,7 @@ class ContextChain(ChainMap):
     def insert_contexts(self, *contexts):
         """Insert one or more contexts in reversed order the chained map.
         (A rule in last context will take precedence)
-        
+
         To facilitate the identification of the context with the matching rule,
         the *relation_to_context* dictionary of the context is used.
         """

--- a/pint/converters.py
+++ b/pint/converters.py
@@ -22,7 +22,7 @@ class Converter:
 
 
 class ScaleConverter(Converter):
-    """A linear transformation"""
+    """A linear transformation."""
 
     is_multiplicative = True
 
@@ -47,7 +47,7 @@ class ScaleConverter(Converter):
 
 
 class OffsetConverter(Converter):
-    """An affine transformation"""
+    """An affine transformation."""
 
     def __init__(self, scale, offset):
         self.scale = scale

--- a/pint/converters.py
+++ b/pint/converters.py
@@ -10,8 +10,7 @@
 
 
 class Converter:
-    """Base class for value converters.
-    """
+    """Base class for value converters."""
 
     is_multiplicative = True
 
@@ -23,8 +22,7 @@ class Converter:
 
 
 class ScaleConverter(Converter):
-    """A linear transformation
-    """
+    """A linear transformation"""
 
     is_multiplicative = True
 
@@ -49,8 +47,7 @@ class ScaleConverter(Converter):
 
 
 class OffsetConverter(Converter):
-    """An affine transformation
-    """
+    """An affine transformation"""
 
     def __init__(self, scale, offset):
         self.scale = scale

--- a/pint/definitions.py
+++ b/pint/definitions.py
@@ -30,10 +30,20 @@ def numeric_parse(s):
 class Definition:
     """Base class for definitions.
 
-    :param name: name.
-    :param symbol: a short name or symbol for the definition
-    :param aliases: iterable of other names.
-    :param converter: an instance of Converter.
+    Parameters
+    ----------
+    name :
+        name.
+    symbol :
+        a short name or symbol for the definition
+    aliases :
+        iterable of other names.
+    converter :
+        an instance of Converter.
+
+    Returns
+    -------
+
     """
 
     def __init__(self, name, symbol, aliases, converter):
@@ -49,6 +59,15 @@ class Definition:
     @classmethod
     def from_string(cls, definition):
         """Parse a definition
+
+        Parameters
+        ----------
+        definition :
+            
+
+        Returns
+        -------
+
         """
         name, definition = definition.split("=", 1)
         name = name.strip()
@@ -103,8 +122,7 @@ class Definition:
 
 
 class PrefixDefinition(Definition):
-    """Definition of a prefix.
-    """
+    """Definition of a prefix."""
 
     def __init__(self, name, symbol, aliases, converter):
         if isinstance(converter, str):
@@ -124,8 +142,16 @@ class PrefixDefinition(Definition):
 class UnitDefinition(Definition):
     """Definition of a unit.
 
-    :param reference: Units container with reference units.
-    :param is_base: indicates if it is a base unit.
+    Parameters
+    ----------
+    reference :
+        Units container with reference units.
+    is_base :
+        indicates if it is a base unit.
+
+    Returns
+    -------
+
     """
 
     def __init__(self, name, symbol, aliases, converter, reference=None, is_base=False):
@@ -171,8 +197,7 @@ class UnitDefinition(Definition):
 
 
 class DimensionDefinition(Definition):
-    """Definition of a dimension.
-    """
+    """Definition of a dimension."""
 
     def __init__(self, name, symbol, aliases, converter, reference=None, is_base=False):
         self.reference = reference
@@ -195,8 +220,7 @@ class DimensionDefinition(Definition):
 
 
 class AliasDefinition(Definition):
-    """Additional alias(es) for an already existing unit
-    """
+    """Additional alias(es) for an already existing unit"""
 
     def __init__(self, name, aliases):
         super().__init__(name=name, symbol=None, aliases=aliases, converter=None)

--- a/pint/definitions.py
+++ b/pint/definitions.py
@@ -59,7 +59,7 @@ class Definition:
         Parameters
         ----------
         definition :
-            
+
 
         Returns
         -------

--- a/pint/definitions.py
+++ b/pint/definitions.py
@@ -32,18 +32,14 @@ class Definition:
 
     Parameters
     ----------
-    name :
-        name.
-    symbol :
-        a short name or symbol for the definition
-    aliases :
-        iterable of other names.
-    converter :
+    name : str
+        Canonical name of the unit/prefix/etc.
+    symbol : str or None
+        A short name or symbol for the definition.
+    aliases : iterable of str
+        Other names for the unit/prefix/etc.
+    converter : callable
         an instance of Converter.
-
-    Returns
-    -------
-
     """
 
     def __init__(self, name, symbol, aliases, converter):
@@ -144,13 +140,10 @@ class UnitDefinition(Definition):
 
     Parameters
     ----------
-    reference :
-        Units container with reference units.
-    is_base :
-        indicates if it is a base unit.
-
-    Returns
-    -------
+    reference : UnitsContainer
+        Reference units.
+    is_base : bool
+        Indicates if it is a base unit.
 
     """
 

--- a/pint/errors.py
+++ b/pint/errors.py
@@ -21,8 +21,7 @@ def _file_prefix(filename=None, lineno=None):
 
 
 class DefinitionSyntaxError(SyntaxError):
-    """Raised when a textual definition has a syntax error.
-    """
+    """ """
 
     def __init__(self, msg, *, filename=None, lineno=None):
         super().__init__(msg)
@@ -44,8 +43,7 @@ class DefinitionSyntaxError(SyntaxError):
 
 
 class RedefinitionError(ValueError):
-    """Raised when a unit or prefix is redefined.
-    """
+    """ """
 
     def __init__(self, name, definition_type, *, filename=None, lineno=None):
         super().__init__(name, definition_type)
@@ -61,8 +59,7 @@ class RedefinitionError(ValueError):
 
 
 class UndefinedUnitError(AttributeError):
-    """Raised when the units are not defined in the unit registry.
-    """
+    """ """
 
     def __init__(self, *unit_names):
         if len(unit_names) == 1 and not isinstance(unit_names[0], str):
@@ -80,8 +77,7 @@ class PintTypeError(TypeError):
 
 
 class DimensionalityError(PintTypeError):
-    """Raised when trying to convert between incompatible units.
-    """
+    """ """
 
     def __init__(self, units1, units2, dim1="", dim2="", *, extra_msg=""):
         super().__init__()
@@ -109,8 +105,7 @@ class DimensionalityError(PintTypeError):
 
 
 class OffsetUnitCalculusError(PintTypeError):
-    """Raised on ambiguous operations with offset units.
-    """
+    """ """
 
     def __str__(self):
         return (

--- a/pint/errors.py
+++ b/pint/errors.py
@@ -21,7 +21,7 @@ def _file_prefix(filename=None, lineno=None):
 
 
 class DefinitionSyntaxError(SyntaxError):
-    """ """
+    """Raised when a textual definition has a syntax error."""
 
     def __init__(self, msg, *, filename=None, lineno=None):
         super().__init__(msg)
@@ -43,7 +43,7 @@ class DefinitionSyntaxError(SyntaxError):
 
 
 class RedefinitionError(ValueError):
-    """ """
+    """Raised when a unit or prefix is redefined."""
 
     def __init__(self, name, definition_type, *, filename=None, lineno=None):
         super().__init__(name, definition_type)
@@ -59,7 +59,7 @@ class RedefinitionError(ValueError):
 
 
 class UndefinedUnitError(AttributeError):
-    """ """
+    """Raised when the units are not defined in the unit registry."""
 
     def __init__(self, *unit_names):
         if len(unit_names) == 1 and not isinstance(unit_names[0], str):
@@ -77,7 +77,7 @@ class PintTypeError(TypeError):
 
 
 class DimensionalityError(PintTypeError):
-    """ """
+    """Raised when trying to convert between incompatible units."""
 
     def __init__(self, units1, units2, dim1="", dim2="", *, extra_msg=""):
         super().__init__()
@@ -105,7 +105,7 @@ class DimensionalityError(PintTypeError):
 
 
 class OffsetUnitCalculusError(PintTypeError):
-    """ """
+    """Raised on ambiguous operations with offset units."""
 
     def __str__(self):
         return (

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -18,10 +18,21 @@ __JOIN_REG_EXP = re.compile(r"\{\d*\}")
 
 def _join(fmt, iterable):
     """Join an iterable with the format specified in fmt.
-
+    
     The format can be specified in two ways:
     - PEP3101 format with two replacement fields (eg. '{} * {}')
     - The concatenating string (eg. ' * ')
+
+    Parameters
+    ----------
+    fmt :
+        
+    iterable :
+        
+
+    Returns
+    -------
+
     """
     if not iterable:
         return ""
@@ -40,6 +51,15 @@ _PRETTY_EXPONENTS = "⁰¹²³⁴⁵⁶⁷⁸⁹"
 
 def _pretty_fmt_exponent(num):
     """Format an number into a pretty printed exponent.
+
+    Parameters
+    ----------
+    num :
+        
+
+    Returns
+    -------
+
     """
     # TODO: Will not work for decimals
     ret = f"{num:n}".replace("-", "⁻")
@@ -110,19 +130,37 @@ def formatter(
 ):
     """Format a list of (name, exponent) pairs.
 
-    :param items: a list of (name, exponent) pairs.
-    :param as_ratio: True to display as ratio, False as negative powers.
-    :param single_denominator: all with terms with negative exponents are
-                               collected together.
-    :param product_fmt: the format used for multiplication.
-    :param division_fmt: the format used for division.
-    :param power_fmt: the format used for exponentiation.
-    :param parentheses_fmt: the format used for parenthesis.
-    :param locale: the locale object as defined in babel.
-    :param babel_length: the length of the translated unit, as defined in babel cldr.
-    :param babel_plural_form: the plural form, calculated as defined in babel.
+    Parameters
+    ----------
+    items :
+        a list of (name, exponent) pairs.
+    as_ratio :
+        True to display as ratio, False as negative powers. (Default value = True)
+    single_denominator :
+        all with terms with negative exponents are
+        collected together. (Default value = False)
+    product_fmt :
+        the format used for multiplication. (Default value = " * ")
+    division_fmt :
+        the format used for division. (Default value = " / ")
+    power_fmt :
+        the format used for exponentiation. (Default value = "{} ** {}")
+    parentheses_fmt :
+        the format used for parenthesis. (Default value = "({0})")
+    locale :
+        the locale object as defined in babel. (Default value = None)
+    babel_length :
+        the length of the translated unit, as defined in babel cldr. (Default value = "long")
+    babel_plural_form :
+        the plural form, calculated as defined in babel. (Default value = "one")
+    exp_call :
+         (Default value = lambda x: f"{x:n}")
 
-    :return: the formula as a string.
+    Returns
+    -------
+    type
+        the formula as a string.
+
     """
 
     if not items:
@@ -240,7 +278,17 @@ def format_unit(unit, spec, **kwspec):
 
 
 def siunitx_format_unit(units):
-    """Returns LaTeX code for the unit that can be put into an siunitx command."""
+    """Returns LaTeX code for the unit that can be put into an siunitx command.
+
+    Parameters
+    ----------
+    units :
+        
+
+    Returns
+    -------
+
+    """
     # NOTE: unit registry is required to identify unit prefixes.
     registry = units._REGISTRY
 

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -18,7 +18,7 @@ __JOIN_REG_EXP = re.compile(r"\{\d*\}")
 
 def _join(fmt, iterable):
     """Join an iterable with the format specified in fmt.
-    
+
     The format can be specified in two ways:
     - PEP3101 format with two replacement fields (eg. '{} * {}')
     - The concatenating string (eg. ' * ')
@@ -26,9 +26,9 @@ def _join(fmt, iterable):
     Parameters
     ----------
     fmt : str
-        
+
     iterable :
-        
+
 
     Returns
     -------

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -25,13 +25,14 @@ def _join(fmt, iterable):
 
     Parameters
     ----------
-    fmt :
+    fmt : str
         
     iterable :
         
 
     Returns
     -------
+    str
 
     """
     if not iterable:
@@ -54,11 +55,11 @@ def _pretty_fmt_exponent(num):
 
     Parameters
     ----------
-    num :
-        
+    num : int
 
     Returns
     -------
+    str
 
     """
     # TODO: Will not work for decimals
@@ -132,33 +133,33 @@ def formatter(
 
     Parameters
     ----------
-    items :
+    items : list
         a list of (name, exponent) pairs.
-    as_ratio :
+    as_ratio : bool, optional
         True to display as ratio, False as negative powers. (Default value = True)
-    single_denominator :
+    single_denominator : bool, optional
         all with terms with negative exponents are
         collected together. (Default value = False)
-    product_fmt :
+    product_fmt : str
         the format used for multiplication. (Default value = " * ")
-    division_fmt :
+    division_fmt : str
         the format used for division. (Default value = " / ")
-    power_fmt :
+    power_fmt : str
         the format used for exponentiation. (Default value = "{} ** {}")
-    parentheses_fmt :
+    parentheses_fmt : str
         the format used for parenthesis. (Default value = "({0})")
-    locale :
+    locale : str
         the locale object as defined in babel. (Default value = None)
-    babel_length :
+    babel_length : str
         the length of the translated unit, as defined in babel cldr. (Default value = "long")
-    babel_plural_form :
+    babel_plural_form : str
         the plural form, calculated as defined in babel. (Default value = "one")
-    exp_call :
+    exp_call : callable
          (Default value = lambda x: f"{x:n}")
 
     Returns
     -------
-    type
+    str
         the formula as a string.
 
     """
@@ -279,16 +280,8 @@ def format_unit(unit, spec, **kwspec):
 
 def siunitx_format_unit(units):
     """Returns LaTeX code for the unit that can be put into an siunitx command.
-
-    Parameters
-    ----------
-    units :
-        
-
-    Returns
-    -------
-
     """
+
     # NOTE: unit registry is required to identify unit prefixes.
     registry = units._REGISTRY
 

--- a/pint/matplotlib.py
+++ b/pint/matplotlib.py
@@ -31,19 +31,6 @@ class PintConverter(matplotlib.units.ConversionInterface):
 
     def convert(self, value, unit, axis):
         """Convert :`Quantity` instances for matplotlib to use.
-
-        Parameters
-        ----------
-        value :
-            
-        unit :
-            
-        axis :
-            
-
-        Returns
-        -------
-
         """
         if iterable(value):
             return [self._convert_value(v, unit, axis) for v in value]
@@ -52,19 +39,6 @@ class PintConverter(matplotlib.units.ConversionInterface):
 
     def _convert_value(self, value, unit, axis):
         """Handle converting using attached unit or falling back to axis units.
-
-        Parameters
-        ----------
-        value :
-            
-        unit :
-            
-        axis :
-            
-
-        Returns
-        -------
-
         """
         if hasattr(value, "units"):
             return value.to(unit).magnitude
@@ -73,37 +47,13 @@ class PintConverter(matplotlib.units.ConversionInterface):
 
     @staticmethod
     def axisinfo(unit, axis):
-        """
+        """Return axis information for this particular unit."""
 
-        Parameters
-        ----------
-        unit :
-            
-        axis :
-            
-
-        Returns
-        -------
-        type
-            
-
-        """
         return PintAxisInfo(unit)
 
     @staticmethod
     def default_units(x, axis):
         """Get the default unit to use for the given combination of unit and axis.
-
-        Parameters
-        ----------
-        x :
-            
-        axis :
-            
-
-        Returns
-        -------
-
         """
         if iterable(x) and sized(x):
             return getattr(x[0], "units", None)
@@ -116,9 +66,9 @@ def setup_matplotlib_handlers(registry, enable):
     Parameters
     ----------
     registry : UnitRegistry
-        the registry that will be used
+        The registry that will be used.
     enable : bool
-        whether support should be enabled or disabled
+        Whether support should be enabled or disabled.
 
     Returns
     -------

--- a/pint/matplotlib.py
+++ b/pint/matplotlib.py
@@ -30,14 +30,42 @@ class PintConverter(matplotlib.units.ConversionInterface):
         self._reg = registry
 
     def convert(self, value, unit, axis):
-        """Convert :`Quantity` instances for matplotlib to use."""
+        """Convert :`Quantity` instances for matplotlib to use.
+
+        Parameters
+        ----------
+        value :
+            
+        unit :
+            
+        axis :
+            
+
+        Returns
+        -------
+
+        """
         if iterable(value):
             return [self._convert_value(v, unit, axis) for v in value]
         else:
             return self._convert_value(value, unit, axis)
 
     def _convert_value(self, value, unit, axis):
-        """Handle converting using attached unit or falling back to axis units."""
+        """Handle converting using attached unit or falling back to axis units.
+
+        Parameters
+        ----------
+        value :
+            
+        unit :
+            
+        axis :
+            
+
+        Returns
+        -------
+
+        """
         if hasattr(value, "units"):
             return value.to(unit).magnitude
         else:
@@ -45,12 +73,38 @@ class PintConverter(matplotlib.units.ConversionInterface):
 
     @staticmethod
     def axisinfo(unit, axis):
-        """Return axis information for this particular unit."""
+        """
+
+        Parameters
+        ----------
+        unit :
+            
+        axis :
+            
+
+        Returns
+        -------
+        type
+            
+
+        """
         return PintAxisInfo(unit)
 
     @staticmethod
     def default_units(x, axis):
-        """Get the default unit to use for the given combination of unit and axis."""
+        """Get the default unit to use for the given combination of unit and axis.
+
+        Parameters
+        ----------
+        x :
+            
+        axis :
+            
+
+        Returns
+        -------
+
+        """
         if iterable(x) and sized(x):
             return getattr(x[0], "units", None)
         return getattr(x, "units", None)
@@ -58,10 +112,17 @@ class PintConverter(matplotlib.units.ConversionInterface):
 
 def setup_matplotlib_handlers(registry, enable):
     """Set up matplotlib's unit support to handle units from a registry.
-       :param registry: the registry that will be used
-       :type registry: UnitRegistry
-       :param enable: whether support should be enabled or disabled
-       :type enable: bool
+
+    Parameters
+    ----------
+    registry : UnitRegistry
+        the registry that will be used
+    enable : bool
+        whether support should be enabled or disabled
+
+    Returns
+    -------
+
     """
     if matplotlib.__version__ < "2.0":
         raise RuntimeError("Matplotlib >= 2.0 required to work with pint.")

--- a/pint/measurement.py
+++ b/pint/measurement.py
@@ -17,10 +17,16 @@ MISSING = object()
 class Measurement(Quantity):
     """Implements a class to describe a quantity with uncertainty.
 
-    :param value: The expected value of the measurement
-    :type value: pint.Quantity or any numeric type
-    :param error: The error or uncertainty of the measurement
-    :type error: pint.Quantity or any numeric type
+    Parameters
+    ----------
+    value : pint.Quantity or any numeric type
+        The expected value of the measurement
+    error : pint.Quantity or any numeric type
+        The error or uncertainty of the measurement
+
+    Returns
+    -------
+
     """
 
     def __new__(cls, value, error, units=MISSING):

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -23,13 +23,13 @@ HANDLED_FUNCTIONS = {}
 
 def _is_quantity(obj):
     """Test for _units and _magnitude attrs.
-    
+
     This is done in place of isinstance(Quantity, arg), which would cause a circular import.
 
     Parameters
     ----------
     obj : Object
-        
+
 
     Returns
     -------
@@ -44,7 +44,7 @@ def _is_quantity_sequence(obj):
     Parameters
     ----------
     obj : object
-        
+
 
     Returns
     -------
@@ -71,7 +71,7 @@ def _get_first_input_units(args, kwargs=None):
 
 def convert_arg(arg, pre_calc_units):
     """Convert quantities and sequences of quantities to pre_calc_units and strip units.
-    
+
     Helper function for convert_to_consistent_units. pre_calc_units must be given as a pint
     Unit or None.
 
@@ -96,7 +96,7 @@ def convert_arg(arg, pre_calc_units):
 
 def convert_to_consistent_units(*args, pre_calc_units=None, **kwargs):
     """Prepare args and kwargs for wrapping by unit conversion and stripping.
-    
+
     If pre_calc_units is not None, takes the args and kwargs for a NumPy function and converts
     any Quantity or Sequence of Quantities into the units of the first Quantiy/Sequence of
     Quantities and returns the magnitudes. Other args/kwargs are treated as dimensionless
@@ -114,7 +114,7 @@ def convert_to_consistent_units(*args, pre_calc_units=None, **kwargs):
 
 def unwrap_and_wrap_consistent_units(*args):
     """Strip units from args while providing a rewrapping function.
-    
+
     Returns the given args as parsed by convert_to_consistent_units assuming units of
     first arg with units, along with a wrapper to restore that unit to the output.
 
@@ -129,9 +129,9 @@ def unwrap_and_wrap_consistent_units(*args):
 
 def get_op_output_unit(unit_op, first_input_units, all_args=None, size=None):
     """Determine resulting unit from given operation.
-    
+
     Options for `unit_op`:
-    
+
     - "sum": `first_input_units`, unless non-multiplicative, which raises
       OffsetUnitCalculusError
     - "mul": product of all units in `all_args`
@@ -149,9 +149,9 @@ def get_op_output_unit(unit_op, first_input_units, all_args=None, size=None):
     Parameters
     ----------
     unit_op :
-        
+
     first_input_units :
-        
+
     all_args :
          (Default value = None)
     size :
@@ -249,7 +249,7 @@ def implement_func(func_type, func_str, input_units=None, output_unit=None):
         `get_op_output_unit`. If some other string, the string is parsed as a unit,
         which becomes the unit of the output. If None, the bare magnitude is returned.
 
-    
+
     """
     # If NumPy is not available, do not attempt implement that which does not exist
     if np is None:

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -23,14 +23,33 @@ HANDLED_FUNCTIONS = {}
 
 def _is_quantity(arg):
     """Test for _units and _magnitude attrs.
-
+    
     This is done in place of isinstance(Quantity, arg), which would cause a circular import.
+
+    Parameters
+    ----------
+    arg :
+        
+
+    Returns
+    -------
+
     """
     return hasattr(arg, "_units") and hasattr(arg, "_magnitude")
 
 
 def _is_quantity_sequence(arg):
-    """Test for sequences of quantities."""
+    """Test for sequences of quantities.
+
+    Parameters
+    ----------
+    arg :
+        
+
+    Returns
+    -------
+
+    """
     return (
         iterable(arg)
         and sized(arg)
@@ -40,7 +59,19 @@ def _is_quantity_sequence(arg):
 
 
 def _get_first_input_units(args, kwargs={}):
-    """Obtain the first valid unit from a collection of args and kwargs."""
+    """Obtain the first valid unit from a collection of args and kwargs.
+
+    Parameters
+    ----------
+    args :
+        
+    kwargs :
+         (Default value = {})
+
+    Returns
+    -------
+
+    """
     for arg in chain(args, kwargs.values()):
         if _is_quantity(arg):
             return arg.units
@@ -50,9 +81,20 @@ def _get_first_input_units(args, kwargs={}):
 
 def convert_arg(arg, pre_calc_units):
     """Convert quantities and sequences of quantities to pre_calc_units and strip units.
-
+    
     Helper function for convert_to_consistent_units. pre_calc_units must be given as a pint
     Unit or None.
+
+    Parameters
+    ----------
+    arg :
+        
+    pre_calc_units :
+        
+
+    Returns
+    -------
+
     """
     if pre_calc_units is not None:
         if _is_quantity(arg):
@@ -74,11 +116,24 @@ def convert_arg(arg, pre_calc_units):
 
 def convert_to_consistent_units(*args, pre_calc_units=None, **kwargs):
     """Prepare args and kwargs for wrapping by unit conversion and stripping.
-
+    
     If pre_calc_units is not None, takes the args and kwargs for a NumPy function and converts
     any Quantity or Sequence of Quantities into the units of the first Quantiy/Sequence of
     Quantities and returns the magnitudes. Other args/kwargs are treated as dimensionless
     Quantities. If pre_calc_units is None, units are simply stripped.
+
+    Parameters
+    ----------
+    *args :
+        
+    pre_calc_units :
+         (Default value = None)
+    **kwargs :
+        
+
+    Returns
+    -------
+
     """
     return (
         tuple(convert_arg(arg, pre_calc_units=pre_calc_units) for arg in args),
@@ -91,9 +146,18 @@ def convert_to_consistent_units(*args, pre_calc_units=None, **kwargs):
 
 def unwrap_and_wrap_consistent_units(*args):
     """Strip units from args while providing a rewrapping function.
-
+    
     Returns the given args as parsed by convert_to_consistent_units assuming units of
     first arg with units, along with a wrapper to restore that unit to the output.
+
+    Parameters
+    ----------
+    *args :
+        
+
+    Returns
+    -------
+
     """
     first_input_units = _get_first_input_units(args)
     args, _ = convert_to_consistent_units(*args, pre_calc_units=first_input_units)
@@ -105,9 +169,9 @@ def unwrap_and_wrap_consistent_units(*args):
 
 def get_op_output_unit(unit_op, first_input_units, all_args=[], size=None):
     """Determine resulting unit from given operation.
-
+    
     Options for `unit_op`:
-
+    
     - "sum": `first_input_units`, unless non-multiplicative, which raises
       OffsetUnitCalculusError
     - "mul": product of all units in `all_args`
@@ -121,6 +185,21 @@ def get_op_output_unit(unit_op, first_input_units, all_args=[], size=None):
     - "sqrt": square root of `first_input_units`
     - "reciprocal": reciprocal of `first_input_units`
     - "size": `first_input_units` raised to the power of `size`
+
+    Parameters
+    ----------
+    unit_op :
+        
+    first_input_units :
+        
+    all_args :
+         (Default value = [])
+    size :
+         (Default value = None)
+
+    Returns
+    -------
+
     """
     if unit_op == "sum":
         result_unit = (1 * first_input_units + 1 * first_input_units).units
@@ -169,6 +248,17 @@ def get_op_output_unit(unit_op, first_input_units, all_args=[], size=None):
 def implements(numpy_func_string, func_type):
     """Register an __array_function__/__array_ufunc__ implementation for Quantity
     objects.
+
+    Parameters
+    ----------
+    numpy_func_string :
+        
+    func_type :
+        
+
+    Returns
+    -------
+
     """
 
     def decorator(func):
@@ -188,25 +278,19 @@ def implement_func(func_type, func_str, input_units=None, output_unit=None):
 
     Parameters
     ----------
-    func_type : str
-        "function" for NumPy functions, "ufunc" for NumPy ufuncs
-    func_str : str
-        String representing the name of the NumPy function/ufunc to add
-    input_units : pint.Unit or str or None
-        Parameter to control how the function downcasts to magnitudes of arguments. If
-        `pint.Unit`, converts all args and kwargs to this unit before downcasting to
-        magnitude. If "all_consistent", converts all args and kwargs to the unit of the
-        first Quantity in args and kwargs before downcasting to magnitude. If some
-        other string, the string is parsed as a unit, and all args and kwargs are
-        converted to that unit. If None, units are stripped without conversion.
-    output_unit : pint.Unit or str or None
-        Parameter to control the unit of the output. If `pint.Unit`, output is wrapped
-        with that unit. If "match_input", output is wrapped with the unit of the first
-        Quantity in args and kwargs. If a string representing a unit operation defined
-        in `get_op_output_unit`, output is wrapped by the unit determined by
-        `get_op_output_unit`. If some other string, the string is parsed as a unit,
-        which becomes the unit of the output. If None, the bare magnitude is returned.
+    func_type :
+        
+    func_str :
+        
+    input_units :
+         (Default value = None)
+    output_unit :
+         (Default value = None)
 
+    Returns
+    -------
+
+    
     """
     # If NumPy is not available, do not attempt implement that which does not exist
     if np is None:
@@ -797,7 +881,27 @@ for func_str in ["var", "nanvar"]:
 
 
 def numpy_wrap(func_type, func, args, kwargs, types):
-    """Return the result from a NumPy function/ufunc as wrapped by Pint."""
+    """
+
+    Parameters
+    ----------
+    func_type :
+        
+    func :
+        
+    args :
+        
+    kwargs :
+        
+    types :
+        
+
+    Returns
+    -------
+    type
+        
+
+    """
     if func_type == "function":
         handled = HANDLED_FUNCTIONS
     elif func_type == "ufunc":

--- a/pint/pint_eval.py
+++ b/pint/pint_eval.py
@@ -39,12 +39,18 @@ _UNARY_OPERATOR_MAP = {"+": lambda x: x, "-": lambda x: x * -1}
 
 class EvalTreeNode:
     def __init__(self, left, operator=None, right=None):
-        """
-        left + operator + right --> binary op
+    """left + operator + right --> binary op
         left + operator --> unary op
         left + right --> implicit op
         left --> single value
-        """
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
+    """
         self.left = left
         self.operator = operator
         self.right = right
@@ -65,9 +71,21 @@ class EvalTreeNode:
     def evaluate(
         self, define_op, bin_op=_BINARY_OPERATOR_MAP, un_op=_UNARY_OPERATOR_MAP
     ):
-        """
-        define_op is a callable that translates tokens into objects
+        """define_op is a callable that translates tokens into objects
         bin_op and un_op provide functions for performing binary and unary operations
+
+        Parameters
+        ----------
+        define_op :
+            
+        bin_op :
+             (Default value = _BINARY_OPERATOR_MAP)
+        un_op :
+             (Default value = _UNARY_OPERATOR_MAP)
+
+        Returns
+        -------
+
         """
 
         if self.right:
@@ -90,22 +108,49 @@ class EvalTreeNode:
 
 def build_eval_tree(tokens, op_priority=_OP_PRIORITY, index=0, depth=0, prev_op=None):
     """
-    Params:
-    Index, depth, and prev_op used recursively, so don't touch.
-    Tokens is an iterable of tokens from an expression to be evaluated.
 
-    Transform the tokens from an expression into a recursive parse tree, following order
-    of operations. Operations can include binary ops (3 + 4), implicit ops (3 kg), or
-    unary ops (-1).
+    Parameters
+    ----------
+    Index :
+        depth
+    Tokens :
+        is an iterable of tokens from an expression to be evaluated
+    Transform :
+        the tokens from an expression into a recursive parse tree
+    of :
+        operations
+    unary :
+        ops
+    General :
+        Strategy
+    1 :
+        Get left side of operator
+    2 :
+        If no tokens left
+    3 :
+        Get operator
+    4 :
+        Use recursion to create tree starting at token on right side of operator
+    4 :
+        
+    5 :
+        Combine left side
+    6 :
+        Go back to step
+    tokens :
+        
+    op_priority :
+         (Default value = _OP_PRIORITY)
+    index :
+         (Default value = 0)
+    depth :
+         (Default value = 0)
+    prev_op :
+         (Default value = None)
 
-    General Strategy:
-    1) Get left side of operator
-    2) If no tokens left, return final result
-    3) Get operator
-    4) Use recursion to create tree starting at token on right side of operator (start at step #1)
-    4.1) If recursive call encounters an operator with lower or equal priority to step #2, exit recursion
-    5) Combine left side, operator, and right side into a new left side
-    6) Go back to step #2
+    Returns
+    -------
+
     """
 
     if depth == 0 and prev_op is None:

--- a/pint/pint_eval.py
+++ b/pint/pint_eval.py
@@ -38,19 +38,15 @@ _UNARY_OPERATOR_MAP = {"+": lambda x: x, "-": lambda x: x * -1}
 
 
 class EvalTreeNode:
-    def __init__(self, left, operator=None, right=None):
-    """left + operator + right --> binary op
-        left + operator --> unary op
-        left + right --> implicit op
-        left --> single value
+    """Single node within an evaluation tree
 
-    Parameters
-    ----------
-
-    Returns
-    -------
-
+    left + operator + right --> binary op
+    left + operator --> unary op
+    left + right --> implicit op
+    left --> single value
     """
+
+    def __init__(self, left, operator=None, right=None):
         self.left = left
         self.operator = operator
         self.right = right
@@ -68,25 +64,25 @@ class EvalTreeNode:
             return self.left[1]
         return "(%s)" % " ".join(comps)
 
-    def evaluate(
-        self, define_op, bin_op=_BINARY_OPERATOR_MAP, un_op=_UNARY_OPERATOR_MAP
-    ):
-        """define_op is a callable that translates tokens into objects
-        bin_op and un_op provide functions for performing binary and unary operations
+    def evaluate(self, define_op, bin_op=None, un_op=None):
+        """Evaluate node.
 
         Parameters
         ----------
-        define_op :
-            
-        bin_op :
+        define_op : callable
+            Translates tokens into objects.
+        bin_op : dict or None, optional
              (Default value = _BINARY_OPERATOR_MAP)
-        un_op :
+        un_op : dict or None, optional
              (Default value = _UNARY_OPERATOR_MAP)
 
         Returns
         -------
 
         """
+
+        bin_op = bin_op or _BINARY_OPERATOR_MAP
+        un_op = un_op or _UNARY_OPERATOR_MAP
 
         if self.right:
             # binary or implicit operator
@@ -107,49 +103,24 @@ class EvalTreeNode:
 
 
 def build_eval_tree(tokens, op_priority=_OP_PRIORITY, index=0, depth=0, prev_op=None):
-    """
+    """Build an evaluation tree from a set of tokens.
 
-    Parameters
-    ----------
-    Index :
-        depth
-    Tokens :
-        is an iterable of tokens from an expression to be evaluated
-    Transform :
-        the tokens from an expression into a recursive parse tree
-    of :
-        operations
-    unary :
-        ops
-    General :
-        Strategy
-    1 :
-        Get left side of operator
-    2 :
-        If no tokens left
-    3 :
-        Get operator
-    4 :
-        Use recursion to create tree starting at token on right side of operator
-    4 :
-        
-    5 :
-        Combine left side
-    6 :
-        Go back to step
-    tokens :
-        
-    op_priority :
-         (Default value = _OP_PRIORITY)
-    index :
-         (Default value = 0)
-    depth :
-         (Default value = 0)
-    prev_op :
-         (Default value = None)
+    Params:
+    Index, depth, and prev_op used recursively, so don't touch.
+    Tokens is an iterable of tokens from an expression to be evaluated.
 
-    Returns
-    -------
+    Transform the tokens from an expression into a recursive parse tree, following order
+    of operations. Operations can include binary ops (3 + 4), implicit ops (3 kg), or
+    unary ops (-1).
+
+    General Strategy:
+    1) Get left side of operator
+    2) If no tokens left, return final result
+    3) Get operator
+    4) Use recursion to create tree starting at token on right side of operator (start at step #1)
+    4.1) If recursive call encounters an operator with lower or equal priority to step #2, exit recursion
+    5) Combine left side, operator, and right side into a new left side
+    6) Go back to step #2
 
     """
 

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -418,7 +418,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         """Transforms a list of Quantities into an numpy.array quantity.
         If no units are specified, the unit of the first element will be used.
         Same as from_sequence.
-        
+
         If units is not specified and list is empty, the unit cannot be determined
         and a ValueError is raised.
 
@@ -439,7 +439,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     def from_sequence(cls, seq, units=None):
         """Transforms a sequence of Quantities into an numpy.array quantity.
         If no units are specified, the unit of the first element will be used.
-        
+
         If units is not specified and sequence is empty, the unit cannot be determined
         and a ValueError is raised.
 
@@ -1597,7 +1597,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
     def dot(self, b):
         """Dot product of two arrays.
-        
+
         Wraps np.dot().
         """
 

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -110,9 +110,19 @@ def check_implemented(f):
 
 @contextlib.contextmanager
 def printoptions(*args, **kwargs):
-    """
-    Numpy printoptions context manager released with version 1.15.0
+    """Numpy printoptions context manager released with version 1.15.0
     https://docs.scipy.org/doc/numpy/reference/generated/numpy.printoptions.html
+
+    Parameters
+    ----------
+    *args :
+        
+    **kwargs :
+        
+
+    Returns
+    -------
+
     """
 
     opts = np.get_printoptions()
@@ -127,10 +137,16 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     """Implements a class to describe a physical quantity:
     the product of a numerical value and a unit of measurement.
 
-    :param value: value of the physical quantity to be created
-    :type value: str, pint.Quantity or any numeric type
-    :param units: units of the physical quantity to be created
-    :type units: UnitsContainer, str or pint.Quantity
+    Parameters
+    ----------
+    value : str, pint.Quantity or any numeric type
+        value of the physical quantity to be created
+    units : UnitsContainer, str or pint.Quantity
+        units of the physical quantity to be created
+
+    Returns
+    -------
+
     """
 
     #: Default formatting string.
@@ -349,50 +365,46 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
     @property
     def magnitude(self):
-        """Quantity's magnitude. Long form for `m`
-        """
+        """Quantity's magnitude. Long form for `m`"""
         return self._magnitude
 
     @property
     def m(self):
-        """Quantity's magnitude. Short form for `magnitude`
-        """
+        """Quantity's magnitude. Short form for `magnitude`"""
         return self._magnitude
 
     def m_as(self, units):
         """Quantity's magnitude expressed in particular units.
 
-        :param units: destination units
-        :type units: pint.Quantity, str or dict
+        Parameters
+        ----------
+        units : pint.Quantity, str or dict
+            destination units
+
+        Returns
+        -------
+
         """
         return self.to(units).magnitude
 
     @property
     def units(self):
-        """Quantity's units. Long form for `u`
-
-        :rtype: UnitsContainer
-        """
+        """Quantity's units. Long form for `u`"""
         return self._REGISTRY.Unit(self._units)
 
     @property
     def u(self):
-        """Quantity's units. Short form for `units`
-
-        :rtype: UnitsContainer
-        """
+        """Quantity's units. Short form for `units`"""
         return self._REGISTRY.Unit(self._units)
 
     @property
     def unitless(self):
-        """Return true if the quantity does not have units.
-        """
+        """ """
         return not bool(self.to_root_units()._units)
 
     @property
     def dimensionless(self):
-        """Return true if the quantity is dimensionless.
-        """
+        """ """
         tmp = self.to_root_units()
 
         return not bool(tmp.dimensionality)
@@ -401,15 +413,25 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
     @property
     def dimensionality(self):
-        """Quantity's dimensionality (e.g. {length: 1, time: -1})
-        """
+        """Quantity's dimensionality (e.g. {length: 1, time: -1})"""
         if self._dimensionality is None:
             self._dimensionality = self._REGISTRY._get_dimensionality(self._units)
 
         return self._dimensionality
 
     def check(self, dimension):
-        """Return true if the quantity's dimension matches passed dimension.
+        """
+
+        Parameters
+        ----------
+        dimension :
+            
+
+        Returns
+        -------
+        type
+            
+
         """
         return self.dimensionality == self._REGISTRY.get_dimensionality(dimension)
 
@@ -418,14 +440,20 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         """Transforms a list of Quantities into an numpy.array quantity.
         If no units are specified, the unit of the first element will be used.
         Same as from_sequence.
-
+        
         If units is not specified and list is empty, the unit cannot be determined
         and a ValueError is raised.
 
-        :param quant_list: list of pint.Quantity
-        :type quant_list: list of pint.Quantity
-        :param units: units of the physical quantity to be created
-        :type units: UnitsContainer, str or pint.Quantity
+        Parameters
+        ----------
+        quant_list : list: list of pint.Quantity
+            list of pint.Quantity
+        units : UnitsContainer, str or pint.Quantity
+            units of the physical quantity to be created (Default value = None)
+
+        Returns
+        -------
+
         """
         return cls.from_sequence(quant_list, units=units)
 
@@ -433,14 +461,20 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     def from_sequence(cls, seq, units=None):
         """Transforms a sequence of Quantities into an numpy.array quantity.
         If no units are specified, the unit of the first element will be used.
-
+        
         If units is not specified and sequence is empty, the unit cannot be determined
         and a ValueError is raised.
 
-        :param seq: sequence of pint.Quantity
-        :type seq: sequence of pint.Quantity
-        :param units: units of the physical quantity to be created
-        :type units: UnitsContainer, str or pint.Quantity
+        Parameters
+        ----------
+        seq : sequence of pint.Quantity
+            sequence of pint.Quantity
+        units : UnitsContainer, str or pint.Quantity
+            units of the physical quantity to be created (Default value = None)
+
+        Returns
+        -------
+
         """
 
         len_seq = len(seq)
@@ -494,8 +528,18 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     def ito(self, other=None, *contexts, **ctx_kwargs):
         """Inplace rescale to different units.
 
-        :param other: destination units.
-        :type other: pint.Quantity, str or dict
+        Parameters
+        ----------
+        other : pint.Quantity, str or dict
+            destination units. (Default value = None)
+        *contexts :
+            
+        **ctx_kwargs :
+            
+
+        Returns
+        -------
+
         """
         other = to_units_container(other, self._REGISTRY)
 
@@ -507,8 +551,18 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     def to(self, other=None, *contexts, **ctx_kwargs):
         """Return Quantity rescaled to different units.
 
-        :param other: destination units.
-        :type other: pint.Quantity, str or dict
+        Parameters
+        ----------
+        other : pint.Quantity, str or dict
+            destination units. (Default value = None)
+        *contexts :
+            
+        **ctx_kwargs :
+            
+
+        Returns
+        -------
+
         """
         other = to_units_container(other, self._REGISTRY)
 
@@ -517,8 +571,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return self.__class__(magnitude, other)
 
     def ito_root_units(self):
-        """Return Quantity rescaled to base units
-        """
+        """ """
 
         _, other = self._REGISTRY._get_root_units(self._units)
 
@@ -528,8 +581,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return None
 
     def to_root_units(self):
-        """Return Quantity rescaled to base units
-        """
+        """ """
         _, other = self._REGISTRY._get_root_units(self._units)
 
         magnitude = self._convert_magnitude_not_inplace(other)
@@ -537,8 +589,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return self.__class__(magnitude, other)
 
     def ito_base_units(self):
-        """Return Quantity rescaled to base units
-        """
+        """ """
 
         _, other = self._REGISTRY._get_base_units(self._units)
 
@@ -548,8 +599,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return None
 
     def to_base_units(self):
-        """Return Quantity rescaled to base units
-        """
+        """ """
         _, other = self._REGISTRY._get_base_units(self._units)
 
         magnitude = self._convert_magnitude_not_inplace(other)
@@ -557,9 +607,17 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return self.__class__(magnitude, other)
 
     def ito_reduced_units(self):
-        """Return Quantity scaled in place to reduced units, i.e. one unit per
-        dimension. This will not reduce compound units (intentionally), nor
-        can it make use of contexts at this time.
+        """
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        type
+            dimension. This will not reduce compound units (intentionally), nor
+            can it make use of contexts at this time.
+
         """
         # shortcuts in case we're dimensionless or only a single unit
         if self.dimensionless:
@@ -581,9 +639,17 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return self.ito(newunits)
 
     def to_reduced_units(self):
-        """Return Quantity scaled in place to reduced units, i.e. one unit per
-        dimension. This will not reduce compound units (intentionally), nor
-        can it make use of contexts at this time.
+        """
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        type
+            dimension. This will not reduce compound units (intentionally), nor
+            can it make use of contexts at this time.
+
         """
         # can we make this more efficient?
         newq = copy.copy(self)
@@ -591,9 +657,17 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return newq
 
     def to_compact(self, unit=None):
-        """Return Quantity rescaled to compact, human-readable units.
+        """
 
-        To get output in terms of a different unit, use the unit parameter.
+        Parameters
+        ----------
+        unit :
+             (Default value = None)
+
+        Returns
+        -------
+        type
+            To get output in terms of a different unit, use the unit parameter.
 
         >>> import pint
         >>> ureg = pint.UnitRegistry()
@@ -680,10 +754,16 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     def _iadd_sub(self, other, op):
         """Perform addition or subtraction operation in-place and return the result.
 
-        :param other: object to be added to / subtracted from self
-        :type other: pint.Quantity or any type accepted by :func:`_to_magnitude`
-        :param op: operator function (e.g. operator.add, operator.isub)
-        :type op: function
+        Parameters
+        ----------
+        other : pint.Quantity or any type accepted by :func:`_to_magnitude`
+            object to be added to / subtracted from self
+        op : function
+            operator function (e.g. operator.add, operator.isub)
+
+        Returns
+        -------
+
         """
         if not self._check(other):
             # other not from same Registry or not a Quantity
@@ -788,10 +868,16 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     def _add_sub(self, other, op):
         """Perform addition or subtraction operation and return the result.
 
-        :param other: object to be added to / subtracted from self
-        :type other: pint.Quantity or any type accepted by :func:`_to_magnitude`
-        :param op: operator function (e.g. operator.add, operator.isub)
-        :type op: function
+        Parameters
+        ----------
+        other : pint.Quantity or any type accepted by :func:`_to_magnitude`
+            object to be added to / subtracted from self
+        op : function
+            operator function (e.g. operator.add, operator.isub)
+
+        Returns
+        -------
+
         """
         if not self._check(other):
             # other not from same Registry or not a Quantity
@@ -927,14 +1013,20 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         """Perform multiplication or division operation in-place and return the
         result.
 
-        :param other: object to be multiplied/divided with self
-        :type other: pint.Quantity or any type accepted by :func:`_to_magnitude`
-        :param magnitude_op: operator function to perform on the magnitudes
+        Parameters
+        ----------
+        other : pint.Quantity or any type accepted by :func:`_to_magnitude`
+            object to be multiplied/divided with self
+        magnitude_op : function
+            operator function to perform on the magnitudes
             (e.g. operator.mul)
-        :type magnitude_op: function
-        :param units_op: operator function to perform on the units; if None,
-            *magnitude_op* is used
-        :type units_op: function or None
+        units_op : function or None
+            operator function to perform on the units; if None,
+            *magnitude_op* is used (Default value = None)
+
+        Returns
+        -------
+
         """
         if units_op is None:
             units_op = magnitude_op
@@ -989,14 +1081,20 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     def _mul_div(self, other, magnitude_op, units_op=None):
         """Perform multiplication or division operation and return the result.
 
-        :param other: object to be multiplied/divided with self
-        :type other: pint.Quantity or any type accepted by :func:`_to_magnitude`
-        :param magnitude_op: operator function to perform on the magnitudes
+        Parameters
+        ----------
+        other : pint.Quantity or any type accepted by :func:`_to_magnitude`
+            object to be multiplied/divided with self
+        magnitude_op : function
+            operator function to perform on the magnitudes
             (e.g. operator.mul)
-        :type magnitude_op: function
-        :param units_op: operator function to perform on the units; if None,
-            *magnitude_op* is used
-        :type units_op: function or None
+        units_op : function or None
+            operator function to perform on the units; if None,
+            *magnitude_op* is used (Default value = None)
+
+        Returns
+        -------
+
         """
         if units_op is None:
             units_op = magnitude_op
@@ -1422,6 +1520,19 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     def _numpy_method_wrap(self, func, *args, **kwargs):
         """Convenience method to wrap on the fly NumPy ndarray methods taking
         care of the units.
+
+        Parameters
+        ----------
+        func :
+            
+        *args :
+            
+        **kwargs :
+            
+
+        Returns
+        -------
+
         """
         # Set input units if needed
         if func.__name__ in set_units_ufuncs:
@@ -1542,8 +1653,17 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
     def dot(self, b):
         """Dot product of two arrays.
-
+        
         Wraps np.dot().
+
+        Parameters
+        ----------
+        b :
+            
+
+        Returns
+        -------
+
         """
         return np.dot(self, b)
 
@@ -1676,13 +1796,11 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     # methods/properties that help for math operations with offset units
     @property
     def _is_multiplicative(self):
-        """Check if the Quantity object has only multiplicative units.
-        """
+        """Check if the Quantity object has only multiplicative units."""
         return not self._get_non_multiplicative_units()
 
     def _get_non_multiplicative_units(self):
-        """Return a list of the of non-multiplicative units of the Quantity object
-        """
+        """ """
         offset_units = [
             unit
             for unit in self._units.keys()
@@ -1691,13 +1809,21 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return offset_units
 
     def _get_delta_units(self):
-        """Return list of delta units ot the Quantity object
-        """
+        """ """
         delta_units = [u for u in self._units.keys() if u.startswith("delta_")]
         return delta_units
 
     def _has_compatible_delta(self, unit):
         """"Check if Quantity object has a delta_unit that is compatible with unit
+
+        Parameters
+        ----------
+        unit :
+            
+
+        Returns
+        -------
+
         """
         deltas = self._get_delta_units()
         if "delta_" + unit in deltas:
@@ -1711,9 +1837,18 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
     def _ok_for_muldiv(self, no_offset_units=None):
         """Checks if Quantity object can be multiplied or divided
-
+        
         :q: pint.Quantity object that is checked
         :no_offset_units: number of offset units in q
+
+        Parameters
+        ----------
+        no_offset_units :
+             (Default value = None)
+
+        Returns
+        -------
+
         """
         is_ok = True
         if no_offset_units is None:

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -112,17 +112,6 @@ def check_implemented(f):
 def printoptions(*args, **kwargs):
     """Numpy printoptions context manager released with version 1.15.0
     https://docs.scipy.org/doc/numpy/reference/generated/numpy.printoptions.html
-
-    Parameters
-    ----------
-    *args :
-        
-    **kwargs :
-        
-
-    Returns
-    -------
-
     """
 
     opts = np.get_printoptions()
@@ -140,9 +129,9 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     Parameters
     ----------
     value : str, pint.Quantity or any numeric type
-        value of the physical quantity to be created
+        Value of the physical quantity to be created.
     units : UnitsContainer, str or pint.Quantity
-        units of the physical quantity to be created
+        Units of the physical quantity to be created.
 
     Returns
     -------
@@ -420,18 +409,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return self._dimensionality
 
     def check(self, dimension):
-        """
-
-        Parameters
-        ----------
-        dimension :
-            
-
-        Returns
-        -------
-        type
-            
-
+        """Return true if the quantity's dimension matches passed dimension.
         """
         return self.dimensionality == self._REGISTRY.get_dimensionality(dimension)
 
@@ -446,14 +424,14 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         Parameters
         ----------
-        quant_list : list: list of pint.Quantity
+        quant_list : list of pint.Quantity
             list of pint.Quantity
         units : UnitsContainer, str or pint.Quantity
             units of the physical quantity to be created (Default value = None)
 
         Returns
         -------
-
+        pint.Quantity
         """
         return cls.from_sequence(quant_list, units=units)
 
@@ -474,7 +452,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         Returns
         -------
-
+        pint.Quantity
         """
 
         len_seq = len(seq)
@@ -531,14 +509,11 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         Parameters
         ----------
         other : pint.Quantity, str or dict
-            destination units. (Default value = None)
-        *contexts :
-            
+            Destination units. (Default value = None)
+        *contexts : str or Context
+            Contexts to use in the transformation.
         **ctx_kwargs :
-            
-
-        Returns
-        -------
+            Values for the Context/s
 
         """
         other = to_units_container(other, self._REGISTRY)
@@ -555,13 +530,14 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         ----------
         other : pint.Quantity, str or dict
             destination units. (Default value = None)
-        *contexts :
-            
+        *contexts : str or Context
+            Contexts to use in the transformation.
         **ctx_kwargs :
-            
+            Values for the Context/s
 
         Returns
         -------
+        pint.Quantity
 
         """
         other = to_units_container(other, self._REGISTRY)
@@ -571,7 +547,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return self.__class__(magnitude, other)
 
     def ito_root_units(self):
-        """ """
+        """Return Quantity rescaled to root units."""
 
         _, other = self._REGISTRY._get_root_units(self._units)
 
@@ -581,7 +557,8 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return None
 
     def to_root_units(self):
-        """ """
+        """Return Quantity rescaled to root units."""
+
         _, other = self._REGISTRY._get_root_units(self._units)
 
         magnitude = self._convert_magnitude_not_inplace(other)
@@ -589,7 +566,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return self.__class__(magnitude, other)
 
     def ito_base_units(self):
-        """ """
+        """Return Quantity rescaled to base units."""
 
         _, other = self._REGISTRY._get_base_units(self._units)
 
@@ -599,7 +576,8 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return None
 
     def to_base_units(self):
-        """ """
+        """Return Quantity rescaled to base units."""
+
         _, other = self._REGISTRY._get_base_units(self._units)
 
         magnitude = self._convert_magnitude_not_inplace(other)
@@ -607,18 +585,11 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return self.__class__(magnitude, other)
 
     def ito_reduced_units(self):
+        """Return Quantity scaled in place to reduced units, i.e. one unit per
+        dimension. This will not reduce compound units (intentionally), nor
+        can it make use of contexts at this time.
         """
 
-        Parameters
-        ----------
-
-        Returns
-        -------
-        type
-            dimension. This will not reduce compound units (intentionally), nor
-            can it make use of contexts at this time.
-
-        """
         # shortcuts in case we're dimensionless or only a single unit
         if self.dimensionless:
             return self.ito({})
@@ -639,35 +610,25 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return self.ito(newunits)
 
     def to_reduced_units(self):
+        """Return Quantity scaled in place to reduced units, i.e. one unit per
+        dimension. This will not reduce compound units (intentionally), nor
+        can it make use of contexts at this time.
         """
 
-        Parameters
-        ----------
 
-        Returns
-        -------
-        type
-            dimension. This will not reduce compound units (intentionally), nor
-            can it make use of contexts at this time.
-
-        """
         # can we make this more efficient?
         newq = copy.copy(self)
         newq.ito_reduced_units()
         return newq
 
     def to_compact(self, unit=None):
-        """
+        """"Return Quantity rescaled to compact, human-readable units.
 
-        Parameters
-        ----------
-        unit :
-             (Default value = None)
+        To get output in terms of a different unit, use the unit parameter.
 
-        Returns
+
+        Example
         -------
-        type
-            To get output in terms of a different unit, use the unit parameter.
 
         >>> import pint
         >>> ureg = pint.UnitRegistry()
@@ -676,6 +637,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         >>> (1e-2*ureg('kg m/s^2')).to_compact('N')
         <Quantity(10.0, 'millinewton')>
         """
+
         if not isinstance(self.magnitude, numbers.Number):
             msg = (
                 "to_compact applied to non numerical types "
@@ -760,9 +722,6 @@ class Quantity(PrettyIPython, SharedRegistryObject):
             object to be added to / subtracted from self
         op : function
             operator function (e.g. operator.add, operator.isub)
-
-        Returns
-        -------
 
         """
         if not self._check(other):
@@ -875,8 +834,6 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         op : function
             operator function (e.g. operator.add, operator.isub)
 
-        Returns
-        -------
 
         """
         if not self._check(other):
@@ -1520,20 +1477,8 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     def _numpy_method_wrap(self, func, *args, **kwargs):
         """Convenience method to wrap on the fly NumPy ndarray methods taking
         care of the units.
-
-        Parameters
-        ----------
-        func :
-            
-        *args :
-            
-        **kwargs :
-            
-
-        Returns
-        -------
-
         """
+
         # Set input units if needed
         if func.__name__ in set_units_ufuncs:
             self.__ito_if_needed(set_units_ufuncs[func.__name__][0])
@@ -1655,16 +1600,8 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         """Dot product of two arrays.
         
         Wraps np.dot().
-
-        Parameters
-        ----------
-        b :
-            
-
-        Returns
-        -------
-
         """
+
         return np.dot(self, b)
 
     def __ito_if_needed(self, to_units):
@@ -1800,7 +1737,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return not self._get_non_multiplicative_units()
 
     def _get_non_multiplicative_units(self):
-        """ """
+        """Return a list of the of non-multiplicative units of the Quantity object."""
         offset_units = [
             unit
             for unit in self._units.keys()
@@ -1809,21 +1746,12 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return offset_units
 
     def _get_delta_units(self):
-        """ """
+        """Return list of delta units ot the Quantity object."""
         delta_units = [u for u in self._units.keys() if u.startswith("delta_")]
         return delta_units
 
     def _has_compatible_delta(self, unit):
         """"Check if Quantity object has a delta_unit that is compatible with unit
-
-        Parameters
-        ----------
-        unit :
-            
-
-        Returns
-        -------
-
         """
         deltas = self._get_delta_units()
         if "delta_" + unit in deltas:
@@ -1837,19 +1765,8 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
     def _ok_for_muldiv(self, no_offset_units=None):
         """Checks if Quantity object can be multiplied or divided
-        
-        :q: pint.Quantity object that is checked
-        :no_offset_units: number of offset units in q
-
-        Parameters
-        ----------
-        no_offset_units :
-             (Default value = None)
-
-        Returns
-        -------
-
         """
+
         is_ok = True
         if no_offset_units is None:
             no_offset_units = len(self._get_non_multiplicative_units())

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -615,7 +615,6 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         can it make use of contexts at this time.
         """
 
-
         # can we make this more efficient?
         newq = copy.copy(self)
         newq.ito_reduced_units()

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -86,6 +86,13 @@ _BLOCK_RE = re.compile(r" |\(")
 class RegistryMeta(type):
     """This is just to call after_init at the right time
     instead of asking the developer to do it when subclassing.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __call__(self, *args, **kwargs):
@@ -95,8 +102,7 @@ class RegistryMeta(type):
 
 
 class RegistryCache:
-    """Cache to speed up unit registries
-    """
+    """Cache to speed up unit registries"""
 
     def __init__(self):
         #: Maps dimensionality (UnitsContainer) to Units (str)
@@ -112,6 +118,13 @@ class RegistryCache:
 class ContextCacheOverlay:
     """Layer on top of the base UnitRegistry cache, specific to a combination of
     active contexts which contain unit redefinitions.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __init__(self, registry_cache: RegistryCache):
@@ -123,9 +136,9 @@ class ContextCacheOverlay:
 
 class BaseRegistry(metaclass=RegistryMeta):
     """Base class for all registries.
-
+    
     Capabilities:
-
+    
     - Register units, prefixes, and dimensions, and their relations.
     - Convert between units.
     - Find dimensionality of a unit.
@@ -134,24 +147,26 @@ class BaseRegistry(metaclass=RegistryMeta):
     - Parse a definition file.
     - Allow extending the definition file parser by registering @ directives.
 
-    :param filename:
+    Parameters
+    ----------
+    filename : str or None
         path of the units definition file to load or line iterable object. Empty to load
         the default definition file. None to leave the UnitRegistry empty.
-    :type filename:
-        str or None
-    :param force_ndarray:
+    force_ndarray :
         convert any input, scalar or not to a numpy.ndarray.
-    :param on_redefinition:
+    on_redefinition : str
         action to take in case a unit is redefined: 'warn', 'raise', 'ignore'
-    :type on_redefinition:
-        str
-    :param auto_reduce_dimensions:
+    auto_reduce_dimensions :
         If True, reduce dimensionality on appropriate operations.
-    :param preprocessors:
+    preprocessors :
         list of callables which are iteratively ran on any input expression or unit
         string
-    :param fmt_locale:
+    fmt_locale :
         locale identifier string, used in `format_babel`
+
+    Returns
+    -------
+
     """
 
     #: Map context prefix to function
@@ -231,8 +246,7 @@ class BaseRegistry(metaclass=RegistryMeta):
         self._initialized = False
 
     def _init_dynamic_classes(self):
-        """Generate subclasses on the fly and attach them to self
-        """
+        """Generate subclasses on the fly and attach them to self"""
         from .unit import build_unit_class
 
         self.Unit = build_unit_class(self)
@@ -246,8 +260,7 @@ class BaseRegistry(metaclass=RegistryMeta):
         self.Measurement = build_measurement_class(self)
 
     def _after_init(self):
-        """This should be called after all __init__
-        """
+        """This should be called after all __init__"""
         self.define(UnitDefinition("pi", "π", (), ScaleConverter(math.pi)))
 
         if self._filename == "":
@@ -264,7 +277,14 @@ class BaseRegistry(metaclass=RegistryMeta):
     def _parse_defaults(self, ifile):
         """Loader for a @default section.
 
-        :type ifile: SourceITerator
+        Parameters
+        ----------
+        ifile :
+            
+
+        Returns
+        -------
+
         """
         next(ifile)
         for lineno, part in ifile.block_iter():
@@ -294,8 +314,14 @@ class BaseRegistry(metaclass=RegistryMeta):
     def set_fmt_locale(self, loc):
         """Change the locale used by default by `format_babel`.
 
-        :param loc:
+        Parameters
+        ----------
+        loc :
             None` (do not translate), 'sys' (detect the system locale) or a locale id string.
+
+        Returns
+        -------
+
         """
         if isinstance(loc, str):
             if loc == "sys":
@@ -308,8 +334,7 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     @property
     def default_format(self):
-        """Default formatting string for quantities.
-        """
+        """Default formatting string for quantities."""
         return self.Quantity.default_format
 
     @default_format.setter
@@ -320,8 +345,14 @@ class BaseRegistry(metaclass=RegistryMeta):
     def define(self, definition):
         """Add unit to the registry.
 
-        :param definition: a dimension, unit or prefix definition.
-        :type definition: str or Definition
+        Parameters
+        ----------
+        definition : str or Definition
+            a dimension, unit or prefix definition.
+
+        Returns
+        -------
+
         """
 
         if isinstance(definition, str):
@@ -332,14 +363,20 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def _define(self, definition):
         """Add unit to the registry.
-
+        
         This method defines only multiplicative units, converting any other type
         to `delta_` units.
 
-        :param definition: a dimension, unit or prefix definition.
-        :type definition: Definition
-        :return: Definition instance, case sensitive unit dict, case insensitive unit dict.
-        :rtype: Definition, dict, dict
+        Parameters
+        ----------
+        definition : Definition
+            a dimension, unit or prefix definition.
+
+        Returns
+        -------
+        Definition, dict, dict
+            Definition instance, case sensitive unit dict, case insensitive unit dict.
+
         """
 
         if isinstance(definition, DimensionDefinition):
@@ -413,6 +450,19 @@ class BaseRegistry(metaclass=RegistryMeta):
     def _define_adder(self, definition, unit_dict, casei_unit_dict):
         """Helper function to store a definition in the internal dictionaries.
         It stores the definition under its name, symbol and aliases.
+
+        Parameters
+        ----------
+        definition :
+            
+        unit_dict :
+            
+        casei_unit_dict :
+            
+
+        Returns
+        -------
+
         """
         self._define_single_adder(
             definition.name, definition, unit_dict, casei_unit_dict
@@ -431,8 +481,23 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def _define_single_adder(self, key, value, unit_dict, casei_unit_dict):
         """Helper function to store a definition in the internal dictionaries.
-
+        
         It warns or raise error on redefinition.
+
+        Parameters
+        ----------
+        key :
+            
+        value :
+            
+        unit_dict :
+            
+        casei_unit_dict :
+            
+
+        Returns
+        -------
+
         """
         if key in unit_dict:
             if self._on_redefinition == "raise":
@@ -454,9 +519,16 @@ class BaseRegistry(metaclass=RegistryMeta):
     def _register_parser(self, prefix, parserfunc):
         """Register a loader for a given @ directive..
 
-        :param prefix: string identifying the section (e.g. @context)
-        :param parserfunc: A function that is able to parse a Definition section.
-        :type parserfunc: SourceIterator -> None
+        Parameters
+        ----------
+        prefix :
+            string identifying the section (e.g. @context)
+        parserfunc : SourceIterator -> None
+            A function that is able to parse a Definition section.
+
+        Returns
+        -------
+
         """
         if self._parsers is None:
             self._parsers = {}
@@ -469,9 +541,17 @@ class BaseRegistry(metaclass=RegistryMeta):
     def load_definitions(self, file, is_resource=False):
         """Add units and prefixes defined in a definition text file.
 
-        :param file: can be a filename or a line iterable.
-        :param is_resource: used to indicate that the file is a resource file
-                            and therefore should be loaded from the package.
+        Parameters
+        ----------
+        file :
+            can be a filename or a line iterable.
+        is_resource :
+            used to indicate that the file is a resource file
+            and therefore should be loaded from the package. (Default value = False)
+
+        Returns
+        -------
+
         """
         # Permit both filenames and line-iterables
         if isinstance(file, str):
@@ -535,8 +615,7 @@ class BaseRegistry(metaclass=RegistryMeta):
                     logger.error("In line {}, cannot add '{}' {}".format(no, line, ex))
 
     def _build_cache(self):
-        """Build a cache of dimensionality and base units.
-        """
+        """Build a cache of dimensionality and base units."""
         self._cache = RegistryCache()
 
         deps = {
@@ -573,7 +652,20 @@ class BaseRegistry(metaclass=RegistryMeta):
                     logger.warning(f"Could not resolve {unit_name}: {exc!r}")
 
     def get_name(self, name_or_alias, case_sensitive=True):
-        """Return the canonical name of a unit.
+        """
+
+        Parameters
+        ----------
+        name_or_alias :
+            
+        case_sensitive :
+             (Default value = True)
+
+        Returns
+        -------
+        type
+            
+
         """
 
         if name_or_alias == "dimensionless":
@@ -608,7 +700,18 @@ class BaseRegistry(metaclass=RegistryMeta):
         return unit_name
 
     def get_symbol(self, name_or_alias):
-        """Return the preferred alias for a unit
+        """
+
+        Parameters
+        ----------
+        name_or_alias :
+            
+
+        Returns
+        -------
+        type
+            
+
         """
         candidates = self.parse_unit_name(name_or_alias)
         if not candidates:
@@ -631,18 +734,34 @@ class BaseRegistry(metaclass=RegistryMeta):
         """Convert unit or dict of units or dimensions to a dict of base dimensions
         dimensions
 
-        :param input_units:
-        :return: dimensionality
+        Parameters
+        ----------
+        input_units :
+            return: dimensionality
+
+        Returns
+        -------
+        type
+            dimensionality
+
         """
         input_units = to_units_container(input_units)
 
         return self._get_dimensionality(input_units)
 
     def _get_dimensionality(self, input_units):
-        """ Convert a UnitsContainer to base dimensions.
+        """Convert a UnitsContainer to base dimensions.
 
-        :param input_units:
-        :return: dimensionality
+        Parameters
+        ----------
+        input_units :
+            return: dimensionality
+
+        Returns
+        -------
+        type
+            dimensionality
+
         """
         if not input_units:
             return UnitsContainer()
@@ -681,12 +800,20 @@ class BaseRegistry(metaclass=RegistryMeta):
                     self._get_dimensionality_recurse(reg.reference, exp2, accumulator)
 
     def _get_dimensionality_ratio(self, unit1, unit2):
-        """ Get the exponential ratio between two units, i.e. solve unit2 = unit1**x for x.
-        :param unit1: first unit
-        :type unit1: UnitsContainer compatible (str, Unit, UnitsContainer, dict)
-        :param unit2: second unit
-        :type unit2: UnitsContainer compatible (str, Unit, UnitsContainer, dict)
-        :returns: exponential proportionality or None if the units cannot be converted
+        """Get the exponential ratio between two units, i.e. solve unit2 = unit1**x for x.
+
+        Parameters
+        ----------
+        unit1 : UnitsContainer compatible (str, Unit, UnitsContainer, dict)
+            first unit
+        unit2 : UnitsContainer compatible (str, Unit, UnitsContainer, dict)
+            second unit
+
+        Returns
+        -------
+        type
+            exponential proportionality or None if the units cannot be converted
+
         """
         # shortcut in case of equal units
         if unit1 == unit2:
@@ -704,16 +831,24 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def get_root_units(self, input_units, check_nonmult=True):
         """Convert unit or dict of units to the root units.
-
+        
         If any unit is non multiplicative and check_converter is True,
         then None is returned as the multiplicative factor.
 
-        :param input_units: units
-        :type input_units: UnitsContainer or str
-        :param check_nonmult: if True, None will be returned as the
-                              multiplicative factor if a non-multiplicative
-                              units is found in the final Units.
-        :return: multiplicative factor, base units
+        Parameters
+        ----------
+        input_units : UnitsContainer or str
+            units
+        check_nonmult :
+            if True, None will be returned as the
+            multiplicative factor if a non-multiplicative
+            units is found in the final Units. (Default value = True)
+
+        Returns
+        -------
+        type
+            multiplicative factor, base units
+
         """
         input_units = to_units_container(input_units)
 
@@ -723,16 +858,24 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def _get_root_units(self, input_units, check_nonmult=True):
         """Convert unit or dict of units to the root units.
-
+        
         If any unit is non multiplicative and check_converter is True,
         then None is returned as the multiplicative factor.
 
-        :param input_units: units
-        :type input_units: UnitsContainer or dict
-        :param check_nonmult: if True, None will be returned as the
-                              multiplicative factor if a non-multiplicative
-                              units is found in the final Units.
-        :return: multiplicative factor, base units
+        Parameters
+        ----------
+        input_units : UnitsContainer or dict
+            units
+        check_nonmult :
+            if True, None will be returned as the
+            multiplicative factor if a non-multiplicative
+            units is found in the final Units. (Default value = True)
+
+        Returns
+        -------
+        type
+            multiplicative factor, base units
+
         """
         if not input_units:
             return 1.0, UnitsContainer()
@@ -759,16 +902,26 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def get_base_units(self, input_units, check_nonmult=True, system=None):
         """Convert unit or dict of units to the base units.
-
+        
         If any unit is non multiplicative and check_converter is True,
         then None is returned as the multiplicative factor.
 
-        :param input_units: units
-        :type input_units: UnitsContainer or str
-        :param check_nonmult: if True, None will be returned as the
-                              multiplicative factor if a non-multiplicative
-                              units is found in the final Units.
-        :return: multiplicative factor, base units
+        Parameters
+        ----------
+        input_units : UnitsContainer or str
+            units
+        check_nonmult :
+            if True, None will be returned as the
+            multiplicative factor if a non-multiplicative
+            units is found in the final Units. (Default value = True)
+        system :
+             (Default value = None)
+
+        Returns
+        -------
+        type
+            multiplicative factor, base units
+
         """
 
         return self.get_root_units(input_units, check_nonmult)
@@ -787,6 +940,17 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def get_compatible_units(self, input_units, group_or_system=None):
         """
+
+        Parameters
+        ----------
+        input_units :
+            
+        group_or_system :
+             (Default value = None)
+
+        Returns
+        -------
+
         """
         input_units = to_units_container(input_units)
 
@@ -796,6 +960,17 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def _get_compatible_units(self, input_units, group_or_system):
         """
+
+        Parameters
+        ----------
+        input_units :
+            
+        group_or_system :
+            
+
+        Returns
+        -------
+
         """
         if not input_units:
             return frozenset()
@@ -806,13 +981,22 @@ class BaseRegistry(metaclass=RegistryMeta):
     def convert(self, value, src, dst, inplace=False):
         """Convert value from some source to destination units.
 
-        :param value: value
-        :param src: source units.
-        :type src: pint.Quantity or str
-        :param dst: destination units.
-        :type dst: pint.Quantity or str
+        Parameters
+        ----------
+        value :
+            value
+        src : pint.Quantity or str
+            source units.
+        dst : pint.Quantity or str
+            destination units.
+        inplace :
+             (Default value = False)
 
-        :return: converted value
+        Returns
+        -------
+        type
+            converted value
+
         """
         src = to_units_container(src, self)
 
@@ -826,13 +1010,24 @@ class BaseRegistry(metaclass=RegistryMeta):
     def _convert(self, value, src, dst, inplace=False, check_dimensionality=True):
         """Convert value from some source to destination units.
 
-        :param value: value
-        :param src: source units.
-        :type src: UnitsContainer
-        :param dst: destination units.
-        :type dst: UnitsContainer
+        Parameters
+        ----------
+        value :
+            value
+        src : UnitsContainer
+            source units.
+        dst : UnitsContainer
+            destination units.
+        inplace :
+             (Default value = False)
+        check_dimensionality :
+             (Default value = True)
 
-        :return: converted value
+        Returns
+        -------
+        type
+            converted value
+
         """
 
         if check_dimensionality:
@@ -869,10 +1064,18 @@ class BaseRegistry(metaclass=RegistryMeta):
         In case of equivalent combinations (e.g. ('kilo', 'gram', '') and
         ('', 'kilogram', ''), prefer those with prefix.
 
-        :returns:
+        Parameters
+        ----------
+        unit_name :
+            
+        case_sensitive :
+             (Default value = True)
+
+        Returns
+        -------
+        str, str, str), ...)
             all non-equivalent combinations of (prefix, unit name, suffix)
-        :rtype:
-            ((str, str, str), ...)
+
         """
         return self._dedup_candidates(
             self._parse_unit_name(unit_name, case_sensitive=case_sensitive)
@@ -880,6 +1083,17 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def _parse_unit_name(self, unit_name, case_sensitive=True):
         """Helper of parse_unit_name
+
+        Parameters
+        ----------
+        unit_name :
+            
+        case_sensitive :
+             (Default value = True)
+
+        Returns
+        -------
+
         """
         stw = unit_name.startswith
         edw = unit_name.endswith
@@ -908,11 +1122,20 @@ class BaseRegistry(metaclass=RegistryMeta):
     @staticmethod
     def _dedup_candidates(candidates):
         """Helper of parse_unit_name.
-
+        
         Given an iterable of unit triplets (prefix, name, suffix), remove those with
         different names but equal value, preferring those with a prefix.
-
+        
         e.g. ('kilo', 'gram', '') and ('', 'kilogram', '')
+
+        Parameters
+        ----------
+        candidates :
+            
+
+        Returns
+        -------
+
         """
         candidates = dict.fromkeys(candidates)  # ordered set
         for cp, cu, cs in list(candidates):
@@ -927,15 +1150,20 @@ class BaseRegistry(metaclass=RegistryMeta):
     def parse_units(self, input_string, as_delta=None):
         """Parse a units expression and returns a UnitContainer with
         the canonical names.
-
+        
         The expression can only contain products, ratios and powers of units.
 
-        :param as_delta: if the expression has multiple units, the parser will
-                         interpret non multiplicative units as their `delta_` counterparts.
+        Parameters
+        ----------
+        as_delta :
+            if the expression has multiple units, the parser will
+            interpret non multiplicative units as their `delta_` counterparts. (Default value = None)
+        input_string :
+            
 
-        :raises:
-            :class:`pint.UndefinedUnitError` if a unit is not in the registry
-            :class:`ValueError` if the expression is invalid.
+        Returns
+        -------
+
         """
         for p in self.preprocessors:
             input_string = p(input_string)
@@ -944,6 +1172,17 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def _parse_units(self, input_string, as_delta=True):
         """
+
+        Parameters
+        ----------
+        input_string :
+            
+        as_delta :
+             (Default value = True)
+
+        Returns
+        -------
+
         """
         cache = self._cache.parse_unit
         if as_delta:
@@ -1006,9 +1245,24 @@ class BaseRegistry(metaclass=RegistryMeta):
         self, input_string, case_sensitive=True, use_decimal=False, **values
     ):
         """Parse a mathematical expression including units and return a quantity object.
-
+        
         Numerical constants can be specified as keyword arguments and will take precedence
         over the names defined in the registry.
+
+        Parameters
+        ----------
+        input_string :
+            
+        case_sensitive :
+             (Default value = True)
+        use_decimal :
+             (Default value = False)
+        **values :
+            
+
+        Returns
+        -------
+
         """
 
         if not input_string:
@@ -1030,15 +1284,23 @@ class BaseRegistry(metaclass=RegistryMeta):
 
 class NonMultiplicativeRegistry(BaseRegistry):
     """Handle of non multiplicative units (e.g. Temperature).
-
+    
     Capabilities:
     - Register non-multiplicative units and their relations.
     - Convert between non-multiplicative units.
 
-    :param default_as_delta: If True, non-multiplicative units are interpreted as
-                             their *delta* counterparts in multiplications.
-    :param autoconvert_offset_to_baseunit: If True, non-multiplicative units are
-                                           converted to base units in multiplications.
+    Parameters
+    ----------
+    default_as_delta :
+        If True, non-multiplicative units are interpreted as
+        their *delta* counterparts in multiplications.
+    autoconvert_offset_to_baseunit :
+        If True, non-multiplicative units are
+        converted to base units in multiplications.
+
+    Returns
+    -------
+
     """
 
     def __init__(
@@ -1056,6 +1318,17 @@ class NonMultiplicativeRegistry(BaseRegistry):
 
     def _parse_units(self, input_string, as_delta=None):
         """
+
+        Parameters
+        ----------
+        input_string :
+            
+        as_delta :
+             (Default value = None)
+
+        Returns
+        -------
+
         """
         if as_delta is None:
             as_delta = self.default_as_delta
@@ -1064,14 +1337,20 @@ class NonMultiplicativeRegistry(BaseRegistry):
 
     def _define(self, definition):
         """Add unit to the registry.
-
+        
         In addition to what is done by the BaseRegistry,
         registers also non-multiplicative units.
 
-        :param definition: a dimension, unit or prefix definition.
-        :type definition: str | Definition
-        :return: Definition instance, case sensitive unit dict, case insensitive unit dict.
-        :rtype: Definition, dict, dict
+        Parameters
+        ----------
+        definition : str | Definition
+            a dimension, unit or prefix definition.
+
+        Returns
+        -------
+        Definition, dict, dict
+            Definition instance, case sensitive unit dict, case insensitive unit dict.
+
         """
 
         definition, d, di = super()._define(definition)
@@ -1127,17 +1406,26 @@ class NonMultiplicativeRegistry(BaseRegistry):
 
     def _convert(self, value, src, dst, inplace=False):
         """Convert value from some source to destination units.
-
+        
         In addition to what is done by the BaseRegistry,
         converts between non-multiplicative units.
 
-        :param value: value
-        :param src: source units.
-        :type src: UnitsContainer
-        :param dst: destination units.
-        :type dst: UnitsContainer
+        Parameters
+        ----------
+        value :
+            value
+        src : UnitsContainer
+            source units.
+        dst : UnitsContainer
+            destination units.
+        inplace :
+             (Default value = False)
 
-        :return: converted value
+        Returns
+        -------
+        type
+            converted value
+
         """
 
         # Conversion needs to consider if non-multiplicative (AKA offset
@@ -1190,15 +1478,21 @@ class NonMultiplicativeRegistry(BaseRegistry):
 
 class ContextRegistry(BaseRegistry):
     """Handle of Contexts.
-
+    
     Conversion between units with different dimenstions according
     to previously established relations (contexts).
     (e.g. in the spectroscopy, conversion between frequency and energy is possible)
-
+    
     Capabilities:
     - Register contexts.
     - Enable and disable contexts.
     - Parse @context directive.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
 
     """
 
@@ -1231,10 +1525,19 @@ class ContextRegistry(BaseRegistry):
 
     def add_context(self, context: Context) -> None:
         """Add a context object to the registry.
-
+        
         The context will be accessible by its name and aliases.
-
+        
         Notice that this method will NOT enable the context. Use `enable_contexts`.
+
+        Parameters
+        ----------
+        context: Context :
+            
+
+        Returns
+        -------
+
         """
         if not context.name:
             raise ValueError("Can't add unnamed context to registry")
@@ -1253,8 +1556,17 @@ class ContextRegistry(BaseRegistry):
 
     def remove_context(self, name_or_alias: str) -> Context:
         """Remove a context from the registry and return it.
-
+        
         Notice that this methods will not disable the context. Use `disable_contexts`.
+
+        Parameters
+        ----------
+        name_or_alias: str :
+            
+
+        Returns
+        -------
+
         """
         context = self._contexts[name_or_alias]
 
@@ -1273,6 +1585,13 @@ class ContextRegistry(BaseRegistry):
         and self._units specific to the combination of active contexts.
         The next time this method is invoked with the same combination of contexts,
         reuse the same variant self._cache and self._units as in the previous time.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         del self._units.maps[:-1]
         units_overlay = any(ctx.redefinitions for ctx in self._active_ctx.contexts)
@@ -1307,6 +1626,15 @@ class ContextRegistry(BaseRegistry):
 
     def _redefine(self, definition: UnitDefinition) -> None:
         """Redefine a unit from a context
+
+        Parameters
+        ----------
+        definition: UnitDefinition :
+            
+
+        Returns
+        -------
+
         """
         # Find original definition in the UnitRegistry
         candidates = self.parse_unit_name(definition.name)
@@ -1351,8 +1679,20 @@ class ContextRegistry(BaseRegistry):
     def enable_contexts(self, *names_or_contexts, **kwargs) -> None:
         """Enable contexts provided by name or by object.
 
-        :param names_or_contexts: sequence of the contexts or contexts names/alias
-        :param kwargs: keyword arguments for the context
+        Parameters
+        ----------
+        names_or_contexts :
+            sequence of the contexts or contexts names/alias
+        kwargs :
+            keyword arguments for the context
+        *names_or_contexts :
+            
+        **kwargs :
+            
+
+        Returns
+        -------
+
         """
 
         # If present, copy the defaults from the containing contexts
@@ -1387,6 +1727,15 @@ class ContextRegistry(BaseRegistry):
 
     def disable_contexts(self, n: int = None) -> None:
         """Disable the last n enabled contexts.
+
+        Parameters
+        ----------
+        n: int :
+             (Default value = None)
+
+        Returns
+        -------
+
         """
         self._active_ctx.remove_contexts(n)
         self._switch_context_cache_and_units()
@@ -1396,37 +1745,51 @@ class ContextRegistry(BaseRegistry):
         """Used as a context manager, this function enables to activate a context
         which is removed after usage.
 
-        :param names: name of the context.
-        :param kwargs: keyword arguments for the contexts.
+        Parameters
+        ----------
+        names :
+            name of the context.
+        kwargs :
+            keyword arguments for the contexts.
+            
+            Context are called by their name::
+            
+            
+            If the context has an argument, you can specify its value as a keyword
+            argument::
+            
+            
+            Multiple contexts can be entered in single call:
+            
+            
+            or nested allowing you to give different values to the same keyword argument::
+            
+            
+            A nested context inherits the defaults from the containing context::
+        *names :
+            
+        **kwargs :
+            
 
-        Context are called by their name::
+        Returns
+        -------
 
-            >>> with ureg.context('one'):
+        >>> with ureg.context('one'):
             ...     pass
-
-        If the context has an argument, you can specify its value as a keyword
-        argument::
-
+        
             >>> with ureg.context('one', n=1):
             ...     pass
-
-        Multiple contexts can be entered in single call:
-
+        
             >>> with ureg.context('one', 'two', n=1):
             ...     pass
-
-        or nested allowing you to give different values to the same keyword argument::
-
+        
             >>> with ureg.context('one', n=1):
             ...     with ureg.context('two', n=2):
             ...         pass
-
-        A nested context inherits the defaults from the containing context::
-
+        
             >>> with ureg.context('one', n=1):
             ...     with ureg.context('two'): # Here n takes the value of the upper context
             ...         pass
-
         """
 
         # Enable the contexts.
@@ -1443,18 +1806,29 @@ class ContextRegistry(BaseRegistry):
 
     def with_context(self, name, **kw):
         """Decorator to wrap a function call in a Pint context.
-
+        
         Use it to ensure that a certain context is active when
         calling a function::
 
-            >>> @ureg.with_context('sp')
+        Parameters
+        ----------
+        names :
+            name of the context.
+        kwargs :
+            keyword arguments for the contexts.
+        name :
+            
+        **kw :
+            
+
+        Returns
+        -------
+        type
+            the wrapped function.
+
+        >>> @ureg.with_context('sp')
             ... def my_cool_fun(wavelenght):
             ...     print('This wavelength is equivalent to: %s', wavelength.to('terahertz'))
-
-
-        :param names: name of the context.
-        :param kwargs: keyword arguments for the contexts.
-        :return: the wrapped function.
         """
 
         def decorator(func):
@@ -1476,18 +1850,27 @@ class ContextRegistry(BaseRegistry):
 
     def _convert(self, value, src, dst, inplace=False):
         """Convert value from some source to destination units.
-
+        
         In addition to what is done by the BaseRegistry,
         converts between units with different dimensions by following
         transformation rules defined in the context.
 
-        :param value: value
-        :param src: source units.
-        :type src: UnitsContainer
-        :param dst: destination units.
-        :type dst: UnitsContainer
+        Parameters
+        ----------
+        value :
+            value
+        src : UnitsContainer
+            source units.
+        dst : UnitsContainer
+            destination units.
+        inplace :
+             (Default value = False)
 
-        :return: converted value
+        Returns
+        -------
+        type
+            converted value
+
         """
 
         # If there is an active context, we look for a path connecting source and
@@ -1510,6 +1893,17 @@ class ContextRegistry(BaseRegistry):
 
     def _get_compatible_units(self, input_units, group_or_system):
         """
+
+        Parameters
+        ----------
+        input_units :
+            
+        group_or_system :
+            
+
+        Returns
+        -------
+
         """
 
         src_dim = self._get_dimensionality(input_units)
@@ -1528,16 +1922,22 @@ class ContextRegistry(BaseRegistry):
 
 class SystemRegistry(BaseRegistry):
     """Handle of Systems and Groups.
-
+    
     Conversion between units with different dimenstions according
     to previously established relations (contexts).
     (e.g. in the spectroscopy, conversion between frequency and energy is possible)
-
+    
     Capabilities:
     - Register systems and groups.
     - List systems
     - Get or get the default system.
     - Parse @system and @group directive.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
 
     """
 
@@ -1564,10 +1964,17 @@ class SystemRegistry(BaseRegistry):
 
     def _after_init(self):
         """After init function
-
+        
         Create default group.
         Add all orphan units to it.
         Set default system.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         super()._after_init()
 
@@ -1604,9 +2011,18 @@ class SystemRegistry(BaseRegistry):
     def get_group(self, name, create_if_needed=True):
         """Return a Group.
 
-        :param name: Name of the group to be
-        :param create_if_needed: Create a group if not Found. If False, raise an Exception.
-        :return: Group
+        Parameters
+        ----------
+        name :
+            Name of the group to be
+        create_if_needed :
+            Create a group if not Found. If False, raise an Exception. (Default value = True)
+
+        Returns
+        -------
+        type
+            Group
+
         """
         if name in self._groups:
             return self._groups[name]
@@ -1637,9 +2053,18 @@ class SystemRegistry(BaseRegistry):
     def get_system(self, name, create_if_needed=True):
         """Return a Group.
 
-        :param name: Name of the group to be
-        :param create_if_needed: Create a group if not Found. If False, raise an Exception.
-        :return: System
+        Parameters
+        ----------
+        name :
+            Name of the group to be
+        create_if_needed :
+            Create a group if not Found. If False, raise an Exception. (Default value = True)
+
+        Returns
+        -------
+        type
+            System
+
         """
         if name in self._systems:
             return self._systems[name]
@@ -1664,19 +2089,29 @@ class SystemRegistry(BaseRegistry):
 
     def get_base_units(self, input_units, check_nonmult=True, system=None):
         """Convert unit or dict of units to the base units.
-
+        
         If any unit is non multiplicative and check_converter is True,
         then None is returned as the multiplicative factor.
-
+        
         Unlike BaseRegistry, in this registry root_units might be different
         from base_units
 
-        :param input_units: units
-        :type input_units: UnitsContainer or str
-        :param check_nonmult: if True, None will be returned as the
-                              multiplicative factor if a non-multiplicative
-                              units is found in the final Units.
-        :return: multiplicative factor, base units
+        Parameters
+        ----------
+        input_units : UnitsContainer or str
+            units
+        check_nonmult :
+            if True, None will be returned as the
+            multiplicative factor if a non-multiplicative
+            units is found in the final Units. (Default value = True)
+        system :
+             (Default value = None)
+
+        Returns
+        -------
+        type
+            multiplicative factor, base units
+
         """
 
         input_units = to_units_container(input_units)
@@ -1728,6 +2163,17 @@ class SystemRegistry(BaseRegistry):
 
     def _get_compatible_units(self, input_units, group_or_system):
         """
+
+        Parameters
+        ----------
+        input_units :
+            
+        group_or_system :
+            
+
+        Returns
+        -------
+
         """
 
         if group_or_system is None:
@@ -1752,23 +2198,35 @@ class SystemRegistry(BaseRegistry):
 class UnitRegistry(SystemRegistry, ContextRegistry, NonMultiplicativeRegistry):
     """The unit registry stores the definitions and relationships between units.
 
-    :param filename: path of the units definition file to load or line-iterable object.
-                     Empty to load the default definition file.
-                     None to leave the UnitRegistry empty.
-    :param force_ndarray: convert any input, scalar or not to a numpy.ndarray.
-    :param default_as_delta: In the context of a multiplication of units, interpret
-                             non-multiplicative units as their *delta* counterparts.
-    :param autoconvert_offset_to_baseunit: If True converts offset units in quantites are
-                                           converted to their base units in multiplicative
-                                           context. If False no conversion happens.
-    :param on_redefinition: action to take in case a unit is redefined.
-                            'warn', 'raise', 'ignore'
-    :type on_redefinition: str
-    :param auto_reduce_dimensions: If True, reduce dimensionality on appropriate operations.
-    :param preprocessors: list of callables which are iteratively ran on any input expression
-                          or unit string
-    :param fmt_locale:
+    Parameters
+    ----------
+    filename :
+        path of the units definition file to load or line-iterable object.
+        Empty to load the default definition file.
+        None to leave the UnitRegistry empty.
+    force_ndarray :
+        convert any input, scalar or not to a numpy.ndarray.
+    default_as_delta :
+        In the context of a multiplication of units, interpret
+        non-multiplicative units as their *delta* counterparts.
+    autoconvert_offset_to_baseunit :
+        If True converts offset units in quantites are
+        converted to their base units in multiplicative
+        context. If False no conversion happens.
+    on_redefinition : str
+        action to take in case a unit is redefined.
+        'warn', 'raise', 'ignore'
+    auto_reduce_dimensions :
+        If True, reduce dimensionality on appropriate operations.
+    preprocessors :
+        list of callables which are iteratively ran on any input expression
+        or unit string
+    fmt_locale :
         locale identifier string, used in `format_babel`. Default to None
+
+    Returns
+    -------
+
     """
 
     def __init__(
@@ -1798,16 +2256,31 @@ class UnitRegistry(SystemRegistry, ContextRegistry, NonMultiplicativeRegistry):
 
     def pi_theorem(self, quantities):
         """Builds dimensionless quantities using the Buckingham π theorem
-        :param quantities: mapping between variable name and units
-        :type quantities: dict
-        :return: a list of dimensionless quantities expressed as dicts
+
+        Parameters
+        ----------
+        quantities : dict
+            mapping between variable name and units
+
+        Returns
+        -------
+        type
+            a list of dimensionless quantities expressed as dicts
+
         """
         return pi_theorem(quantities, self)
 
     def setup_matplotlib(self, enable=True):
         """Set up handlers for matplotlib's unit support.
-        :param enable: whether support should be enabled or disabled
-        :type enable: bool
+
+        Parameters
+        ----------
+        enable : bool
+            whether support should be enabled or disabled (Default value = True)
+
+        Returns
+        -------
+
         """
         # Delays importing matplotlib until it's actually requested
         from .matplotlib import setup_matplotlib_handlers

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -122,9 +122,9 @@ class ContextCacheOverlay:
 
 class BaseRegistry(metaclass=RegistryMeta):
     """Base class for all registries.
-    
+
     Capabilities:
-    
+
     - Register units, prefixes, and dimensions, and their relations.
     - Convert between units.
     - Find dimensionality of a unit.
@@ -329,7 +329,7 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def _define(self, definition):
         """Add unit to the registry.
-        
+
         This method defines only multiplicative units, converting any other type
         to `delta_` units.
 
@@ -434,7 +434,7 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def _define_single_adder(self, key, value, unit_dict, casei_unit_dict):
         """Helper function to store a definition in the internal dictionaries.
-        
+
         It warns or raise error on redefinition.
         """
         if key in unit_dict:
@@ -723,7 +723,7 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def get_root_units(self, input_units, check_nonmult=True):
         """Convert unit or dict of units to the root units.
-        
+
         If any unit is non multiplicative and check_converter is True,
         then None is returned as the multiplicative factor.
 
@@ -750,7 +750,7 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def _get_root_units(self, input_units, check_nonmult=True):
         """Convert unit or dict of units to the root units.
-        
+
         If any unit is non multiplicative and check_converter is True,
         then None is returned as the multiplicative factor.
 
@@ -794,7 +794,7 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def get_base_units(self, input_units, check_nonmult=True, system=None):
         """Convert unit or dict of units to the base units.
-        
+
         If any unit is non multiplicative and check_converter is True,
         then None is returned as the multiplicative factor.
 
@@ -937,7 +937,7 @@ class BaseRegistry(metaclass=RegistryMeta):
         Parameters
         ----------
         unit_name :
-            
+
         case_sensitive :
              (Default value = True)
 
@@ -981,10 +981,10 @@ class BaseRegistry(metaclass=RegistryMeta):
     @staticmethod
     def _dedup_candidates(candidates):
         """Helper of parse_unit_name.
-        
+
         Given an iterable of unit triplets (prefix, name, suffix), remove those with
         different names but equal value, preferring those with a prefix.
-        
+
         e.g. ('kilo', 'gram', '') and ('', 'kilogram', '')
         """
         candidates = dict.fromkeys(candidates)  # ordered set
@@ -1000,7 +1000,7 @@ class BaseRegistry(metaclass=RegistryMeta):
     def parse_units(self, input_string, as_delta=None):
         """Parse a units expression and returns a UnitContainer with
         the canonical names.
-        
+
         The expression can only contain products, ratios and powers of units.
 
         Parameters
@@ -1085,20 +1085,20 @@ class BaseRegistry(metaclass=RegistryMeta):
         self, input_string, case_sensitive=True, use_decimal=False, **values
     ):
         """Parse a mathematical expression including units and return a quantity object.
-        
+
         Numerical constants can be specified as keyword arguments and will take precedence
         over the names defined in the registry.
 
         Parameters
         ----------
         input_string :
-            
+
         case_sensitive :
              (Default value = True)
         use_decimal :
              (Default value = False)
         **values :
-            
+
 
         Returns
         -------
@@ -1124,7 +1124,7 @@ class BaseRegistry(metaclass=RegistryMeta):
 
 class NonMultiplicativeRegistry(BaseRegistry):
     """Handle of non multiplicative units (e.g. Temperature).
-    
+
     Capabilities:
     - Register non-multiplicative units and their relations.
     - Convert between non-multiplicative units.
@@ -1163,7 +1163,7 @@ class NonMultiplicativeRegistry(BaseRegistry):
 
     def _define(self, definition):
         """Add unit to the registry.
-        
+
         In addition to what is done by the BaseRegistry,
         registers also non-multiplicative units.
 
@@ -1232,7 +1232,7 @@ class NonMultiplicativeRegistry(BaseRegistry):
 
     def _convert(self, value, src, dst, inplace=False):
         """Convert value from some source to destination units.
-        
+
         In addition to what is done by the BaseRegistry,
         converts between non-multiplicative units.
 
@@ -1304,11 +1304,11 @@ class NonMultiplicativeRegistry(BaseRegistry):
 
 class ContextRegistry(BaseRegistry):
     """Handle of Contexts.
-    
+
     Conversion between units with different dimenstions according
     to previously established relations (contexts).
     (e.g. in the spectroscopy, conversion between frequency and energy is possible)
-    
+
     Capabilities:
     - Register contexts.
     - Enable and disable contexts.
@@ -1344,9 +1344,9 @@ class ContextRegistry(BaseRegistry):
 
     def add_context(self, context: Context) -> None:
         """Add a context object to the registry.
-        
+
         The context will be accessible by its name and aliases.
-        
+
         Notice that this method will NOT enable the context. Use `enable_contexts`.
 
         """
@@ -1367,7 +1367,7 @@ class ContextRegistry(BaseRegistry):
 
     def remove_context(self, name_or_alias: str) -> Context:
         """Remove a context from the registry and return it.
-        
+
         Notice that this methods will not disable the context. Use `disable_contexts`.
 
         """
@@ -1474,7 +1474,7 @@ class ContextRegistry(BaseRegistry):
         kwargs :
             keyword arguments for the context
         *names_or_contexts :
-            
+
         **kwargs :
 
         """
@@ -1535,23 +1535,23 @@ class ContextRegistry(BaseRegistry):
             name of the context.
         kwargs :
             keyword arguments for the contexts.
-            
+
             Context are called by their name::
-            
-            
+
+
             If the context has an argument, you can specify its value as a keyword
             argument::
-            
-            
+
+
             Multiple contexts can be entered in single call:
-            
-            
+
+
             or nested allowing you to give different values to the same keyword argument::
-            
-            
+
+
             A nested context inherits the defaults from the containing context::
         *names :
-            
+
         **kwargs :
 
 
@@ -1586,7 +1586,7 @@ class ContextRegistry(BaseRegistry):
 
     def with_context(self, name, **kw):
         """Decorator to wrap a function call in a Pint context.
-        
+
         Use it to ensure that a certain context is active when
         calling a function::
 
@@ -1597,9 +1597,9 @@ class ContextRegistry(BaseRegistry):
         kwargs :
             keyword arguments for the contexts.
         name :
-            
+
         **kw :
-            
+
 
         Returns
         -------
@@ -1632,7 +1632,7 @@ class ContextRegistry(BaseRegistry):
 
     def _convert(self, value, src, dst, inplace=False):
         """Convert value from some source to destination units.
-        
+
         In addition to what is done by the BaseRegistry,
         converts between units with different dimensions by following
         transformation rules defined in the context.
@@ -1693,11 +1693,11 @@ class ContextRegistry(BaseRegistry):
 
 class SystemRegistry(BaseRegistry):
     """Handle of Systems and Groups.
-    
+
     Conversion between units with different dimenstions according
     to previously established relations (contexts).
     (e.g. in the spectroscopy, conversion between frequency and energy is possible)
-    
+
     Capabilities:
     - Register systems and groups.
     - List systems
@@ -1729,7 +1729,7 @@ class SystemRegistry(BaseRegistry):
 
     def _after_init(self):
         """After init function
-        
+
         Create default group.
         Add all orphan units to it.
         Set default system.
@@ -1847,10 +1847,10 @@ class SystemRegistry(BaseRegistry):
 
     def get_base_units(self, input_units, check_nonmult=True, system=None):
         """Convert unit or dict of units to the base units.
-        
+
         If any unit is non multiplicative and check_converter is True,
         then None is returned as the multiplicative factor.
-        
+
         Unlike BaseRegistry, in this registry root_units might be different
         from base_units
 

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -86,13 +86,6 @@ _BLOCK_RE = re.compile(r" |\(")
 class RegistryMeta(type):
     """This is just to call after_init at the right time
     instead of asking the developer to do it when subclassing.
-
-    Parameters
-    ----------
-
-    Returns
-    -------
-
     """
 
     def __call__(self, *args, **kwargs):
@@ -118,13 +111,6 @@ class RegistryCache:
 class ContextCacheOverlay:
     """Layer on top of the base UnitRegistry cache, specific to a combination of
     active contexts which contain unit redefinitions.
-
-    Parameters
-    ----------
-
-    Returns
-    -------
-
     """
 
     def __init__(self, registry_cache: RegistryCache):
@@ -152,7 +138,7 @@ class BaseRegistry(metaclass=RegistryMeta):
     filename : str or None
         path of the units definition file to load or line iterable object. Empty to load
         the default definition file. None to leave the UnitRegistry empty.
-    force_ndarray :
+    force_ndarray : bool
         convert any input, scalar or not to a numpy.ndarray.
     on_redefinition : str
         action to take in case a unit is redefined: 'warn', 'raise', 'ignore'
@@ -163,9 +149,6 @@ class BaseRegistry(metaclass=RegistryMeta):
         string
     fmt_locale :
         locale identifier string, used in `format_babel`
-
-    Returns
-    -------
 
     """
 
@@ -276,15 +259,6 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def _parse_defaults(self, ifile):
         """Loader for a @default section.
-
-        Parameters
-        ----------
-        ifile :
-            
-
-        Returns
-        -------
-
         """
         next(ifile)
         for lineno, part in ifile.block_iter():
@@ -316,12 +290,8 @@ class BaseRegistry(metaclass=RegistryMeta):
 
         Parameters
         ----------
-        loc :
+        loc : str or None
             None` (do not translate), 'sys' (detect the system locale) or a locale id string.
-
-        Returns
-        -------
-
         """
         if isinstance(loc, str):
             if loc == "sys":
@@ -349,10 +319,6 @@ class BaseRegistry(metaclass=RegistryMeta):
         ----------
         definition : str or Definition
             a dimension, unit or prefix definition.
-
-        Returns
-        -------
-
         """
 
         if isinstance(definition, str):
@@ -450,19 +416,6 @@ class BaseRegistry(metaclass=RegistryMeta):
     def _define_adder(self, definition, unit_dict, casei_unit_dict):
         """Helper function to store a definition in the internal dictionaries.
         It stores the definition under its name, symbol and aliases.
-
-        Parameters
-        ----------
-        definition :
-            
-        unit_dict :
-            
-        casei_unit_dict :
-            
-
-        Returns
-        -------
-
         """
         self._define_single_adder(
             definition.name, definition, unit_dict, casei_unit_dict
@@ -483,21 +436,6 @@ class BaseRegistry(metaclass=RegistryMeta):
         """Helper function to store a definition in the internal dictionaries.
         
         It warns or raise error on redefinition.
-
-        Parameters
-        ----------
-        key :
-            
-        value :
-            
-        unit_dict :
-            
-        casei_unit_dict :
-            
-
-        Returns
-        -------
-
         """
         if key in unit_dict:
             if self._on_redefinition == "raise":
@@ -652,20 +590,7 @@ class BaseRegistry(metaclass=RegistryMeta):
                     logger.warning(f"Could not resolve {unit_name}: {exc!r}")
 
     def get_name(self, name_or_alias, case_sensitive=True):
-        """
-
-        Parameters
-        ----------
-        name_or_alias :
-            
-        case_sensitive :
-             (Default value = True)
-
-        Returns
-        -------
-        type
-            
-
+        """Return the canonical name of a unit.
         """
 
         if name_or_alias == "dimensionless":
@@ -700,18 +625,7 @@ class BaseRegistry(metaclass=RegistryMeta):
         return unit_name
 
     def get_symbol(self, name_or_alias):
-        """
-
-        Parameters
-        ----------
-        name_or_alias :
-            
-
-        Returns
-        -------
-        type
-            
-
+        """Return the preferred alias for a unit.
         """
         candidates = self.parse_unit_name(name_or_alias)
         if not candidates:
@@ -733,17 +647,6 @@ class BaseRegistry(metaclass=RegistryMeta):
     def get_dimensionality(self, input_units):
         """Convert unit or dict of units or dimensions to a dict of base dimensions
         dimensions
-
-        Parameters
-        ----------
-        input_units :
-            return: dimensionality
-
-        Returns
-        -------
-        type
-            dimensionality
-
         """
         input_units = to_units_container(input_units)
 
@@ -751,17 +654,6 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def _get_dimensionality(self, input_units):
         """Convert a UnitsContainer to base dimensions.
-
-        Parameters
-        ----------
-        input_units :
-            return: dimensionality
-
-        Returns
-        -------
-        type
-            dimensionality
-
         """
         if not input_units:
             return UnitsContainer()
@@ -811,7 +703,7 @@ class BaseRegistry(metaclass=RegistryMeta):
 
         Returns
         -------
-        type
+        number or None
             exponential proportionality or None if the units cannot be converted
 
         """
@@ -839,14 +731,14 @@ class BaseRegistry(metaclass=RegistryMeta):
         ----------
         input_units : UnitsContainer or str
             units
-        check_nonmult :
+        check_nonmult : bool
             if True, None will be returned as the
             multiplicative factor if a non-multiplicative
             units is found in the final Units. (Default value = True)
 
         Returns
         -------
-        type
+        number, Unit
             multiplicative factor, base units
 
         """
@@ -866,14 +758,14 @@ class BaseRegistry(metaclass=RegistryMeta):
         ----------
         input_units : UnitsContainer or dict
             units
-        check_nonmult :
+        check_nonmult : bool
             if True, None will be returned as the
             multiplicative factor if a non-multiplicative
             units is found in the final Units. (Default value = True)
 
         Returns
         -------
-        type
+        number, Unit
             multiplicative factor, base units
 
         """
@@ -919,7 +811,7 @@ class BaseRegistry(metaclass=RegistryMeta):
 
         Returns
         -------
-        type
+        Number, Unit
             multiplicative factor, base units
 
         """
@@ -940,17 +832,6 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def get_compatible_units(self, input_units, group_or_system=None):
         """
-
-        Parameters
-        ----------
-        input_units :
-            
-        group_or_system :
-             (Default value = None)
-
-        Returns
-        -------
-
         """
         input_units = to_units_container(input_units)
 
@@ -960,17 +841,6 @@ class BaseRegistry(metaclass=RegistryMeta):
 
     def _get_compatible_units(self, input_units, group_or_system):
         """
-
-        Parameters
-        ----------
-        input_units :
-            
-        group_or_system :
-            
-
-        Returns
-        -------
-
         """
         if not input_units:
             return frozenset()
@@ -1073,7 +943,7 @@ class BaseRegistry(metaclass=RegistryMeta):
 
         Returns
         -------
-        str, str, str), ...)
+        tuple of (str, str, str)
             all non-equivalent combinations of (prefix, unit name, suffix)
 
         """
@@ -1082,18 +952,7 @@ class BaseRegistry(metaclass=RegistryMeta):
         )
 
     def _parse_unit_name(self, unit_name, case_sensitive=True):
-        """Helper of parse_unit_name
-
-        Parameters
-        ----------
-        unit_name :
-            
-        case_sensitive :
-             (Default value = True)
-
-        Returns
-        -------
-
+        """Helper of parse_unit_name.
         """
         stw = unit_name.startswith
         edw = unit_name.endswith
@@ -1127,15 +986,6 @@ class BaseRegistry(metaclass=RegistryMeta):
         different names but equal value, preferring those with a prefix.
         
         e.g. ('kilo', 'gram', '') and ('', 'kilogram', '')
-
-        Parameters
-        ----------
-        candidates :
-            
-
-        Returns
-        -------
-
         """
         candidates = dict.fromkeys(candidates)  # ordered set
         for cp, cu, cs in list(candidates):
@@ -1155,11 +1005,10 @@ class BaseRegistry(metaclass=RegistryMeta):
 
         Parameters
         ----------
-        as_delta :
+        input_string : str
+        as_delta : bool or None
             if the expression has multiple units, the parser will
             interpret non multiplicative units as their `delta_` counterparts. (Default value = None)
-        input_string :
-            
 
         Returns
         -------
@@ -1171,19 +1020,10 @@ class BaseRegistry(metaclass=RegistryMeta):
         return self.Unit(units)
 
     def _parse_units(self, input_string, as_delta=True):
+        """Parse a units expression and returns a UnitContainer with
+        the canonical names.
         """
 
-        Parameters
-        ----------
-        input_string :
-            
-        as_delta :
-             (Default value = True)
-
-        Returns
-        -------
-
-        """
         cache = self._cache.parse_unit
         if as_delta:
             try:
@@ -1291,15 +1131,12 @@ class NonMultiplicativeRegistry(BaseRegistry):
 
     Parameters
     ----------
-    default_as_delta :
+    default_as_delta : bool
         If True, non-multiplicative units are interpreted as
         their *delta* counterparts in multiplications.
-    autoconvert_offset_to_baseunit :
+    autoconvert_offset_to_baseunit : bool
         If True, non-multiplicative units are
         converted to base units in multiplications.
-
-    Returns
-    -------
 
     """
 
@@ -1318,17 +1155,6 @@ class NonMultiplicativeRegistry(BaseRegistry):
 
     def _parse_units(self, input_string, as_delta=None):
         """
-
-        Parameters
-        ----------
-        input_string :
-            
-        as_delta :
-             (Default value = None)
-
-        Returns
-        -------
-
         """
         if as_delta is None:
             as_delta = self.default_as_delta
@@ -1343,8 +1169,8 @@ class NonMultiplicativeRegistry(BaseRegistry):
 
         Parameters
         ----------
-        definition : str | Definition
-            a dimension, unit or prefix definition.
+        definition : str or Definition
+            A dimension, unit or prefix definition.
 
         Returns
         -------
@@ -1487,13 +1313,6 @@ class ContextRegistry(BaseRegistry):
     - Register contexts.
     - Enable and disable contexts.
     - Parse @context directive.
-
-    Parameters
-    ----------
-
-    Returns
-    -------
-
     """
 
     def __init__(self, **kwargs):
@@ -1530,14 +1349,6 @@ class ContextRegistry(BaseRegistry):
         
         Notice that this method will NOT enable the context. Use `enable_contexts`.
 
-        Parameters
-        ----------
-        context: Context :
-            
-
-        Returns
-        -------
-
         """
         if not context.name:
             raise ValueError("Can't add unnamed context to registry")
@@ -1559,14 +1370,6 @@ class ContextRegistry(BaseRegistry):
         
         Notice that this methods will not disable the context. Use `disable_contexts`.
 
-        Parameters
-        ----------
-        name_or_alias: str :
-            
-
-        Returns
-        -------
-
         """
         context = self._contexts[name_or_alias]
 
@@ -1585,12 +1388,6 @@ class ContextRegistry(BaseRegistry):
         and self._units specific to the combination of active contexts.
         The next time this method is invoked with the same combination of contexts,
         reuse the same variant self._cache and self._units as in the previous time.
-
-        Parameters
-        ----------
-
-        Returns
-        -------
 
         """
         del self._units.maps[:-1]
@@ -1626,15 +1423,6 @@ class ContextRegistry(BaseRegistry):
 
     def _redefine(self, definition: UnitDefinition) -> None:
         """Redefine a unit from a context
-
-        Parameters
-        ----------
-        definition: UnitDefinition :
-            
-
-        Returns
-        -------
-
         """
         # Find original definition in the UnitRegistry
         candidates = self.parse_unit_name(definition.name)
@@ -1688,10 +1476,6 @@ class ContextRegistry(BaseRegistry):
         *names_or_contexts :
             
         **kwargs :
-            
-
-        Returns
-        -------
 
         """
 
@@ -1769,27 +1553,23 @@ class ContextRegistry(BaseRegistry):
         *names :
             
         **kwargs :
-            
 
-        Returns
+
+        Example
         -------
 
         >>> with ureg.context('one'):
-            ...     pass
-        
-            >>> with ureg.context('one', n=1):
-            ...     pass
-        
-            >>> with ureg.context('one', 'two', n=1):
-            ...     pass
-        
-            >>> with ureg.context('one', n=1):
-            ...     with ureg.context('two', n=2):
-            ...         pass
-        
-            >>> with ureg.context('one', n=1):
-            ...     with ureg.context('two'): # Here n takes the value of the upper context
-            ...         pass
+        ...     pass
+        >>> with ureg.context('one', n=1):
+        ...     pass
+        >>> with ureg.context('one', 'two', n=1):
+        ...     pass
+        >>> with ureg.context('one', n=1):
+        ...     with ureg.context('two', n=2):
+        ...         pass
+        >>> with ureg.context('one', n=1):
+        ...     with ureg.context('two'): # Here n takes the value of the upper context
+        ...         pass
         """
 
         # Enable the contexts.
@@ -1823,9 +1603,11 @@ class ContextRegistry(BaseRegistry):
 
         Returns
         -------
-        type
+        callable
             the wrapped function.
 
+        Example
+        -------
         >>> @ureg.with_context('sp')
             ... def my_cool_fun(wavelenght):
             ...     print('This wavelength is equivalent to: %s', wavelength.to('terahertz'))
@@ -1868,7 +1650,7 @@ class ContextRegistry(BaseRegistry):
 
         Returns
         -------
-        type
+        callable
             converted value
 
         """
@@ -1893,17 +1675,6 @@ class ContextRegistry(BaseRegistry):
 
     def _get_compatible_units(self, input_units, group_or_system):
         """
-
-        Parameters
-        ----------
-        input_units :
-            
-        group_or_system :
-            
-
-        Returns
-        -------
-
         """
 
         src_dim = self._get_dimensionality(input_units)
@@ -1932,12 +1703,6 @@ class SystemRegistry(BaseRegistry):
     - List systems
     - Get or get the default system.
     - Parse @system and @group directive.
-
-    Parameters
-    ----------
-
-    Returns
-    -------
 
     """
 
@@ -1968,13 +1733,6 @@ class SystemRegistry(BaseRegistry):
         Create default group.
         Add all orphan units to it.
         Set default system.
-
-        Parameters
-        ----------
-
-        Returns
-        -------
-
         """
         super()._after_init()
 
@@ -2162,19 +1920,6 @@ class SystemRegistry(BaseRegistry):
         return base_factor, destination_units
 
     def _get_compatible_units(self, input_units, group_or_system):
-        """
-
-        Parameters
-        ----------
-        input_units :
-            
-        group_or_system :
-            
-
-        Returns
-        -------
-
-        """
 
         if group_or_system is None:
             group_or_system = self._default_system
@@ -2223,10 +1968,6 @@ class UnitRegistry(SystemRegistry, ContextRegistry, NonMultiplicativeRegistry):
         or unit string
     fmt_locale :
         locale identifier string, used in `format_babel`. Default to None
-
-    Returns
-    -------
-
     """
 
     def __init__(
@@ -2264,7 +2005,7 @@ class UnitRegistry(SystemRegistry, ContextRegistry, NonMultiplicativeRegistry):
 
         Returns
         -------
-        type
+        list
             a list of dimensionless quantities expressed as dicts
 
         """
@@ -2277,9 +2018,6 @@ class UnitRegistry(SystemRegistry, ContextRegistry, NonMultiplicativeRegistry):
         ----------
         enable : bool
             whether support should be enabled or disabled (Default value = True)
-
-        Returns
-        -------
 
         """
         # Delays importing matplotlib until it's actually requested

--- a/pint/registry_helpers.py
+++ b/pint/registry_helpers.py
@@ -45,14 +45,14 @@ def _to_units_container(a, registry=None):
     Parameters
     ----------
     a :
-        
+
     registry :
          (Default value = None)
 
     Returns
     -------
     UnitsContainer, bool
-        
+
 
     """
     if isinstance(a, str) and "=" in a:
@@ -154,7 +154,7 @@ def _parse_wrap_args(args, registry=None):
 
 def _apply_defaults(func, args, kwargs):
     """Apply default keyword arguments.
-    
+
     Named keywords may have been left blank. This function applies the default
     values so that every argument is defined.
     """
@@ -170,15 +170,15 @@ def _apply_defaults(func, args, kwargs):
 
 def wraps(ureg, ret, args, strict=True):
     """Wraps a function to become pint-aware.
-    
+
     Use it when a function requires a numerical value but in some specific
     units. The wrapper function will take a pint quantity, convert to the units
     specified in `args` and then call the wrapped function with the resulting
     magnitude.
-    
+
     The value returned by the wrapped function will be converted to the units
     specified in `ret`.
-    
+
     Use None to skip argument conversion.
     Set strict to False, to accept also numerical values.
 
@@ -256,10 +256,10 @@ def wraps(ureg, ret, args, strict=True):
 
 def check(ureg, *args):
     """Decorator to for quantity type checking for function inputs.
-    
+
     Use it to ensure that the decorated function input parameters match
     the expected type of pint quantity.
-    
+
     Use None to skip argument checking.
 
     Parameters
@@ -269,7 +269,7 @@ def check(ureg, *args):
     args :
         iterable of input units.
     *args :
-        
+
 
     Returns
     -------

--- a/pint/registry_helpers.py
+++ b/pint/registry_helpers.py
@@ -51,7 +51,7 @@ def _to_units_container(a, registry=None):
 
     Returns
     -------
-    type
+    UnitsContainer, bool
         
 
     """
@@ -157,19 +157,6 @@ def _apply_defaults(func, args, kwargs):
     
     Named keywords may have been left blank. This function applies the default
     values so that every argument is defined.
-
-    Parameters
-    ----------
-    func :
-        
-    args :
-        
-    kwargs :
-        
-
-    Returns
-    -------
-
     """
 
     sig = signature(func)
@@ -203,12 +190,12 @@ def wraps(ureg, ret, args, strict=True):
         output units.
     args :
         iterable of input units.
-    strict :
-        boolean to indicate that only quantities are accepted. (Default value = True)
+    strict : bool
+        Indicates that only quantities are accepted. (Default value = True)
 
     Returns
     -------
-    type
+    callable
         the wrapped function.
 
     """

--- a/pint/registry_helpers.py
+++ b/pint/registry_helpers.py
@@ -19,8 +19,16 @@ from .util import UnitsContainer, to_units_container
 def _replace_units(original_units, values_by_name):
     """Convert a unit compatible type to a UnitsContainer.
 
-    :param original_units: a UnitsContainer instance.
-    :param values_by_name: a map between original names and the new values.
+    Parameters
+    ----------
+    original_units :
+        a UnitsContainer instance.
+    values_by_name :
+        a map between original names and the new values.
+
+    Returns
+    -------
+
     """
     q = 1
     for arg_name, exponent in original_units.items():
@@ -34,7 +42,18 @@ def _to_units_container(a, registry=None):
     checking if it is string field prefixed with an equal
     (which is considered a reference)
 
-    Return a tuple with the unit container and a boolean indicating if it was a reference.
+    Parameters
+    ----------
+    a :
+        
+    registry :
+         (Default value = None)
+
+    Returns
+    -------
+    type
+        
+
     """
     if isinstance(a, str) and "=" in a:
         return to_units_container(a.split("=", 1)[1]), True
@@ -135,9 +154,22 @@ def _parse_wrap_args(args, registry=None):
 
 def _apply_defaults(func, args, kwargs):
     """Apply default keyword arguments.
-
+    
     Named keywords may have been left blank. This function applies the default
     values so that every argument is defined.
+
+    Parameters
+    ----------
+    func :
+        
+    args :
+        
+    kwargs :
+        
+
+    Returns
+    -------
+
     """
 
     sig = signature(func)
@@ -151,25 +183,34 @@ def _apply_defaults(func, args, kwargs):
 
 def wraps(ureg, ret, args, strict=True):
     """Wraps a function to become pint-aware.
-
+    
     Use it when a function requires a numerical value but in some specific
     units. The wrapper function will take a pint quantity, convert to the units
     specified in `args` and then call the wrapped function with the resulting
     magnitude.
-
+    
     The value returned by the wrapped function will be converted to the units
     specified in `ret`.
-
+    
     Use None to skip argument conversion.
     Set strict to False, to accept also numerical values.
 
-    :param ureg: a UnitRegistry instance.
-    :param ret: output units.
-    :param args: iterable of input units.
-    :param strict: boolean to indicate that only quantities are accepted.
-    :return: the wrapped function.
-    :raises:
-        :class:`ValueError` if strict and one of the arguments is not a Quantity.
+    Parameters
+    ----------
+    ureg :
+        a UnitRegistry instance.
+    ret :
+        output units.
+    args :
+        iterable of input units.
+    strict :
+        boolean to indicate that only quantities are accepted. (Default value = True)
+
+    Returns
+    -------
+    type
+        the wrapped function.
+
     """
 
     if not isinstance(args, (list, tuple)):
@@ -228,17 +269,31 @@ def wraps(ureg, ret, args, strict=True):
 
 def check(ureg, *args):
     """Decorator to for quantity type checking for function inputs.
-
+    
     Use it to ensure that the decorated function input parameters match
     the expected type of pint quantity.
-
+    
     Use None to skip argument checking.
 
-    :param ureg: a UnitRegistry instance.
-    :param args: iterable of input units.
-    :return: the wrapped function.
-    :raises pint.DimensionalityError:
+    Parameters
+    ----------
+    ureg :
+        a UnitRegistry instance.
+    args :
+        iterable of input units.
+    *args :
+        
+
+    Returns
+    -------
+    type
+        the wrapped function.
+
+    Raises
+    ------
+    pint.DimensionalityError
         if the parameters don't match dimensions
+
     """
     dimensions = [
         ureg.get_dimensionality(dim) if dim is not None else None for dim in args

--- a/pint/systems.py
+++ b/pint/systems.py
@@ -41,13 +41,6 @@ class Group(SharedRegistryObject):
             ...
             <definition N>
         @end
-
-    Parameters
-    ----------
-
-    Returns
-    -------
-
     """
 
     #: Regex to match the header parts of a definition.
@@ -96,12 +89,6 @@ class Group(SharedRegistryObject):
         
         Calculated to include to all units in all included _used_groups.
 
-        Parameters
-        ----------
-
-        Returns
-        -------
-
         """
         if self._computed_members is None:
             self._computed_members = set(self._unit_names)
@@ -137,15 +124,6 @@ class Group(SharedRegistryObject):
 
     def add_units(self, *unit_names):
         """Add units to group.
-
-        Parameters
-        ----------
-        *unit_names :
-            
-
-        Returns
-        -------
-
         """
         for unit_name in unit_names:
             self._unit_names.add(unit_name)
@@ -158,15 +136,6 @@ class Group(SharedRegistryObject):
 
     def remove_units(self, *unit_names):
         """Remove units from group.
-
-        Parameters
-        ----------
-        *unit_names :
-            
-
-        Returns
-        -------
-
         """
         for unit_name in unit_names:
             self._unit_names.remove(unit_name)
@@ -175,15 +144,6 @@ class Group(SharedRegistryObject):
 
     def add_groups(self, *group_names):
         """Add groups to group.
-
-        Parameters
-        ----------
-        *group_names :
-            
-
-        Returns
-        -------
-
         """
         d = self._REGISTRY._groups
         for group_name in group_names:
@@ -203,15 +163,6 @@ class Group(SharedRegistryObject):
 
     def remove_groups(self, *group_names):
         """Remove groups from group.
-
-        Parameters
-        ----------
-        *group_names :
-            
-
-        Returns
-        -------
-
         """
         d = self._REGISTRY._groups
         for group_name in group_names:
@@ -314,13 +265,6 @@ class System(SharedRegistryObject):
         - new_unit_name: a non root unit which is going to replace the old_unit.
     
     If the new_unit_name and the old_unit_name, the later and the colon can be ommited.
-
-    Parameters
-    ----------
-
-    Returns
-    -------
-
     """
 
     #: Regex to match the header parts of a context.
@@ -390,15 +334,6 @@ class System(SharedRegistryObject):
 
     def add_groups(self, *group_names):
         """Add groups to group.
-
-        Parameters
-        ----------
-        *group_names :
-            
-
-        Returns
-        -------
-
         """
         self._used_groups |= set(group_names)
 
@@ -406,31 +341,13 @@ class System(SharedRegistryObject):
 
     def remove_groups(self, *group_names):
         """Remove groups from group.
-
-        Parameters
-        ----------
-        *group_names :
-            
-
-        Returns
-        -------
-
         """
         self._used_groups -= set(group_names)
 
         self.invalidate_members()
 
     def format_babel(self, locale):
-        """translate the name of the system
-
-        Parameters
-        ----------
-        locale :
-            
-
-        Returns
-        -------
-
+        """translate the name of the system.
         """
         if locale and self.name in _babel_systems:
             name = _babel_systems[self.name]

--- a/pint/systems.py
+++ b/pint/systems.py
@@ -26,21 +26,28 @@ from .util import (
 
 class Group(SharedRegistryObject):
     """A group is a set of units.
-
+    
     Units can be added directly or by including other groups.
-
+    
     Members are computed dynamically, that is if a unit is added to a group X
     all groups that include X are affected.
-
+    
     The group belongs to one Registry.
-
+    
     It can be specified in the definition file as::
-
+    
         @group <name> [using <group 1>, ..., <group N>]
             <definition 1>
             ...
             <definition N>
         @end
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     #: Regex to match the header parts of a definition.
@@ -86,10 +93,15 @@ class Group(SharedRegistryObject):
     @property
     def members(self):
         """Names of the units that are members of the group.
-
+        
         Calculated to include to all units in all included _used_groups.
 
-        :rtype: frozenset[str]
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         if self._computed_members is None:
             self._computed_members = set(self._unit_names)
@@ -102,8 +114,7 @@ class Group(SharedRegistryObject):
         return self._computed_members
 
     def invalidate_members(self):
-        """Invalidate computed members in this Group and all parent nodes.
-        """
+        """Invalidate computed members in this Group and all parent nodes."""
         self._computed_members = None
         d = self._REGISTRY._groups
         for name in self._used_by:
@@ -127,7 +138,14 @@ class Group(SharedRegistryObject):
     def add_units(self, *unit_names):
         """Add units to group.
 
-        :type unit_names: str
+        Parameters
+        ----------
+        *unit_names :
+            
+
+        Returns
+        -------
+
         """
         for unit_name in unit_names:
             self._unit_names.add(unit_name)
@@ -141,7 +159,14 @@ class Group(SharedRegistryObject):
     def remove_units(self, *unit_names):
         """Remove units from group.
 
-        :type unit_names: str
+        Parameters
+        ----------
+        *unit_names :
+            
+
+        Returns
+        -------
+
         """
         for unit_name in unit_names:
             self._unit_names.remove(unit_name)
@@ -151,7 +176,14 @@ class Group(SharedRegistryObject):
     def add_groups(self, *group_names):
         """Add groups to group.
 
-        :type group_names: str
+        Parameters
+        ----------
+        *group_names :
+            
+
+        Returns
+        -------
+
         """
         d = self._REGISTRY._groups
         for group_name in group_names:
@@ -172,7 +204,14 @@ class Group(SharedRegistryObject):
     def remove_groups(self, *group_names):
         """Remove groups from group.
 
-        :type group_names: str
+        Parameters
+        ----------
+        *group_names :
+            
+
+        Returns
+        -------
+
         """
         d = self._REGISTRY._groups
         for group_name in group_names:
@@ -187,10 +226,16 @@ class Group(SharedRegistryObject):
     def from_lines(cls, lines, define_func):
         """Return a Group object parsing an iterable of lines.
 
-        :param lines: iterable
-        :type lines: list[str]
-        :param define_func: Function to define a unit in the registry.
-        :type define_func: str -> None
+        Parameters
+        ----------
+        lines : list[str]
+            iterable
+        define_func : str -> None
+            Function to define a unit in the registry.
+
+        Returns
+        -------
+
         """
         lines = SourceIterator(lines)
         lineno, header = next(lines)
@@ -246,29 +291,36 @@ class Group(SharedRegistryObject):
 
 class System(SharedRegistryObject):
     """A system is a Group plus a set of base units.
-
+    
     Members are computed dynamically, that is if a unit is added to a group X
     all groups that include X are affected.
-
+    
     The System belongs to one Registry.
-
+    
     It can be specified in the definition file as::
-
+    
         @system <name> [using <group 1>, ..., <group N>]
             <rule 1>
             ...
             <rule N>
         @end
-
+    
     The syntax for the rule is:
-
+    
         new_unit_name : old_unit_name
-
+    
     where:
         - old_unit_name: a root unit part which is going to be removed from the system.
         - new_unit_name: a non root unit which is going to replace the old_unit.
-
+    
     If the new_unit_name and the old_unit_name, the later and the colon can be ommited.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     #: Regex to match the header parts of a context.
@@ -333,14 +385,20 @@ class System(SharedRegistryObject):
         return self._computed_members
 
     def invalidate_members(self):
-        """Invalidate computed members in this Group and all parent nodes.
-        """
+        """Invalidate computed members in this Group and all parent nodes."""
         self._computed_members = None
 
     def add_groups(self, *group_names):
         """Add groups to group.
 
-        :type group_names: str
+        Parameters
+        ----------
+        *group_names :
+            
+
+        Returns
+        -------
+
         """
         self._used_groups |= set(group_names)
 
@@ -349,7 +407,14 @@ class System(SharedRegistryObject):
     def remove_groups(self, *group_names):
         """Remove groups from group.
 
-        :type group_names: str
+        Parameters
+        ----------
+        *group_names :
+            
+
+        Returns
+        -------
+
         """
         self._used_groups -= set(group_names)
 
@@ -358,7 +423,14 @@ class System(SharedRegistryObject):
     def format_babel(self, locale):
         """translate the name of the system
 
-        :type locale: Locale
+        Parameters
+        ----------
+        locale :
+            
+
+        Returns
+        -------
+
         """
         if locale and self.name in _babel_systems:
             name = _babel_systems[self.name]

--- a/pint/systems.py
+++ b/pint/systems.py
@@ -26,16 +26,16 @@ from .util import (
 
 class Group(SharedRegistryObject):
     """A group is a set of units.
-    
+
     Units can be added directly or by including other groups.
-    
+
     Members are computed dynamically, that is if a unit is added to a group X
     all groups that include X are affected.
-    
+
     The group belongs to one Registry.
-    
+
     It can be specified in the definition file as::
-    
+
         @group <name> [using <group 1>, ..., <group N>]
             <definition 1>
             ...
@@ -86,7 +86,7 @@ class Group(SharedRegistryObject):
     @property
     def members(self):
         """Names of the units that are members of the group.
-        
+
         Calculated to include to all units in all included _used_groups.
 
         """
@@ -242,28 +242,28 @@ class Group(SharedRegistryObject):
 
 class System(SharedRegistryObject):
     """A system is a Group plus a set of base units.
-    
+
     Members are computed dynamically, that is if a unit is added to a group X
     all groups that include X are affected.
-    
+
     The System belongs to one Registry.
-    
+
     It can be specified in the definition file as::
-    
+
         @system <name> [using <group 1>, ..., <group N>]
             <rule 1>
             ...
             <rule N>
         @end
-    
+
     The syntax for the rule is:
-    
+
         new_unit_name : old_unit_name
-    
+
     where:
         - old_unit_name: a root unit part which is going to be removed from the system.
         - new_unit_name: a non root unit which is going to replace the old_unit.
-    
+
     If the new_unit_name and the old_unit_name, the later and the colon can be ommited.
     """
 

--- a/pint/testsuite/__init__.py
+++ b/pint/testsuite/__init__.py
@@ -117,8 +117,7 @@ class QuantityTestCase(BaseTestCase):
 
 
 def testsuite():
-    """A testsuite that has all the pint tests.
-    """
+    """A testsuite that has all the pint tests."""
     suite = unittest.TestLoader().discover(os.path.dirname(__file__))
     from pint.compat import HAS_NUMPY, HAS_UNCERTAINTIES
 
@@ -135,8 +134,7 @@ def testsuite():
 
 
 def main():
-    """Runs the testsuite as command line application.
-    """
+    """Runs the testsuite as command line application."""
     try:
         unittest.main()
     except Exception as e:
@@ -145,8 +143,15 @@ def main():
 
 def run():
     """Run all tests.
-
+    
     :return: a :class:`unittest.TestResult` object
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
     test_runner = unittest.TextTestRunner()
     return test_runner.run(testsuite())
@@ -165,7 +170,14 @@ _GLOBS = {
 def add_docs(suite):
     """Add docs to suite
 
-    :type suite: unittest.TestSuite
+    Parameters
+    ----------
+    suite :
+        
+
+    Returns
+    -------
+
     """
     docpath = os.path.join(os.path.dirname(__file__), "..", "..", "docs")
     docpath = os.path.abspath(docpath)

--- a/pint/testsuite/__init__.py
+++ b/pint/testsuite/__init__.py
@@ -143,7 +143,7 @@ def main():
 
 def run():
     """Run all tests.
-    
+
     :return: a :class:`unittest.TestResult` object
 
     Parameters
@@ -173,7 +173,7 @@ def add_docs(suite):
     Parameters
     ----------
     suite :
-        
+
 
     Returns
     -------

--- a/pint/testsuite/parameterized.py
+++ b/pint/testsuite/parameterized.py
@@ -109,7 +109,7 @@ class ParameterizedTestMixin(metaclass=ParameterizedTestCaseMetaClass):
         cls, param_names, data, func_name_format="{func_name}_{case_num:05d}"
     ):
         """Decorator for parameterizing a test method - example:
-        
+
         @ParameterizedTestCase.parameterize(
             ("isbn", "expected_title"), [
                 ("0262033844", "Introduction to Algorithms"),
@@ -118,9 +118,9 @@ class ParameterizedTestMixin(metaclass=ParameterizedTestCaseMetaClass):
         Parameters
         ----------
         param_names :
-            
+
         data :
-            
+
         func_name_format :
              (Default value = "{func_name}_{case_num:05d}")
 

--- a/pint/testsuite/parameterized.py
+++ b/pint/testsuite/parameterized.py
@@ -109,11 +109,23 @@ class ParameterizedTestMixin(metaclass=ParameterizedTestCaseMetaClass):
         cls, param_names, data, func_name_format="{func_name}_{case_num:05d}"
     ):
         """Decorator for parameterizing a test method - example:
-
+        
         @ParameterizedTestCase.parameterize(
             ("isbn", "expected_title"), [
                 ("0262033844", "Introduction to Algorithms"),
                 ("0321558146", "Campbell Essential Biology")])
+
+        Parameters
+        ----------
+        param_names :
+            
+        data :
+            
+        func_name_format :
+             (Default value = "{func_name}_{case_num:05d}")
+
+        Returns
+        -------
 
         """
 

--- a/pint/testsuite/test_application_registry.py
+++ b/pint/testsuite/test_application_registry.py
@@ -145,6 +145,13 @@ class TestCustomApplicationRegistry(BaseTestCase):
 class TestSwapApplicationRegistry(BaseTestCase):
     """Test that the constructors of Quantity, Unit, and Measurement capture
     the registry that is set as the application registry at creation time
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def setUp(self):

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -527,21 +527,21 @@ class TestIssues(QuantityTestCase):
         @ureg.wraps(ureg.second, (ureg.meters, ureg.meters / ureg.second ** 2))
         def calculate_time_to_fall(height, gravity=Q_(9.8, "m/s^2")):
             """Calculate time to fall from a height h with a default gravity.
-            
+
             By default, the gravity is assumed to be earth gravity,
             but it can be modified.
-            
+
             d = .5 * g * t**2
             t = sqrt(2 * d / g)
 
             Parameters
             ----------
             height :
-                
+
             gravity :
                  (Default value = Q_(9.8)
             "m/s^2") :
-                
+
 
             Returns
             -------
@@ -568,11 +568,11 @@ class TestIssues(QuantityTestCase):
             Parameters
             ----------
             time :
-                
+
             rate :
                  (Default value = Q_(1)
             "m/s") :
-                
+
 
             Returns
             -------

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -527,12 +527,25 @@ class TestIssues(QuantityTestCase):
         @ureg.wraps(ureg.second, (ureg.meters, ureg.meters / ureg.second ** 2))
         def calculate_time_to_fall(height, gravity=Q_(9.8, "m/s^2")):
             """Calculate time to fall from a height h with a default gravity.
-
+            
             By default, the gravity is assumed to be earth gravity,
             but it can be modified.
-
+            
             d = .5 * g * t**2
             t = sqrt(2 * d / g)
+
+            Parameters
+            ----------
+            height :
+                
+            gravity :
+                 (Default value = Q_(9.8)
+            "m/s^2") :
+                
+
+            Returns
+            -------
+
             """
             return sqrt(2 * height / gravity)
 
@@ -551,6 +564,19 @@ class TestIssues(QuantityTestCase):
         @ureg.wraps("=A*B", ("=A", "=B"))
         def get_displacement(time, rate=Q_(1, "m/s")):
             """Calculates displacement from a duration and default rate.
+
+            Parameters
+            ----------
+            time :
+                
+            rate :
+                 (Default value = Q_(1)
+            "m/s") :
+                
+
+            Returns
+            -------
+
             """
             return time * rate
 
@@ -649,6 +675,13 @@ class TestIssues(QuantityTestCase):
         """pprint.pformat() invokes sorted() on large sets and frozensets and graciously
         handles TypeError, but not generic Exceptions. This test will fail if
         pint.DimensionalityError stops being a subclass of TypeError.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         meter_units = ureg.get_compatible_units(ureg.meter)
         hertz_units = ureg.get_compatible_units(ureg.hertz)

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1124,9 +1124,9 @@ class TestNumpyUnclassified(TestNumpyMethods):
 @unittest.skip
 class TestBitTwiddlingUfuncs(TestUFuncs):
     """Universal functions (ufuncs) >  Bittwiddling functions
-    
+
     http://docs.scipy.org/doc/numpy/reference/ufuncs.html#bittwiddlingfunctions
-    
+
     bitwise_and(x1, x2[, out])         Compute the bitwise AND of two arrays elementwise.
     bitwise_or(x1, x2[, out])  Compute the bitwise OR of two arrays elementwise.
     bitwise_xor(x1, x2[, out])         Compute the bitwise XOR of two arrays elementwise.

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -802,8 +802,7 @@ class TestNumpyUnclassified(TestNumpyMethods):
         self.assertFalse(np.iterable(1 * self.ureg.m))
 
     def test_reversible_op(self):
-        """
-        """
+        """ """
         x = self.q.magnitude
         u = self.Q_(np.ones(x.shape))
         self.assertQuantityEqual(x / self.q, u * x / self.q)
@@ -1125,15 +1124,22 @@ class TestNumpyUnclassified(TestNumpyMethods):
 @unittest.skip
 class TestBitTwiddlingUfuncs(TestUFuncs):
     """Universal functions (ufuncs) >  Bittwiddling functions
-
+    
     http://docs.scipy.org/doc/numpy/reference/ufuncs.html#bittwiddlingfunctions
-
+    
     bitwise_and(x1, x2[, out])         Compute the bitwise AND of two arrays elementwise.
     bitwise_or(x1, x2[, out])  Compute the bitwise OR of two arrays elementwise.
     bitwise_xor(x1, x2[, out])         Compute the bitwise XOR of two arrays elementwise.
     invert(x[, out])   Compute bitwise inversion, or bitwise NOT, elementwise.
     left_shift(x1, x2[, out])  Shift the bits of an integer to the left.
     right_shift(x1, x2[, out])         Shift the bits of an integer to the right.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     @property

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -1502,6 +1502,13 @@ class TestCompareZero(QuantityTestCase):
     """This test case checks the special treatment that the zero value
     receives in the comparisons: pint>=0.9 supports comparisons against zero
     even for non-dimensionless quantities
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def test_equal_zero(self):

--- a/pint/testsuite/test_umath.py
+++ b/pint/testsuite/test_umath.py
@@ -146,7 +146,7 @@ class TestUFuncs(QuantityTestCase):
         rtol :
             relative tolerance. (Default value = 1e-6)
         "same") :
-            
+
 
         Returns
         -------
@@ -271,9 +271,9 @@ class TestUFuncs(QuantityTestCase):
 @helpers.requires_numpy()
 class TestMathUfuncs(TestUFuncs):
     """Universal functions (ufunc) > Math operations
-    
+
     http://docs.scipy.org/doc/numpy/reference/ufuncs.html#math-operations
-    
+
     add(x1, x2[, out]) 	Add arguments element-wise.
     subtract(x1, x2[, out]) 	Subtract arguments, element-wise.
     multiply(x1, x2[, out]) 	Multiply arguments element-wise.
@@ -419,9 +419,9 @@ class TestMathUfuncs(TestUFuncs):
 @helpers.requires_numpy()
 class TestTrigUfuncs(TestUFuncs):
     """Universal functions (ufunc) > Trigonometric functions
-    
+
     http://docs.scipy.org/doc/numpy/reference/ufuncs.html#trigonometric-functions
-    
+
     sin(x[, out]) 	Trigonometric sine, element-wise.
     cos(x[, out]) 	Cosine elementwise.
     tan(x[, out]) 	Compute tangent element-wise.
@@ -676,9 +676,9 @@ class TestTrigUfuncs(TestUFuncs):
 
 class TestComparisonUfuncs(TestUFuncs):
     """Universal functions (ufunc) > Comparison functions
-    
+
     http://docs.scipy.org/doc/numpy/reference/ufuncs.html#comparison-functions
-    
+
     greater(x1, x2[, out]) 	Return the truth value of (x1 > x2) element-wise.
     greater_equal(x1, x2[, out]) 	Return the truth value of (x1 >= x2) element-wise.
     less(x1, x2[, out]) 	Return the truth value of (x1 < x2) element-wise.
@@ -715,9 +715,9 @@ class TestComparisonUfuncs(TestUFuncs):
 
 class TestFloatingUfuncs(TestUFuncs):
     """Universal functions (ufunc) > Floating functions
-    
+
     http://docs.scipy.org/doc/numpy/reference/ufuncs.html#floating-functions
-    
+
     isreal(x) 	Returns a bool array, where True if input element is real.
     iscomplex(x) 	Returns a bool array, where True if input element is complex.
     isfinite(x[, out]) 	Test element-wise for finite-ness (not infinity or not Not a Number).

--- a/pint/testsuite/test_umath.py
+++ b/pint/testsuite/test_umath.py
@@ -42,18 +42,30 @@ class TestUFuncs(QuantityTestCase):
     ):
         """Test function that takes a single argument and returns Quantity.
 
-        :param func: function callable.
-        :param ok_with: iterables of values that work fine.
-        :param raise_with: iterables of values that raise exceptions.
-        :param output_units: units to be used when building results.
-                             'same': ok_with[n].units (default).
-                             is float: ok_with[n].units ** output_units.
-                             None: no output units, the result should be an ndarray.
-                             Other value will be parsed as unit.
-        :param results: iterable of results.
-                        If None, the result will be obtained by applying
-                        func to each ok_with value
-        :param rtol: relative tolerance.
+        Parameters
+        ----------
+        func :
+            function callable.
+        ok_with :
+            iterables of values that work fine.
+        raise_with :
+            iterables of values that raise exceptions. (Default value = ())
+        output_units :
+            units to be used when building results.
+            'same': ok_with[n].units (default).
+            is float: ok_with[n].units ** output_units.
+            None: no output units, the result should be an ndarray.
+            Other value will be parsed as unit.
+        results :
+            iterable of results.
+            If None, the result will be obtained by applying
+            func to each ok_with value (Default value = None)
+        rtol :
+            relative tolerance. (Default value = 1e-6)
+
+        Returns
+        -------
+
         """
         if results is None:
             results = [None] * len(ok_with)
@@ -83,12 +95,22 @@ class TestUFuncs(QuantityTestCase):
     def _testn(self, func, ok_with, raise_with=(), results=None):
         """Test function that takes a single argument and returns and ndarray (not a Quantity)
 
-        :param func: function callable.
-        :param ok_with: iterables of values that work fine.
-        :param raise_with: iterables of values that raise exceptions.
-        :param results: iterable of results.
-                        If None, the result will be obtained by applying
-                        func to each ok_with value
+        Parameters
+        ----------
+        func :
+            function callable.
+        ok_with :
+            iterables of values that work fine.
+        raise_with :
+            iterables of values that raise exceptions. (Default value = ())
+        results :
+            iterable of results.
+            If None, the result will be obtained by applying
+            func to each ok_with value (Default value = None)
+
+        Returns
+        -------
+
         """
         self._test1(func, ok_with, raise_with, output_units=None, results=results)
 
@@ -103,18 +125,32 @@ class TestUFuncs(QuantityTestCase):
     ):
         """Test functions that takes a single argument and return two Quantities.
 
-        :param func: function callable.
-        :param ok_with: iterables of values that work fine.
-        :param raise_with: iterables of values that raise exceptions.
-        :param output_units: tuple of units to be used when building the result tuple.
-                             'same': ok_with[n].units (default).
-                             is float: ok_with[n].units ** output_units.
-                             None: no output units, the result should be an ndarray.
-                             Other value will be parsed as unit.
-        :param results: iterable of results.
-                        If None, the result will be obtained by applying
-                        func to each ok_with value
-        :param rtol: relative tolerance.
+        Parameters
+        ----------
+        func :
+            function callable.
+        ok_with :
+            iterables of values that work fine.
+        raise_with :
+            iterables of values that raise exceptions. (Default value = ())
+        output_units :
+            tuple of units to be used when building the result tuple.
+            'same': ok_with[n].units (default).
+            is float: ok_with[n].units ** output_units.
+            None: no output units, the result should be an ndarray.
+            Other value will be parsed as unit.
+        results :
+            iterable of results.
+            If None, the result will be obtained by applying
+            func to each ok_with value (Default value = None)
+        rtol :
+            relative tolerance. (Default value = 1e-6)
+        "same") :
+            
+
+        Returns
+        -------
+
         """
 
         if results is None:
@@ -152,19 +188,32 @@ class TestUFuncs(QuantityTestCase):
     ):
         """Test function that takes two arguments and return a Quantity.
 
-        :param func: function callable.
-        :param x1: first argument of func.
-        :param ok_with: iterables of values that work fine.
-        :param raise_with: iterables of values that raise exceptions.
-        :param output_units: units to be used when building results.
-                             'same': x1.units (default).
-                             'prod': x1.units * ok_with[n].units
-                             'div': x1.units / ok_with[n].units
-                             'second': x1.units * ok_with[n]
-                             None: no output units, the result should be an ndarray.
-                             Other value will be parsed as unit.
-        :param rtol: relative tolerance.
-        :param convert2: if the ok_with[n] should be converted to x1.units.
+        Parameters
+        ----------
+        func :
+            function callable.
+        x1 :
+            first argument of func.
+        ok_with :
+            iterables of values that work fine.
+        raise_with :
+            iterables of values that raise exceptions. (Default value = ())
+        output_units :
+            units to be used when building results.
+            'same': x1.units (default).
+            'prod': x1.units * ok_with[n].units
+            'div': x1.units / ok_with[n].units
+            'second': x1.units * ok_with[n]
+            None: no output units, the result should be an ndarray.
+            Other value will be parsed as unit.
+        rtol :
+            relative tolerance. (Default value = 1e-6)
+        convert2 :
+            if the ok_with[n] should be converted to x1.units. (Default value = True)
+
+        Returns
+        -------
+
         """
         for x2 in ok_with:
             err_msg = "At {} with {} and {}".format(func.__name__, x1, x2)
@@ -201,10 +250,20 @@ class TestUFuncs(QuantityTestCase):
     def _testn2(self, func, x1, ok_with, raise_with=()):
         """Test function that takes two arguments and return a ndarray.
 
-        :param func: function callable.
-        :param x1: first argument of func.
-        :param ok_with: iterables of values that work fine.
-        :param raise_with: iterables of values that raise exceptions.
+        Parameters
+        ----------
+        func :
+            function callable.
+        x1 :
+            first argument of func.
+        ok_with :
+            iterables of values that work fine.
+        raise_with :
+            iterables of values that raise exceptions. (Default value = ())
+
+        Returns
+        -------
+
         """
         self._test2(func, x1, ok_with, raise_with, output_units=None)
 
@@ -212,9 +271,9 @@ class TestUFuncs(QuantityTestCase):
 @helpers.requires_numpy()
 class TestMathUfuncs(TestUFuncs):
     """Universal functions (ufunc) > Math operations
-
+    
     http://docs.scipy.org/doc/numpy/reference/ufuncs.html#math-operations
-
+    
     add(x1, x2[, out]) 	Add arguments element-wise.
     subtract(x1, x2[, out]) 	Subtract arguments, element-wise.
     multiply(x1, x2[, out]) 	Multiply arguments element-wise.
@@ -243,6 +302,13 @@ class TestMathUfuncs(TestUFuncs):
     square(x[, out]) 	Return the element-wise square of the input.
     reciprocal(x[, out]) 	Return the reciprocal of the argument, element-wise.
     ones_like(x[, out]) 	Returns an array of ones with the same shape and type as a given array.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def test_add(self):
@@ -353,9 +419,9 @@ class TestMathUfuncs(TestUFuncs):
 @helpers.requires_numpy()
 class TestTrigUfuncs(TestUFuncs):
     """Universal functions (ufunc) > Trigonometric functions
-
+    
     http://docs.scipy.org/doc/numpy/reference/ufuncs.html#trigonometric-functions
-
+    
     sin(x[, out]) 	Trigonometric sine, element-wise.
     cos(x[, out]) 	Cosine elementwise.
     tan(x[, out]) 	Compute tangent element-wise.
@@ -372,6 +438,13 @@ class TestTrigUfuncs(TestUFuncs):
     arctanh(x[, out]) 	Inverse hyperbolic tangent elementwise.
     deg2rad(x[, out]) 	Convert angles from degrees to radians.
     rad2deg(x[, out]) 	Convert angles from radians to degrees.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def test_sin(self):
@@ -603,15 +676,22 @@ class TestTrigUfuncs(TestUFuncs):
 
 class TestComparisonUfuncs(TestUFuncs):
     """Universal functions (ufunc) > Comparison functions
-
+    
     http://docs.scipy.org/doc/numpy/reference/ufuncs.html#comparison-functions
-
+    
     greater(x1, x2[, out]) 	Return the truth value of (x1 > x2) element-wise.
     greater_equal(x1, x2[, out]) 	Return the truth value of (x1 >= x2) element-wise.
     less(x1, x2[, out]) 	Return the truth value of (x1 < x2) element-wise.
     less_equal(x1, x2[, out]) 	Return the truth value of (x1 =< x2) element-wise.
     not_equal(x1, x2[, out]) 	Return (x1 != x2) element-wise.
     equal(x1, x2[, out]) 	Return (x1 == x2) element-wise.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def test_greater(self):
@@ -635,9 +715,9 @@ class TestComparisonUfuncs(TestUFuncs):
 
 class TestFloatingUfuncs(TestUFuncs):
     """Universal functions (ufunc) > Floating functions
-
+    
     http://docs.scipy.org/doc/numpy/reference/ufuncs.html#floating-functions
-
+    
     isreal(x) 	Returns a bool array, where True if input element is real.
     iscomplex(x) 	Returns a bool array, where True if input element is complex.
     isfinite(x[, out]) 	Test element-wise for finite-ness (not infinity or not Not a Number).
@@ -653,6 +733,13 @@ class TestFloatingUfuncs(TestUFuncs):
     floor(x[, out]) 	Return the floor of the input, element-wise.
     ceil(x[, out]) 	Return the ceiling of the input, element-wise.
     trunc(x[, out]) 	Return the truncated value of the input, element-wise.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def test_isreal(self):

--- a/pint/unit.py
+++ b/pint/unit.py
@@ -116,7 +116,7 @@ class Unit(PrettyIPython, SharedRegistryObject):
 
     @property
     def dimensionless(self):
-        """ """
+        """Return true if the Unit is dimensionless."""
         return not bool(self.dimensionality)
 
     @property

--- a/pint/unit.py
+++ b/pint/unit.py
@@ -20,11 +20,7 @@ from .util import PrettyIPython, SharedRegistryObject, UnitsContainer
 
 
 class Unit(PrettyIPython, SharedRegistryObject):
-    """Implements a class to describe a unit supporting math operations.
-
-    :type units: UnitsContainer, str, Unit or Quantity.
-
-    """
+    """Implements a class to describe a unit supporting math operations."""
 
     #: Default formatting string.
     default_format = ""
@@ -120,16 +116,12 @@ class Unit(PrettyIPython, SharedRegistryObject):
 
     @property
     def dimensionless(self):
-        """Return true if the Unit is dimensionless.
-
-        """
+        """ """
         return not bool(self.dimensionality)
 
     @property
     def dimensionality(self):
-        """Unit's dimensionality (e.g. {length: 1, time: -1})
-
-        """
+        """Unit's dimensionality (e.g. {length: 1, time: -1})"""
         try:
             return self._dimensionality
         except AttributeError:
@@ -263,12 +255,20 @@ class Unit(PrettyIPython, SharedRegistryObject):
     def from_(self, value, strict=True, name="value"):
         """Converts a numerical value or quantity to this unit
 
-        :param value: a Quantity (or numerical value if strict=False) to convert
-        :param strict: boolean to indicate that only quanities are accepted
-        :param name: descriptive name to use if an exception occurs
-        :return: The converted value as this unit
-        :raises:
-            :class:`ValueError` if strict and one of the arguments is not a Quantity.
+        Parameters
+        ----------
+        value :
+            a Quantity (or numerical value if strict=False) to convert
+        strict :
+            boolean to indicate that only quanities are accepted (Default value = True)
+        name :
+            descriptive name to use if an exception occurs (Default value = "value")
+
+        Returns
+        -------
+        type
+            The converted value as this unit
+
         """
         if self._check(value):
             if not isinstance(value, self._REGISTRY.Quantity):
@@ -283,12 +283,20 @@ class Unit(PrettyIPython, SharedRegistryObject):
         """Converts a numerical value or quantity to this unit, then returns
         the magnitude of the converted value
 
-        :param value: a Quantity (or numerical value if strict=False) to convert
-        :param strict: boolean to indicate that only quanities are accepted
-        :param name: descriptive name to use if an exception occurs
-        :return: The magnitude of the converted value
-        :raises:
-            :class:`ValueError` if strict and one of the arguments is not a Quantity.
+        Parameters
+        ----------
+        value :
+            a Quantity (or numerical value if strict=False) to convert
+        strict :
+            boolean to indicate that only quanities are accepted (Default value = True)
+        name :
+            descriptive name to use if an exception occurs (Default value = "value")
+
+        Returns
+        -------
+        type
+            The magnitude of the converted value
+
         """
         return self.from_(value, strict=strict, name=name).magnitude
 

--- a/pint/util.py
+++ b/pint/util.py
@@ -891,12 +891,6 @@ class SourceIterator:
     for lineno, line in SourceIterator(sequence):
         # do something here
 
-    Parameters
-    ----------
-
-    Returns
-    -------
-
     """
 
     def __new__(cls, sequence):
@@ -933,13 +927,6 @@ class SourceIterator:
 class BlockIterator(SourceIterator):
     """Like SourceIterator but stops when it finds '@end'
     It also raises an error if another '@' directive is found inside.
-
-    Parameters
-    ----------
-
-    Returns
-    -------
-
     """
 
     def __new__(cls, line_iterator):
@@ -978,10 +965,6 @@ def iterable(y):
     type :
         object
     y :
-        
-
-    Returns
-    -------
 
     """
     try:
@@ -1001,10 +984,6 @@ def sized(y):
     type :
         object
     y :
-        
-
-    Returns
-    -------
 
     """
     try:

--- a/pint/util.py
+++ b/pint/util.py
@@ -37,7 +37,7 @@ def matrix_to_string(
     Parameters
     ----------
     matrix :
-        
+
     row_headers :
          (Default value = None)
     col_headers :
@@ -69,7 +69,7 @@ def transpose(matrix):
     Parameters
     ----------
     matrix :
-        
+
 
     Returns
     -------
@@ -305,7 +305,7 @@ class udict(dict):
 class UnitsContainer(Mapping):
     """The UnitsContainer stores the product of units and their respective
     exponent and implements the corresponding operations.
-    
+
     UnitsContainer is a read-only mapping. All operations (even in place ones)
 
     Parameters
@@ -314,7 +314,7 @@ class UnitsContainer(Mapping):
     Returns
     -------
     type
-        
+
 
     """
 
@@ -351,7 +351,7 @@ class UnitsContainer(Mapping):
         Parameters
         ----------
         keys :
-            
+
 
         Returns
         -------
@@ -369,9 +369,9 @@ class UnitsContainer(Mapping):
         Parameters
         ----------
         oldkey :
-            
+
         newkey :
-            
+
 
         Returns
         -------
@@ -490,7 +490,7 @@ class UnitsContainer(Mapping):
 class ParserHelper(UnitsContainer):
     """The ParserHelper stores in place the product of variables and
     their respective exponent and implements the corresponding operations.
-    
+
     ParserHelper is a read-only mapping. All operations (even in place ones)
 
     Parameters
@@ -514,13 +514,13 @@ class ParserHelper(UnitsContainer):
     @classmethod
     def from_word(cls, input_word):
         """Creates a ParserHelper object with a single variable with exponent one.
-        
+
         Equivalent to: ParserHelper({'word': 1})
 
         Parameters
         ----------
         input_word :
-            
+
 
         Returns
         -------
@@ -552,7 +552,7 @@ class ParserHelper(UnitsContainer):
         Parameters
         ----------
         input_string :
-            
+
 
         Returns
         -------
@@ -736,7 +736,7 @@ def _is_dim(name):
 
 class SharedRegistryObject:
     """Base class for object keeping a reference to the registree.
-    
+
     Such object are for now Quantity and Unit, in a number of places it is
     that an object from this class has a '_units' attribute.
 
@@ -765,7 +765,7 @@ class SharedRegistryObject:
         Parameters
         ----------
         other :
-            
+
 
         Returns
         -------
@@ -814,7 +814,7 @@ def to_units_container(unit_like, registry=None):
     Parameters
     ----------
     unit_like :
-        
+
     registry :
          (Default value = None)
 
@@ -842,12 +842,12 @@ def infer_base_unit(q):
     Parameters
     ----------
     q :
-        
+
 
     Returns
     -------
     type
-        
+
 
     """
     d = udict()
@@ -868,7 +868,7 @@ def getattr_maybe_raise(self, item):
     Parameters
     ----------
     item :
-        
+
 
     Returns
     -------
@@ -882,12 +882,12 @@ def getattr_maybe_raise(self, item):
 
 class SourceIterator:
     """Iterator to facilitate reading the definition files.
-    
+
     Accepts any sequence (like a list of lines, a file or another SourceIterator)
-    
+
     The iterator yields the line number and line (skipping comments and empty lines)
     and stripping white spaces.
-    
+
     for lineno, line in SourceIterator(sequence):
         # do something here
 
@@ -954,7 +954,7 @@ class BlockIterator(SourceIterator):
 
 def iterable(y):
     """Check whether or not an object can be iterated over.
-    
+
     Vendored from numpy under the terms of the BSD 3-Clause License. (Copyright
     (c) 2005-2019, NumPy Developers.)
 

--- a/pint/util.py
+++ b/pint/util.py
@@ -33,6 +33,21 @@ def matrix_to_string(
     matrix, row_headers=None, col_headers=None, fmtfun=lambda x: str(int(x))
 ):
     """Takes a 2D matrix (as nested list) and returns a string.
+
+    Parameters
+    ----------
+    matrix :
+        
+    row_headers :
+         (Default value = None)
+    col_headers :
+         (Default value = None)
+    fmtfun :
+         (Default value = lambda x: str(int(x)))
+
+    Returns
+    -------
+
     """
     ret = []
     if col_headers:
@@ -50,6 +65,15 @@ def matrix_to_string(
 
 def transpose(matrix):
     """Takes a 2D matrix (as nested list) and returns the transposed version.
+
+    Parameters
+    ----------
+    matrix :
+        
+
+    Returns
+    -------
+
     """
     return [list(val) for val in zip(*matrix)]
 
@@ -57,10 +81,20 @@ def transpose(matrix):
 def column_echelon_form(matrix, ntype=Fraction, transpose_result=False):
     """Calculates the column echelon form using Gaussian elimination.
 
-    :param matrix: a 2D matrix as nested list.
-    :param ntype: the numerical type to use in the calculation.
-    :param transpose_result: indicates if the returned matrix should be transposed.
-    :return: column echelon form, transformed identity matrix, swapped rows
+    Parameters
+    ----------
+    matrix :
+        a 2D matrix as nested list.
+    ntype :
+        the numerical type to use in the calculation. (Default value = Fraction)
+    transpose_result :
+        indicates if the returned matrix should be transposed. (Default value = False)
+
+    Returns
+    -------
+    type
+        column echelon form, transformed identity matrix, swapped rows
+
     """
     lead = 0
 
@@ -124,9 +158,18 @@ def column_echelon_form(matrix, ntype=Fraction, transpose_result=False):
 def pi_theorem(quantities, registry=None):
     """Builds dimensionless quantities using the Buckingham π theorem
 
-    :param quantities: mapping between variable name and units
-    :type quantities: dict
-    :return: a list of dimensionless quantities expressed as dicts
+    Parameters
+    ----------
+    quantities : dict
+        mapping between variable name and units
+    registry :
+         (Default value = None)
+
+    Returns
+    -------
+    type
+        a list of dimensionless quantities expressed as dicts
+
     """
 
     # Preprocess input and build the dimensionality Matrix
@@ -189,12 +232,18 @@ def pi_theorem(quantities, registry=None):
 def solve_dependencies(dependencies):
     """Solve a dependency graph.
 
-    :param dependencies:
+    Parameters
+    ----------
+    dependencies :
         dependency dictionary. For each key, the value is an iterable indicating its
         dependencies.
-    :return:
+
+    Returns
+    -------
+    type
         iterator of sets, each containing keys of independents tasks dependent only of
         the previous tasks in the list.
+
     """
     while dependencies:
         # values not in keys (items without dep)
@@ -244,9 +293,7 @@ def find_connected_nodes(graph, start, visited=None):
 
 
 class udict(dict):
-    """ Custom dict implementing __missing__.
-
-    """
+    """Custom dict implementing __missing__."""
 
     def __missing__(self, key):
         return 0.0
@@ -258,9 +305,16 @@ class udict(dict):
 class UnitsContainer(Mapping):
     """The UnitsContainer stores the product of units and their respective
     exponent and implements the corresponding operations.
-
+    
     UnitsContainer is a read-only mapping. All operations (even in place ones)
-    return new instances.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+    type
+        
 
     """
 
@@ -292,7 +346,15 @@ class UnitsContainer(Mapping):
         return new
 
     def remove(self, keys):
-        """ Create a new UnitsContainer purged from given keys.
+        """Create a new UnitsContainer purged from given keys.
+
+        Parameters
+        ----------
+        keys :
+            
+
+        Returns
+        -------
 
         """
         new = self.copy()
@@ -302,7 +364,17 @@ class UnitsContainer(Mapping):
         return new
 
     def rename(self, oldkey, newkey):
-        """ Create a new UnitsContainer in which an entry has been renamed.
+        """Create a new UnitsContainer in which an entry has been renamed.
+
+        Parameters
+        ----------
+        oldkey :
+            
+        newkey :
+            
+
+        Returns
+        -------
 
         """
         new = self.copy()
@@ -416,15 +488,20 @@ class UnitsContainer(Mapping):
 
 
 class ParserHelper(UnitsContainer):
-    """ The ParserHelper stores in place the product of variables and
+    """The ParserHelper stores in place the product of variables and
     their respective exponent and implements the corresponding operations.
-
+    
     ParserHelper is a read-only mapping. All operations (even in place ones)
-    return new instances.
 
-    WARNING : The hash value used does not take into account the scale
-    attribute so be careful if you use it as a dict key and then two unequal
-    object can have the same hash.
+    Parameters
+    ----------
+
+    Returns
+    -------
+    type
+        WARNING : The hash value used does not take into account the scale
+        attribute so be careful if you use it as a dict key and then two unequal
+        object can have the same hash.
 
     """
 
@@ -437,8 +514,16 @@ class ParserHelper(UnitsContainer):
     @classmethod
     def from_word(cls, input_word):
         """Creates a ParserHelper object with a single variable with exponent one.
-
+        
         Equivalent to: ParserHelper({'word': 1})
+
+        Parameters
+        ----------
+        input_word :
+            
+
+        Returns
+        -------
 
         """
         return cls(1, [(input_word, 1)])
@@ -463,6 +548,15 @@ class ParserHelper(UnitsContainer):
     @lru_cache()
     def from_string(cls, input_string):
         """Parse linear expression mathematical units and return a quantity object.
+
+        Parameters
+        ----------
+        input_string :
+            
+
+        Returns
+        -------
+
         """
         if not input_string:
             return cls()
@@ -642,9 +736,15 @@ def _is_dim(name):
 
 class SharedRegistryObject:
     """Base class for object keeping a reference to the registree.
-
+    
     Such object are for now Quantity and Unit, in a number of places it is
     that an object from this class has a '_units' attribute.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
 
     """
 
@@ -662,9 +762,16 @@ class SharedRegistryObject:
         """Check if the other object use a registry and if so that it is the
         same registry.
 
-        Return True is both use a registry and they use the same, False is
-        other don't use a registry and raise ValueError if other don't use the
-        same unit registry.
+        Parameters
+        ----------
+        other :
+            
+
+        Returns
+        -------
+        type
+            other don't use a registry and raise ValueError if other don't use the
+            same unit registry.
 
         """
         if self._REGISTRY is getattr(other, "_REGISTRY", None):
@@ -702,7 +809,17 @@ class PrettyIPython:
 
 
 def to_units_container(unit_like, registry=None):
-    """ Convert a unit compatible type to a UnitsContainer.
+    """Convert a unit compatible type to a UnitsContainer.
+
+    Parameters
+    ----------
+    unit_like :
+        
+    registry :
+         (Default value = None)
+
+    Returns
+    -------
 
     """
     mro = type(unit_like).mro()
@@ -720,7 +837,19 @@ def to_units_container(unit_like, registry=None):
 
 
 def infer_base_unit(q):
-    """Return UnitsContainer of q with all prefixes stripped."""
+    """
+
+    Parameters
+    ----------
+    q :
+        
+
+    Returns
+    -------
+    type
+        
+
+    """
     d = udict()
     for unit_name, power in q._units.items():
         candidates = q._REGISTRY.parse_unit_name(unit_name)
@@ -735,6 +864,15 @@ def infer_base_unit(q):
 def getattr_maybe_raise(self, item):
     """Helper function to invoke at the beginning of all overridden ``__getattr__``
     methods. Raise AttributeError if the user tries to ask for a _ or __ attribute.
+
+    Parameters
+    ----------
+    item :
+        
+
+    Returns
+    -------
+
     """
     # Double-underscore attributes are tricky to detect because they are
     # automatically prefixed with the class name - which may be a subclass of self
@@ -744,14 +882,20 @@ def getattr_maybe_raise(self, item):
 
 class SourceIterator:
     """Iterator to facilitate reading the definition files.
-
+    
     Accepts any sequence (like a list of lines, a file or another SourceIterator)
-
+    
     The iterator yields the line number and line (skipping comments and empty lines)
     and stripping white spaces.
-
+    
     for lineno, line in SourceIterator(sequence):
         # do something here
+
+    Parameters
+    ----------
+
+    Returns
+    -------
 
     """
 
@@ -782,14 +926,20 @@ class SourceIterator:
     next = __next__
 
     def block_iter(self):
-        """Iterate block including header.
-        """
+        """Iterate block including header."""
         return BlockIterator(self)
 
 
 class BlockIterator(SourceIterator):
     """Like SourceIterator but stops when it finds '@end'
     It also raises an error if another '@' directive is found inside.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __new__(cls, line_iterator):
@@ -817,12 +967,22 @@ class BlockIterator(SourceIterator):
 
 def iterable(y):
     """Check whether or not an object can be iterated over.
-
+    
     Vendored from numpy under the terms of the BSD 3-Clause License. (Copyright
     (c) 2005-2019, NumPy Developers.)
 
-    :param value: Input object.
-    :param type: object
+    Parameters
+    ----------
+    value :
+        Input object.
+    type :
+        object
+    y :
+        
+
+    Returns
+    -------
+
     """
     try:
         iter(y)
@@ -834,8 +994,18 @@ def iterable(y):
 def sized(y):
     """Check whether or not an object has a defined length.
 
-    :param value: Input object.
-    :param type: object
+    Parameters
+    ----------
+    value :
+        Input object.
+    type :
+        object
+    y :
+        
+
+    Returns
+    -------
+
     """
     try:
         len(y)


### PR DESCRIPTION
As defined here https://numpydoc.readthedocs.io/en/latest/format.html

- [ ] ~~Closes # (insert issue number)~~
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [ ] ~~The change is fully covered by automated unit tests~~
- [ ] ~~Documented in docs/ as appropriate~~
- [x] Added an entry to the CHANGES file

See #947