### PR TITLE
Fix __array__ signature

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Pint Changelog
 
 - Fixed several Sphinx issues. Fixed intersphinx hooks to all classes missing.
   (Issue #881, Thanks Guido Imperiale)
+- Fixed __array__ signature to match numpy docs (Issue #974, Thanks Ryan May)
 
 0.10 (2020-01-05)
 -----------------

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1551,7 +1551,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         else:
             return value
 
-    def __array__(self):
+    def __array__(self, t=None):
         warnings.warn(
             "The unit of the quantity is stripped when downcasting to ndarray.",
             UnitStrippedWarning,

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1036,6 +1036,12 @@ class TestNumpyUnclassified(TestNumpyMethods):
         with self.assertWarns(UnitStrippedWarning):
             np.asarray(self.q)
 
+    @patch("pint.quantity.ARRAY_FALLBACK", False)
+    def test_ndarray_downcast_with_dtype(self):
+        with self.assertWarns(UnitStrippedWarning):
+            qarr = np.asarray(self.q, dtype=np.float64)
+            self.assertEqual(qarr.dtype, np.float64)
+
     def test_array_protocol_fallback(self):
         with self.assertWarns(DeprecationWarning) as cm:
             for attr in ("__array_struct__", "__array_interface__"):


### PR DESCRIPTION
According to [numpy docs](https://docs.scipy.org/doc/numpy/reference/arrays.classes.html#numpy.class.__array__), `__array__` can optionally be given a dtype. This fixes the signature to not error when we get one, but doesn't do anything with it--everything seems to work fine with that.

- [X] Closes #974 
- [X] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [X] The change is fully covered by automated unit tests
- [X] Documented in docs/ as appropriate
- [X] Added an entry to the CHANGES file
