### PR TITLE
Allow constants in units by using leading underscore

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,8 @@ Pint Changelog
 
 - Added additional NumPy function implementations (allclose, intersect1d)
   (Issue #979, Thanks Jon Thielen)
+- Allow constants in units by using a leading underscore (Issue #989, Thanks
+  Juan Nunez-Iglesias)
 
 0.10.1 (2020-01-07)
 -------------------

--- a/docs/defining.rst
+++ b/docs/defining.rst
@@ -138,3 +138,17 @@ Same for aliases and derived dimensions:
 .. warning::
    Units, prefixes, aliases and dimensions added programmatically are forgotten when the
    program ends.
+
+
+Units with constants
+--------------------
+
+Some units, such as ``L/100km``, contain constants. These can be defined with a
+leading underscore:
+
+.. doctest::
+
+   >>> ureg.define('_100km = 100 * kilometer')
+   >>> ureg.define('mpg = 1 * mile / gallon')
+   >>> fuel_ec_europe = 5 * ureg.L / ureg._100km
+   >>> fuel_ec_us = (1 / fuel_ec_europe).to(ureg.mpg)

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -699,12 +699,12 @@ class TestIssues(QuantityTestCase):
 
     def test_issue507(self):
         # leading underscore in unit works with numbers
-        u.define("_100km = 100 * kilometer")
-        battery_ec = 16 * u.kWh / u._100km
+        ureg.define("_100km = 100 * kilometer")
+        battery_ec = 16 * ureg.kWh / ureg._100km
         # ... but not with text
-        u.define("_home = 4700 * kWh / year")
+        ureg.define("_home = 4700 * kWh / year")
         with self.assertRaises(AttributeError):
-            home_elec_power = 1 * u._home
+            home_elec_power = 1 * ureg._home
 
 
 try:

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -705,6 +705,10 @@ class TestIssues(QuantityTestCase):
         ureg.define("_home = 4700 * kWh / year")
         with self.assertRaises(AttributeError):
             home_elec_power = 1 * ureg._home
+        # ... or with *only* underscores
+        ureg.define("_ = 45 * km")
+        with self.assertRaises(AttributeError):
+            one_blank = 1 * ureg._
 
 
 try:

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -699,12 +699,13 @@ class TestIssues(QuantityTestCase):
 
     def test_issue507(self):
         # leading underscore in unit works with numbers
-        u.define('_100km = 100 * kilometer')
+        u.define("_100km = 100 * kilometer")
         battery_ec = 16 * u.kWh / u._100km
         # ... but not with text
-        u.define('_home = 4700 * kWh / year')
+        u.define("_home = 4700 * kWh / year")
         with self.assertRaises(AttributeError):
             home_elec_power = 1 * u._home
+
 
 try:
 

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -700,15 +700,15 @@ class TestIssues(QuantityTestCase):
     def test_issue507(self):
         # leading underscore in unit works with numbers
         ureg.define("_100km = 100 * kilometer")
-        battery_ec = 16 * ureg.kWh / ureg._100km
+        battery_ec = 16 * ureg.kWh / ureg._100km  # noqa: F841
         # ... but not with text
         ureg.define("_home = 4700 * kWh / year")
         with self.assertRaises(AttributeError):
-            home_elec_power = 1 * ureg._home
+            home_elec_power = 1 * ureg._home  # noqa: F841
         # ... or with *only* underscores
         ureg.define("_ = 45 * km")
         with self.assertRaises(AttributeError):
-            one_blank = 1 * ureg._
+            one_blank = 1 * ureg._  # noqa: F841
 
 
 try:

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -697,6 +697,14 @@ class TestIssues(QuantityTestCase):
         with self.assertRaises(DimensionalityError):
             q.to("joule")
 
+    def test_issue507(self):
+        # leading underscore in unit works with numbers
+        u.define('_100km = 100 * kilometer')
+        battery_ec = 16 * u.kWh / u._100km
+        # ... but not with text
+        u.define('_home = 4700 * kWh / year')
+        with self.assertRaises(AttributeError):
+            home_elec_power = 1 * u._home
 
 try:
 

--- a/pint/util.py
+++ b/pint/util.py
@@ -862,12 +862,16 @@ def infer_base_unit(q):
 
 
 def getattr_maybe_raise(self, item):
-    """Helper function to invoke at the beginning of all overridden ``__getattr__``
-    methods. Raise AttributeError if the user tries to ask for a _ or __ attribute.
+    """Helper function invoked at start of all overridden ``__getattr__``.
+
+    Raise AttributeError if the user tries to ask for a _ or __ attribute,
+    *unless* it is immediately followed by a number, to enable units
+    encompassing constants, such as ``L / _100km``.
 
     Parameters
     ----------
-    item :
+    item : string
+        Item to be found.
 
 
     Returns

--- a/pint/util.py
+++ b/pint/util.py
@@ -876,7 +876,11 @@ def getattr_maybe_raise(self, item):
     """
     # Double-underscore attributes are tricky to detect because they are
     # automatically prefixed with the class name - which may be a subclass of self
-    if item.startswith("_") or item.endswith("__"):
+    if (
+        item.startswith("_")
+        and not item.lstrip('_')[0].isdigit()
+        or item.endswith("__")
+    ):
         raise AttributeError("%r object has no attribute %r" % (self, item))
 
 

--- a/pint/util.py
+++ b/pint/util.py
@@ -882,7 +882,7 @@ def getattr_maybe_raise(self, item):
     # automatically prefixed with the class name - which may be a subclass of self
     if (
         item.startswith("_")
-        and not item.lstrip('_')[0].isdigit()
+        and not item.lstrip("_")[0].isdigit()
         or item.endswith("__")
     ):
         raise AttributeError("%r object has no attribute %r" % (self, item))

--- a/pint/util.py
+++ b/pint/util.py
@@ -880,10 +880,10 @@ def getattr_maybe_raise(self, item):
     """
     # Double-underscore attributes are tricky to detect because they are
     # automatically prefixed with the class name - which may be a subclass of self
-    if item.endswith("__") or (
-        item.startswith("_")
-        and len(item.lstrip("_")) > 1
-        and not item.lstrip("_")[0].isdigit()
+    if (
+        item.endswith("__")
+        or len(item.lstrip("_")) == 0
+        or (item.startswith("_") and not item.lstrip("_")[0].isdigit())
     ):
         raise AttributeError("%r object has no attribute %r" % (self, item))
 

--- a/pint/util.py
+++ b/pint/util.py
@@ -880,10 +880,10 @@ def getattr_maybe_raise(self, item):
     """
     # Double-underscore attributes are tricky to detect because they are
     # automatically prefixed with the class name - which may be a subclass of self
-    if (
+    if item.endswith("__") or (
         item.startswith("_")
+        and len(item.lstrip("_")) > 1
         and not item.lstrip("_")[0].isdigit()
-        or item.endswith("__")
     ):
         raise AttributeError("%r object has no attribute %r" % (self, item))
 


### PR DESCRIPTION
See #507 for discussion.

This change allows code like the following:

```python
In [1]: from pint import UnitRegistry                                              
In [2]: u = UnitRegistry()                                                         
In [3]: u.define('_100km = 100 * kilometer')                                       
In [4]: u.define('mpg = 1 * mile / gallon')                                        
In [5]: volt_petrol_ec = 5 * u.L / u._100km                                        
In [6]: (1 / volt_petrol_ec).to(u.mpg)                                             
Out[6]: 47.042916666666656 <Unit('mpg')>
```

- [x] Closes #507
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
