### PR TITLE
Raise ValueError on ambiguous boolean conversion and add pending NumPy functions/ufuncs from issue tracker

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,10 @@ Pint Changelog
 0.10 (unreleased)
 -----------------
 
+- **BREAKING CHANGE**:
+  Boolean value of Quantities with offsets units is ambiguous, and so, now a ValueError
+  is raised when attempting to cast such a Quantity to boolean.
+  (Issue #965, Thanks Jon Thielen)
 - Documentation on Pint's array type compatibility has been added to the NumPy support
   page, including a graph of the duck array type casting hierarchy as understood by Pint
   for N-dimensional arrays.

--- a/docs/numpy.ipynb
+++ b/docs/numpy.ipynb
@@ -284,7 +284,7 @@
     "\n",
     "The following [ufuncs](http://docs.scipy.org/doc/numpy/reference/ufuncs.html) can be applied to a Quantity object:\n",
     "\n",
-    "- **Math operations**: `add`, `subtract`, `multiply`, `divide`, `logaddexp`, `logaddexp2`, `true_divide`, `floor_divide`, `negative`, `remainder`, `mod`, `fmod`, `absolute`, `rint`, `sign`, `conj`, `exp`, `exp2`, `log`, `log2`, `log10`, `expm1`, `log1p`, `sqrt`, `square`, `reciprocal`\n",
+    "- **Math operations**: `add`, `subtract`, `multiply`, `divide`, `logaddexp`, `logaddexp2`, `true_divide`, `floor_divide`, `negative`, `remainder`, `mod`, `fmod`, `absolute`, `rint`, `sign`, `conj`, `exp`, `exp2`, `log`, `log2`, `log10`, `expm1`, `log1p`, `sqrt`, `square`, `cbrt`, `reciprocal`\n",
     "- **Trigonometric functions**: `sin`, `cos`, `tan`, `arcsin`, `arccos`, `arctan`, `arctan2`, `hypot`, `sinh`, `cosh`, `tanh`, `arcsinh`, `arccosh`, `arctanh`\n",
     "- **Comparison functions**: `greater`, `greater_equal`, `less`, `less_equal`, `not_equal`, `equal`\n",
     "- **Floating functions**: `isreal`, `iscomplex`, `isfinite`, `isinf`, `isnan`, `signbit`, `copysign`, `nextafter`, `modf`, `ldexp`, `frexp`, `fmod`, `floor`, `ceil`, `trunc`\n",
@@ -301,7 +301,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['alen', 'amax', 'amin', 'append', 'argmax', 'argmin', 'argsort', 'around', 'atleast_1d', 'atleast_2d', 'atleast_3d', 'average', 'block', 'broadcast_to', 'clip', 'column_stack', 'compress', 'concatenate', 'copy', 'copyto', 'count_nonzero', 'cross', 'cumprod', 'cumproduct', 'cumsum', 'diagonal', 'diff', 'dot', 'dstack', 'ediff1d', 'einsum', 'empty_like', 'expand_dims', 'fix', 'flip', 'full_like', 'gradient', 'hstack', 'insert', 'interp', 'isclose', 'iscomplex', 'isin', 'isreal', 'linspace', 'mean', 'median', 'meshgrid', 'moveaxis', 'nan_to_num', 'nanargmax', 'nanargmin', 'nancumprod', 'nancumsum', 'nanmax', 'nanmean', 'nanmedian', 'nanmin', 'nanpercentile', 'nanstd', 'nansum', 'nanvar', 'ndim', 'nonzero', 'ones_like', 'pad', 'percentile', 'ptp', 'ravel', 'resize', 'result_type', 'rollaxis', 'rot90', 'round_', 'searchsorted', 'shape', 'size', 'sort', 'squeeze', 'stack', 'std', 'sum', 'swapaxes', 'tile', 'transpose', 'trapz', 'trim_zeros', 'unwrap', 'var', 'vstack', 'where', 'zeros_like']\n"
+      "['alen', 'all', 'amax', 'amin', 'any', 'append', 'argmax', 'argmin', 'argsort', 'around', 'atleast_1d', 'atleast_2d', 'atleast_3d', 'average', 'block', 'broadcast_to', 'clip', 'column_stack', 'compress', 'concatenate', 'copy', 'copyto', 'count_nonzero', 'cross', 'cumprod', 'cumproduct', 'cumsum', 'diagonal', 'diff', 'dot', 'dstack', 'ediff1d', 'einsum', 'empty_like', 'expand_dims', 'fix', 'flip', 'full_like', 'gradient', 'hstack', 'insert', 'interp', 'isclose', 'iscomplex', 'isin', 'isreal', 'linalg.solve', 'linspace', 'mean', 'median', 'meshgrid', 'moveaxis', 'nan_to_num', 'nanargmax', 'nanargmin', 'nancumprod', 'nancumsum', 'nanmax', 'nanmean', 'nanmedian', 'nanmin', 'nanpercentile', 'nanstd', 'nansum', 'nanvar', 'ndim', 'nonzero', 'ones_like', 'pad', 'percentile', 'ptp', 'ravel', 'resize', 'result_type', 'rollaxis', 'rot90', 'round_', 'searchsorted', 'shape', 'size', 'sort', 'squeeze', 'stack', 'std', 'sum', 'swapaxes', 'tile', 'transpose', 'trapz', 'trim_zeros', 'unwrap', 'var', 'vstack', 'where', 'zeros_like']\n"
      ]
     }
    ],

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1481,7 +1481,11 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     __gt__ = lambda self, other: self.compare(other, op=operator.gt)
 
     def __bool__(self):
-        return bool(self._magnitude)
+        # Only cast when non-ambiguous (when multiplicative unit)
+        if self._is_multiplicative:
+            return bool(self._magnitude)
+        else:
+            raise ValueError("Boolean value of Quantity with offset unit is ambiguous.")
 
     __nonzero__ = __bool__
 

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -374,6 +374,13 @@ class TestNumpyMathematicalFunctions(TestNumpyMethods):
             np.array([30, 80, 130, 180, 230]) * self.ureg.m ** 2,
         )
 
+    @helpers.requires_array_function_protocol()
+    def test_solve(self):
+        self.assertQuantityAlmostEqual(
+            np.linalg.solve(self.q, [[3], [7]] * self.ureg.s),
+            self.Q_([[1], [1]], "m / s"),
+        )
+
     # Arithmetic operations
     def test_addition_with_scalar(self):
         a = np.array([0, 1, 2])
@@ -413,6 +420,14 @@ class TestNumpyMathematicalFunctions(TestNumpyMethods):
             self.q ** self.Q_(2), self.Q_([[1, 4], [9, 16]], "m**2")
         )
         self.assertNDArrayEqual(arr ** self.Q_(2), np.array([0, 1, 4]))
+
+    def test_sqrt(self):
+        q = self.Q_(100, "m**2")
+        self.assertQuantityEqual(np.sqrt(q), self.Q_(10, "m"))
+
+    def test_cbrt(self):
+        q = self.Q_(1000, "m**3")
+        self.assertQuantityEqual(np.cbrt(q), self.Q_(10, "m"))
 
     @unittest.expectedFailure
     @helpers.requires_numpy()
@@ -536,6 +551,18 @@ class TestNumpyUnclassified(TestNumpyMethods):
     def test_nonzero_numpy_func(self):
         q = [1, 0, 5, 6, 0, 9] * self.ureg.m
         self.assertNDArrayEqual(np.nonzero(q)[0], [0, 2, 3, 5])
+
+    @helpers.requires_array_function_protocol()
+    def test_any_numpy_func(self):
+        q = [0, 1] * self.ureg.m
+        self.assertTrue(np.any(q))
+        self.assertRaises(ValueError, np.any, self.q_temperature)
+
+    @helpers.requires_array_function_protocol()
+    def test_all_numpy_func(self):
+        q = [0, 1] * self.ureg.m
+        self.assertFalse(np.all(q))
+        self.assertRaises(ValueError, np.all, self.q_temperature)
 
     @helpers.requires_array_function_protocol()
     def test_count_nonzero_numpy_func(self):

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -54,6 +54,8 @@ class TestQuantity(QuantityTestCase):
         self.assertTrue(self.Q_(1, "meter"))
         self.assertFalse(self.Q_(0, None))
         self.assertFalse(self.Q_(0, "meter"))
+        self.assertRaises(ValueError, bool, self.Q_(0, "degC"))
+        self.assertFalse(self.Q_(0, "delta_degC"))
 
     def test_quantity_comparison(self):
         x = self.Q_(4.2, "meter")


### PR DESCRIPTION
There were a few follow-up issues from #905 that were missing fairly simple implementations, so this PR takes care of them in preparation for the upcoming release.

Part of this was resolving #866 by raising a `ValueError` due to ambiguity when casting Quantities with offset units to boolean, which is technically a breaking change (although I would argue that the previous behavior was incorrect as discussed in #866).

Also, @keewis, this implements `np.any` and `np.all`, which are two of the functions you had mentioned were needed by xarray. I think now the only one still missing is `np.prod` (https://github.com/hgrecco/pint/issues/867) which will likely have to wait since there hasn't been a good solution yet.

- [x] Closes #419; Closes #470; Closes #807; Closes #866
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
