### PR TITLE
also treat NaN as a special value in pad

### DIFF
--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -655,7 +655,7 @@ def _pad(array, pad_width, mode="constant", **kwargs):
         if iterable(arg):
             return tuple(_recursive_convert(a, unit=unit) for a in arg)
         elif not _is_quantity(arg):
-            if arg == 0:
+            if arg == 0 or np.isnan(arg):
                 arg = unit._REGISTRY.Quantity(arg, unit)
             else:
                 arg = unit._REGISTRY.Quantity(arg, "dimensionless")

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1067,15 +1067,17 @@ class TestNumpyUnclassified(TestNumpyMethods):
     def test_pad(self):
         # Tests reproduced with modification from NumPy documentation
         a = [1, 2, 3, 4, 5] * self.ureg.m
-        b = self.Q_([4, 6, 8, 9, -3], "degC")
+        b = self.Q_([4.0, 6.0, 8.0, 9.0, -3.0], "degC")
 
         self.assertQuantityEqual(
             np.pad(a, (2, 3), "constant", constant_values=(0, 600 * self.ureg.cm)),
             [0, 0, 1, 2, 3, 4, 5, 6, 6, 6] * self.ureg.m,
         )
         self.assertQuantityEqual(
-            np.pad(b, (2, 1), "constant", constant_values=self.Q_(10, "degC")),
-            self.Q_([10, 10, 4, 6, 8, 9, -3, 10], "degC"),
+            np.pad(
+                b, (2, 1), "constant", constant_values=(np.nan, self.Q_(10, "degC"))
+            ),
+            self.Q_([np.nan, np.nan, 4, 6, 8, 9, -3, 10], "degC"),
         )
         self.assertRaises(
             DimensionalityError, np.pad, a, (2, 3), "constant", constant_values=4


### PR DESCRIPTION
In #994, the `np.pad` implementation was modified to fail on non-quantity `constant_values` / `end_values` arguments, with a special exception for `0`. Throughout the code base, we treat `np.nan` the same way we treat `0` so we should do that in `np.pad`, too.

- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests

Should be ready for merging.