### PR TITLE
Fix Bug Quantity to_compact

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,6 +27,7 @@ Other contributors, listed alphabetically, are:
 * Joel B. Mohler <joel@kiwistrawberry.us>
 * John David Reaver <jdreaver@adlerhorst.com>
 * Jonas Olson <jolson@kth.se>
+* Jules Chéron <me@julescheron.com>
 * Kaido Kert <kaidokert@gmail.com>
 * Kenneth D. Mankoff <mankoff@gmail.com>
 * Kevin Davies <kdavies4@gmail.com>

--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ Pint Changelog
   (Issue #979, Thanks Jon Thielen)
 - Allow constants in units by using a leading underscore (Issue #989, Thanks
   Juan Nunez-Iglesias)
+- Fixed bug where to_compact handled prefix units incorrectly (Issue #960)
 
 0.10.1 (2020-01-07)
 -------------------

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -689,6 +689,8 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         if unit is None:
             unit = infer_base_unit(self)
+        else:
+            unit = infer_base_unit(self.__class__(1, unit))
 
         q_base = self.to(unit)
 

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -710,6 +710,11 @@ class TestIssues(QuantityTestCase):
         with self.assertRaises(AttributeError):
             one_blank = 1 * ureg._  # noqa: F841
 
+    def test_issue960(self):
+        q = (1 * ureg.nanometer).to_compact("micrometer")
+        assert q.units == ureg.nanometer
+        assert q.magnitude == 1
+
 
 try:
 


### PR DESCRIPTION
- Handles unit in to_compact function.
- Use same function infer_base_unit on Quantity based on input unit.
- Add unit test in test_issues.py

- [x] Closes #960
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Added an entry to the CHANGES file
