### PR TITLE
Rename sequence-of-quantities helper, with tests for bug in issue 973

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,12 @@
 Pint Changelog
 ==============
 
-0.11 (unreleased)
+0.10.1 (unreleased)
 -----------------
 
+- Fixed bug introduced in 0.10 that prevented creation of size-zero Quantities
+  from NumPy arrays by multiplication.
+  (Issue #977, Thanks Jon Thielen)
 - Fixed several Sphinx issues. Fixed intersphinx hooks to all classes missing.
   (Issue #881, Thanks Guido Imperiale)
 - Fixed __array__ signature to match numpy docs (Issue #974, Thanks Ryan May)

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -38,7 +38,7 @@ def _is_quantity(obj):
     return hasattr(obj, "_units") and hasattr(obj, "_magnitude")
 
 
-def _is_quantity_sequence(obj):
+def _is_sequence_with_quantity_elements(obj):
     """Test for sequences of quantities.
 
     Parameters
@@ -54,6 +54,7 @@ def _is_quantity_sequence(obj):
         iterable(obj)
         and sized(obj)
         and not isinstance(obj, str)
+        and len(obj) > 0
         and all(_is_quantity(item) for item in obj)
     )
 
@@ -65,7 +66,7 @@ def _get_first_input_units(args, kwargs=None):
     for arg in chain(args, kwargs.values()):
         if _is_quantity(arg):
             return arg.units
-        elif _is_quantity_sequence(arg):
+        elif _is_sequence_with_quantity_elements(arg):
             return arg[0].units
 
 
@@ -79,7 +80,7 @@ def convert_arg(arg, pre_calc_units):
     if pre_calc_units is not None:
         if _is_quantity(arg):
             return arg.m_as(pre_calc_units)
-        elif _is_quantity_sequence(arg):
+        elif _is_sequence_with_quantity_elements(arg):
             return [item.m_as(pre_calc_units) for item in arg]
         elif arg is not None:
             if pre_calc_units.dimensionless:
@@ -89,7 +90,7 @@ def convert_arg(arg, pre_calc_units):
     else:
         if _is_quantity(arg):
             return arg.m
-        elif _is_quantity_sequence(arg):
+        elif _is_sequence_with_quantity_elements(arg):
             return [item.m for item in arg]
     return arg
 
@@ -626,7 +627,7 @@ def _isin(element, test_elements, assume_unique=False, invert=False):
         except DimensionalityError:
             # Incompatible unit test elements cannot be in element
             return np.full(element.shape, False)
-    elif _is_quantity_sequence(test_elements):
+    elif _is_sequence_with_quantity_elements(test_elements):
         compatible_test_elements = []
         for test_element in test_elements:
             try:

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -733,6 +733,15 @@ try:
         callable(q)
         assert isinstance(q._magnitude, type_before)
 
+    @pytest.mark.skipif(np is None, reason="NumPy is not available")
+    def test_issue973():
+        """Verify that an empty array Quantity can be created through multiplication."""
+        q0 = np.array([]) * ureg.m  # by Unit
+        q1 = np.array([]) * ureg("m")  # by Quantity
+        assert isinstance(q0, ureg.Quantity)
+        assert isinstance(q1, ureg.Quantity)
+        assert len(q0) == len(q1) == 0
+
 
 except AttributeError:
     # Calling attributes on np will fail if NumPy is not available

--- a/pint/testsuite/test_numpy_func.py
+++ b/pint/testsuite/test_numpy_func.py
@@ -5,7 +5,7 @@ from pint import DimensionalityError, OffsetUnitCalculusError
 from pint.compat import np
 from pint.numpy_func import (
     _is_quantity,
-    _is_quantity_sequence,
+    _is_sequence_with_quantity_elements,
     convert_to_consistent_units,
     get_op_output_unit,
     implements,
@@ -48,14 +48,20 @@ class TestNumPyFuncUtils(TestNumpyMethods):
         self.assertFalse(_is_quantity("not-a-quantity"))
         # TODO (#905 follow-up): test other duck arrays that wrap or are wrapped by Pint
 
-    def test_is_quantity_sequence(self):
-        self.assertTrue(_is_quantity_sequence((self.Q_(0, "m"), self.Q_(32.0, "degF"))))
-        self.assertTrue(_is_quantity_sequence(np.arange(4) * self.ureg.m))
-        self.assertFalse(_is_quantity_sequence((self.Q_(0), True)))
-        self.assertFalse(_is_quantity_sequence([1, 3, 5]))
-        self.assertFalse(_is_quantity_sequence(9 * self.ureg.m))
-        self.assertFalse(_is_quantity_sequence(np.arange(4)))
-        self.assertFalse(_is_quantity_sequence("0123"))
+    def test_is_sequence_with_quantity_elements(self):
+        self.assertTrue(
+            _is_sequence_with_quantity_elements(
+                (self.Q_(0, "m"), self.Q_(32.0, "degF"))
+            )
+        )
+        self.assertTrue(_is_sequence_with_quantity_elements(np.arange(4) * self.ureg.m))
+        self.assertFalse(_is_sequence_with_quantity_elements((self.Q_(0), True)))
+        self.assertFalse(_is_sequence_with_quantity_elements([1, 3, 5]))
+        self.assertFalse(_is_sequence_with_quantity_elements(9 * self.ureg.m))
+        self.assertFalse(_is_sequence_with_quantity_elements(np.arange(4)))
+        self.assertFalse(_is_sequence_with_quantity_elements("0123"))
+        self.assertFalse(_is_sequence_with_quantity_elements([]))
+        self.assertFalse(_is_sequence_with_quantity_elements(np.array([])))
 
     def test_convert_to_consistent_units_with_pre_calc_units(self):
         args, kwargs = convert_to_consistent_units(


### PR DESCRIPTION
Implements the changes discussed in #973.

Also, @hgrecco, since you had mentioned in #973 wanting this solved ASAP, I took the liberty of changing the unreleased version header in the changelog to 0.10.1 (as a patch release). Hopefully that was okay! If you'd like me to undo that though, just let me know.

- [x] Closes #973
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- ~~Documented in docs/ as appropriate~~
- [x] Added an entry to the CHANGES file
