### PR TITLE
Change default datatype to np.ptype("int") in test_numpy 

### DIFF
--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -885,7 +885,7 @@ class TestNumpyUnclassified(TestNumpyMethods):
 
     @helpers.requires_array_function_protocol()
     def test_result_type_numpy_func(self):
-        self.assertEqual(np.result_type(self.q), np.dtype("int64"))
+        self.assertEqual(np.result_type(self.q), np.dtype("int"))
 
     @helpers.requires_array_function_protocol()
     def test_nan_to_num_numpy_func(self):


### PR DESCRIPTION
The test function test_result_type_numpy_func checks the datatype for [[1, 2], [3, 4]] * self.ureg.m to be integer. The test originally ensured the datatype to be np.ptype("int64"), but that fails in 32 bit environments, as shown in issue #1006.
Using np.ptype("int") instead ensure that the quantity is of default integer type, making numpy itself decide whether it should be np.ptype("int64") or np.ptype("int32").

- [x] Closes #1006
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [  ] Documented in docs/ as appropriate
- [  ] Added an entry to the CHANGES file