### PR TITLE
Add implementations and tests for allclose and intersect1d

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 .DS_Store
 docs/_build/
 .idea
+.vscode
 build/
 dist/
 MANIFEST

--- a/CHANGES
+++ b/CHANGES
@@ -4,8 +4,8 @@ Pint Changelog
 0.11 (unreleased)
 -----------------
 
-- Nothing changed yet.
-
+- Added additional NumPy function implementations (allclose, intersect1d)
+  (Issue #979, Thanks Jon Thielen)
 
 0.10.1 (2020-01-07)
 -------------------

--- a/docs/numpy.ipynb
+++ b/docs/numpy.ipynb
@@ -301,7 +301,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['alen', 'all', 'amax', 'amin', 'any', 'append', 'argmax', 'argmin', 'argsort', 'around', 'atleast_1d', 'atleast_2d', 'atleast_3d', 'average', 'block', 'broadcast_to', 'clip', 'column_stack', 'compress', 'concatenate', 'copy', 'copyto', 'count_nonzero', 'cross', 'cumprod', 'cumproduct', 'cumsum', 'diagonal', 'diff', 'dot', 'dstack', 'ediff1d', 'einsum', 'empty_like', 'expand_dims', 'fix', 'flip', 'full_like', 'gradient', 'hstack', 'insert', 'interp', 'isclose', 'iscomplex', 'isin', 'isreal', 'linalg.solve', 'linspace', 'mean', 'median', 'meshgrid', 'moveaxis', 'nan_to_num', 'nanargmax', 'nanargmin', 'nancumprod', 'nancumsum', 'nanmax', 'nanmean', 'nanmedian', 'nanmin', 'nanpercentile', 'nanstd', 'nansum', 'nanvar', 'ndim', 'nonzero', 'ones_like', 'pad', 'percentile', 'ptp', 'ravel', 'reshape', 'resize', 'result_type', 'rollaxis', 'rot90', 'round_', 'searchsorted', 'shape', 'size', 'sort', 'squeeze', 'stack', 'std', 'sum', 'swapaxes', 'tile', 'transpose', 'trapz', 'trim_zeros', 'unwrap', 'var', 'vstack', 'where', 'zeros_like']\n"
+      "['alen', 'all', 'allclose', 'amax', 'amin', 'any', 'append', 'argmax', 'argmin', 'argsort', 'around', 'atleast_1d', 'atleast_2d', 'atleast_3d', 'average', 'block', 'broadcast_to', 'clip', 'column_stack', 'compress', 'concatenate', 'copy', 'copyto', 'count_nonzero', 'cross', 'cumprod', 'cumproduct', 'cumsum', 'diagonal', 'diff', 'dot', 'dstack', 'ediff1d', 'einsum', 'empty_like', 'expand_dims', 'fix', 'flip', 'full_like', 'gradient', 'hstack', 'insert', 'interp', 'intersect1d', 'isclose', 'iscomplex', 'isin', 'isreal', 'linalg.solve', 'linspace', 'mean', 'median', 'meshgrid', 'moveaxis', 'nan_to_num', 'nanargmax', 'nanargmin', 'nancumprod', 'nancumsum', 'nanmax', 'nanmean', 'nanmedian', 'nanmin', 'nanpercentile', 'nanstd', 'nansum', 'nanvar', 'ndim', 'nonzero', 'ones_like', 'pad', 'percentile', 'ptp', 'ravel', 'reshape', 'resize', 'result_type', 'rollaxis', 'rot90', 'round_', 'searchsorted', 'shape', 'size', 'sort', 'squeeze', 'stack', 'std', 'sum', 'swapaxes', 'tile', 'transpose', 'trapz', 'trim_zeros', 'unwrap', 'var', 'vstack', 'where', 'zeros_like']\n"
      ]
     }
    ],
@@ -522,7 +522,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.dot.Digraph at 0x7fe7030a9208>"
+       "<graphviz.dot.Digraph at 0x7f68cc084208>"
       ]
      },
      "execution_count": 13,
@@ -636,14 +636,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<COO: shape=(100, 100, 100), dtype=float64, nnz=99897, fill_value=0.0> meter\n",
+      "<COO: shape=(100, 100, 100), dtype=float64, nnz=99598, fill_value=0.0> meter\n",
       "\n",
-      "0.09488747484058625 meter\n"
+      "0.09462606529121113 meter\n"
      ]
     }
    ],
    "source": [
     "from sparse import COO\n",
+    "\n",
+    "np.random.seed(80243963)\n",
     "\n",
     "x = np.random.random((100, 100, 100))\n",
     "x[x < 0.9] = 0  # fill most of the array with zeros\n",

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -772,6 +772,8 @@ for func_str, unit_arguments, wrap_output in [
     ("insert", ["arr", "values"], True),
     ("resize", "a", True),
     ("reshape", "a", True),
+    ("allclose", ["a", "b"], False),
+    ("intersect1d", ["ar1", "ar2"], True),
 ]:
     implement_consistent_units_by_argument(func_str, unit_arguments, wrap_output)
 

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1153,6 +1153,22 @@ class TestNumpyUnclassified(TestNumpyMethods):
             ),
         )  # Note: Does not support Quantity pad_with vectorized callable use
 
+    @helpers.requires_array_function_protocol()
+    def test_allclose(self):
+        self.assertTrue(
+            np.allclose([1e10, 1e-8] * self.ureg.m, [1.00001e10, 1e-9] * self.ureg.m)
+        )
+        self.assertFalse(
+            np.allclose([1e10, 1e-8] * self.ureg.m, [1.00001e10, 1e-9] * self.ureg.mm)
+        )
+
+    @helpers.requires_array_function_protocol()
+    def test_intersect1d(self):
+        self.assertQuantityEqual(
+            np.intersect1d([1, 3, 4, 3] * self.ureg.m, [3, 1, 2, 1] * self.ureg.m),
+            [1, 3] * self.ureg.m,
+        )
+
 
 @unittest.skip
 class TestBitTwiddlingUfuncs(TestUFuncs):


### PR DESCRIPTION
Adds two recently requested NumPy function implementations (`allclose` from #978 and `intersect1d` from #976).

In case it is useful, below is a quick check of what NumPy functions in the main module Pint *does not* implement yet (as of this PR):

```python
import numpy as np
from pint.numpy_func import HANDLED_FUNCTIONS

print(sorted(set(attr for attr in dir(np)
                 if hasattr(getattr(np, attr), '_implementation'))
             - set(HANDLED_FUNCTIONS))) 
```
```
['alltrue', 'angle', 'apply_along_axis', 'apply_over_axes', 'argpartition', 'argwhere', 'array2string', 'array_equal', 'array_equiv', 'array_repr', 'array_split', 'array_str', 'asfarray', 'asscalar', 'bincount', 'broadcast_arrays', 'busday_count', 'busday_offset', 'can_cast', 'choose', 'common_type', 'convolve', 'corrcoef', 'correlate', 'cov', 'datetime_as_string', 'delete', 'diag', 'diag_indices_from', 'diagflat', 'digitize', 'dsplit', 'einsum_path', 'extract', 'fill_diagonal', 'flatnonzero', 'fliplr', 'flipud', 'fv', 'geomspace', 'histogram', 'histogram2d', 'histogram_bin_edges', 'histogramdd', 'hsplit', 'i0', 'imag', 'in1d', 'inner', 'ipmt', 'irr', 'is_busday', 'iscomplexobj', 'isneginf', 'isposinf', 'isrealobj', 'ix_', 'kron', 'lexsort', 'logspace', 'max', 'may_share_memory', 'min', 'min_scalar_type', 'mirr', 'msort', 'nanprod', 'nanquantile', 'nper', 'npv', 'outer', 'packbits', 'partition', 'piecewise', 'place', 'pmt', 'poly', 'polyadd', 'polyder', 'polydiv', 'polyfit', 'polyint', 'polymul', 'polysub', 'polyval', 'ppmt', 'prod', 'product', 'put', 'put_along_axis', 'putmask', 'pv', 'quantile', 'rank', 'rate', 'ravel_multi_index', 'real', 'real_if_close', 'repeat', 'roll', 'roots', 'round', 'row_stack', 'save', 'savetxt', 'savez', 'savez_compressed', 'select', 'setdiff1d', 'setxor1d', 'shares_memory', 'sinc', 'sometrue', 'sort_complex', 'split', 'take', 'take_along_axis', 'tensordot', 'trace', 'tril', 'tril_indices_from', 'triu', 'triu_indices_from', 'union1d', 'unique', 'unpackbits', 'unravel_index', 'vander', 'vdot', 'vsplit']
```

- [x] Closes #976; Closes #978
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
