### PR TITLE
Add parse_pattern function

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -251,14 +251,14 @@ or
 
 .. note:: Pint´s rule for parsing strings with a mixture of numbers and
    units is that **units are treated with the same precedence as numbers**.
-   
+
 For example, the unit of
 
 .. doctest::
 
    >>> Q_('3 l / 100 km')
    <Quantity(0.03, 'kilometer * liter')>
-   
+
 may be unexpected first but is a consequence of applying this rule. Use
 brackets to get the expected result:
 
@@ -270,6 +270,38 @@ brackets to get the expected result:
 .. note:: Since version 0.7, Pint **does not** use eval_ under the hood.
    This change removes the `serious security problems`_ that the system is
    exposed to when parsing information from untrusted sources.
+
+
+Strings containing values can be parsed using the ``ureg.parse_pattern`` function. A ``format``-like string with the units defined in it is used as the pattern:
+
+.. doctest::
+
+   >>> input_string = '10 feet 10 inches'
+   >>> pattern = '{feet} feet {inch} inches'
+   >>> ureg.parse_pattern(input_string, pattern)
+   [10.0 <Unit('foot')>, 10.0 <Unit('inch')>]
+
+To search for multiple matches, set the ``many`` parameter to ``True``. The following example also demonstrates how the parser is able to find matches in amongst filler characters:
+
+.. doctest::
+
+   >>> input_string = '10 feet - 20 feet ! 30 feet.'
+   >>> pattern = '{feet} feet'
+   >>> ureg.parse_pattern(input_string, pattern, many=True)
+   [[10.0 <Unit('foot')>], [20.0 <Unit('foot')>], [30.0 <Unit('foot')>]]
+
+The full power of regex can also be employed when writing patterns:
+
+.. doctest::
+
+   >>> input_string = "10` - 20 feet ! 30 ft."
+   >>> pattern = r"{feet}(`| feet| ft)"
+   >>> ureg.parse_pattern(input_string, pattern, many=True)
+   [[10.0 <Unit('foot')>], [20.0 <Unit('foot')>], [30.0 <Unit('foot')>]]
+
+*Note that the curly brackets (``{}``) are converted to a float-matching pattern by the parser.*
+
+This function is useful for tasks such as bulk extraction of units from thousands of uniform strings or even very large texts with units dotted around in no particular pattern.
 
 
 .. _sec-string-formatting:
@@ -303,12 +335,12 @@ Pint supports float formatting for numpy arrays as well:
    >>> # scientific form formatting with unit pretty printing
    >>> print('The array is {:+.2E~P}'.format(accel))
    The array is [-1.10E+00 +1.00E-06 +1.25E+00 +1.30E+00] m/s²
-   
+
 Pint also supports 'f-strings'_ from python>=3.6 :
 
 .. doctest::
 
-   >>> accel = 1.3 * ureg['meter/second**2'] 
+   >>> accel = 1.3 * ureg['meter/second**2']
    >>> print(f'The str is {accel}')
    The str is 1.3 meter / second ** 2
    >>> print(f'The str is {accel:.3e}')
@@ -318,7 +350,7 @@ Pint also supports 'f-strings'_ from python>=3.6 :
    >>> print(f'The str is {accel:~.3e}')
    The str is 1.300e+00 m / s ** 2
    >>> print(f'The str is {accel:~H}')
-   The str is 1.3 m/s²  
+   The str is 1.3 m/s²
 
 But Pint also extends the standard formatting capabilities for unicode and
 LaTeX representations:
@@ -349,11 +381,11 @@ If you want to use abbreviated unit names, prefix the specification with `~`:
 The same is true for latex (`L`) and HTML (`H`) specs.
 
 .. note::
-   The abbreviated unit is drawn from the unit registry where the 3rd item in the 
-   equivalence chain (ie 1 = 2 = **3**) will be returned when the prefix '~' is 
+   The abbreviated unit is drawn from the unit registry where the 3rd item in the
+   equivalence chain (ie 1 = 2 = **3**) will be returned when the prefix '~' is
    used. The 1st item in the chain is the canonical name of the unit.
 
-The formatting specs (ie 'L', 'H', 'P') can be used with Python string 'formatting 
+The formatting specs (ie 'L', 'H', 'P') can be used with Python string 'formatting
 syntax'_ for custom float representations. For example, scientific notation:
 
 ..doctest::

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -85,6 +85,19 @@ from .util import (
 _BLOCK_RE = re.compile(r" |\(")
 
 
+@functools.lru_cache()
+def pattern_to_regex(pattern):
+    if hasattr(pattern, "finditer"):
+        pattern = pattern.pattern
+
+    # Replace "{unit_name}" match string with float regex with unit_name as group
+    pattern = re.sub(
+        r"{(\w+)}", r"(?P<\1>[+-]?[0-9]+(?:.[0-9]+)?(?:[Ee][+-]?[0-9]+)?)", pattern
+    )
+
+    return re.compile(pattern)
+
+
 class RegistryMeta(type):
     """This is just to call after_init at the right time
     instead of asking the developer to do it when subclassing.
@@ -1085,6 +1098,62 @@ class BaseRegistry(metaclass=RegistryMeta):
             return ParserHelper.eval_token(token, use_decimal=use_decimal)
         else:
             raise Exception("unknown token type")
+
+    def parse_pattern(
+        self, input_string, pattern, case_sensitive=True, use_decimal=False, many=False
+    ):
+        """Parse a string with a given regex pattern and returns result.
+
+        Parameters
+        ----------
+        input_string :
+
+        pattern_string:
+             The regex parse string
+        case_sensitive :
+             (Default value = True)
+        use_decimal :
+             (Default value = False)
+        many :
+             Match many results
+             (Default value = False)
+
+
+        Returns
+        -------
+
+        """
+
+        if not input_string:
+            return self.Quantity(1)
+
+        # Parse string
+        pattern = pattern_to_regex(pattern)
+        matched = re.finditer(pattern, input_string)
+
+        # Extract result(s)
+        results = []
+        for match in matched:
+            # Extract units from result
+            match = match.groupdict()
+
+            # Parse units
+            units = []
+            for unit, value in match.items():
+                # Construct measure by multiplying value by unit
+                units.append(
+                    float(value)
+                    * self.parse_expression(unit, case_sensitive, use_decimal)
+                )
+
+            # Add to results
+            results.append(units)
+
+            # Return first match only
+            if not many:
+                return results[0]
+
+        return results
 
     def parse_expression(
         self, input_string, case_sensitive=True, use_decimal=False, **values

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -658,6 +658,47 @@ class TestRegistry(QuantityTestCase):
         self.assertEqual(ureg.parse_units(""), ureg.Unit(""))
         self.assertRaises(ValueError, ureg.parse_units, "2 * meter")
 
+    def test_parse_string_pattern(self):
+        ureg = self.ureg
+        self.assertEqual(
+            ureg.parse_pattern("10'11", r"{foot}'{inch}"),
+            [ureg.Quantity(10.0, "foot"), ureg.Quantity(11.0, "inch")],
+        )
+
+    def test_parse_string_pattern_no_preprocess(self):
+        """Were preprocessors enabled, this would be interpreted as 10*11, not
+        two separate units, and thus cause the parsing to fail"""
+        ureg = self.ureg
+        self.assertEqual(
+            ureg.parse_pattern("10 11", r"{kg} {lb}"),
+            [ureg.Quantity(10.0, "kilogram"), ureg.Quantity(11.0, "pound")],
+        )
+
+    def test_parse_pattern_many_results(self):
+        ureg = self.ureg
+        self.assertEqual(
+            ureg.parse_pattern(
+                "1.5kg or 2kg will be fine, if you do not have 3kg",
+                r"{kg}kg",
+                many=True,
+            ),
+            [
+                [ureg.Quantity(1.5, "kilogram")],
+                [ureg.Quantity(2.0, "kilogram")],
+                [ureg.Quantity(3.0, "kilogram")],
+            ],
+        )
+
+    def test_parse_pattern_many_results_two_units(self):
+        ureg = self.ureg
+        self.assertEqual(
+            ureg.parse_pattern("10'10 or 10'11", "{foot}'{inch}", many=True),
+            [
+                [ureg.Quantity(10.0, "foot"), ureg.Quantity(10.0, "inch")],
+                [ureg.Quantity(10.0, "foot"), ureg.Quantity(11.0, "inch")],
+            ],
+        )
+
 
 class TestCompatibleUnits(QuantityTestCase):
     FORCE_NDARRAY = False


### PR DESCRIPTION
- [X] Closes #997.
- [X] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [?] Documented in docs/ as appropriate
- [?] Added an entry to the CHANGES file

I don't like to open issues that I am able to implement myself, so I quickly made a POC implementation which seems to work quite well and is sufficient for my purposes.

Parsing with regex isn't as clean as parsing with the `parse` (https://github.com/r1chardj0n3s/parse) library which I initially thought of using, but I decided that after such a long time of being fully independent of third-party libraries, you wouldn't want to begin now. Thus readability has been sacrificed at the cost of upholding the design principles. Personally I don't mind as long as the feature is usable.

Thank you for this great module!