### PR TITLE
Changed pytest arguments to ignores testsuite in coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit = pint/testsuite/*
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
   # But broke travis 2019-08
   # - sudo rm -rf /dev/shm
   # - sudo ln -s /run/shm /dev/shm
-  - export TEST_OPTS="-rfsxEX -s --cov=pint"
+  - export TEST_OPTS="-rfsxEX -s --cov=pint --cov-config=.coveragerc"
 
 install:
   - conda create -n travis $PKGS pytest pytest-cov coveralls


### PR DESCRIPTION
- [ ] ~Closes # (insert issue number)~
- [ ] ~Executed ``black -t py36 . && isort -rc . && flake8`` with no errors~
- [ ] ~The change is fully covered by automated unit tests~
- [ ] ~Documented in docs/ as appropriate~
- [ ] ~Added an entry to the CHANGES file~
