### PR TITLE
treat non-quantity parameters to np.pad like dimensionless

### DIFF
--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -654,10 +654,14 @@ def _pad(array, pad_width, mode="constant", **kwargs):
     def _recursive_convert(arg, unit):
         if iterable(arg):
             return tuple(_recursive_convert(a, unit=unit) for a in arg)
-        elif _is_quantity(arg):
-            return arg.m_as(unit)
         else:
-            return arg
+            if not _is_quantity(arg):
+                if arg == 0:
+                    arg = unit._REGISTRY.Quantity(arg, unit)
+                else:
+                    arg = unit._REGISTRY.Quantity(arg, "dimensionless")
+
+            return arg.m_as(unit)
 
     # pad only dispatches on array argument, so we know it is a Quantity
     units = array.units

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -654,14 +654,13 @@ def _pad(array, pad_width, mode="constant", **kwargs):
     def _recursive_convert(arg, unit):
         if iterable(arg):
             return tuple(_recursive_convert(a, unit=unit) for a in arg)
-        else:
-            if not _is_quantity(arg):
-                if arg == 0:
-                    arg = unit._REGISTRY.Quantity(arg, unit)
-                else:
-                    arg = unit._REGISTRY.Quantity(arg, "dimensionless")
+        elif not _is_quantity(arg):
+            if arg == 0:
+                arg = unit._REGISTRY.Quantity(arg, unit)
+            else:
+                arg = unit._REGISTRY.Quantity(arg, "dimensionless")
 
-            return arg.m_as(unit)
+        return arg.m_as(unit)
 
     # pad only dispatches on array argument, so we know it is a Quantity
     units = array.units

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1067,9 +1067,18 @@ class TestNumpyUnclassified(TestNumpyMethods):
     def test_pad(self):
         # Tests reproduced with modification from NumPy documentation
         a = [1, 2, 3, 4, 5] * self.ureg.m
+        b = self.Q_([4, 6, 8, 9, -3], "degC")
+
         self.assertQuantityEqual(
-            np.pad(a, (2, 3), "constant", constant_values=(4, 600 * self.ureg.cm)),
-            [4, 4, 1, 2, 3, 4, 5, 6, 6, 6] * self.ureg.m,
+            np.pad(a, (2, 3), "constant", constant_values=(0, 600 * self.ureg.cm)),
+            [0, 0, 1, 2, 3, 4, 5, 6, 6, 6] * self.ureg.m,
+        )
+        self.assertQuantityEqual(
+            np.pad(b, (2, 1), "constant", constant_values=self.Q_(10, "degC")),
+            self.Q_([10, 10, 4, 6, 8, 9, -3, 10], "degC"),
+        )
+        self.assertRaises(
+            DimensionalityError, np.pad, a, (2, 3), "constant", constant_values=4
         )
         self.assertQuantityEqual(
             np.pad(a, (2, 3), "edge"), [1, 1, 1, 2, 3, 4, 5, 5, 5, 5] * self.ureg.m


### PR DESCRIPTION
- [x] Closes #992
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
