### PR TITLE
Make `__str__` and `__format__` locale aware

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.11 (unreleased)
 -----------------
 
+- Make `__str__` and `__format__` locale aware
 - Remove `default_en_0.6.txt`
 - Reorganize long_description.
 - Moved Pi to defintions files.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -419,9 +419,26 @@ Finally, if Babel_ is installed you can translate unit names to any language
    >>> accel.format_babel(locale='fr_FR')
    '1.3 mètre par seconde²'
 
-You can also specify the format locale at u
+You can also specify the format locale at the registry level either at creation:
 
     >>> ureg = UnitRegistry(fmt_locale='fr_FR')
+
+or later:
+
+.. doctest::
+
+    >>> ureg.set_fmt_locale('fr_FR')
+
+and by doing that, string formatting is now localized:
+
+.. doctest::
+
+    >>> str(accel)
+    '1.3 mètre par seconde²'
+    >>> "%s" % accel
+    '1.3 mètre par seconde²'
+    >>> "{}".format(accel)
+    '1.3 mètre par seconde²'
 
 
 Using Pint in your projects

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -252,6 +252,9 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return ret
 
     def __str__(self):
+        if self._REGISTRY.fmt_locale is not None:
+            return self.format_babel()
+
         return format(self)
 
     def __bytes__(self):
@@ -270,6 +273,9 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     _exp_pattern = re.compile(r"([0-9]\.?[0-9]*)e(-?)\+?0*([0-9]+)")
 
     def __format__(self, spec):
+        if self._REGISTRY.fmt_locale is not None:
+            return self.format_babel(spec)
+
         spec = spec or self.default_format
 
         if "L" in spec:

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -172,6 +172,9 @@ class BaseRegistry(metaclass=RegistryMeta):
     #: type: Dict[str, (SourceIterator -> None)]
     _parsers = None
 
+    #: Babel.Locale instance or None
+    fmt_locale = None
+
     #: List to be used in addition of units when dir(registry) is called.
     #: Also used for autocompletion in IPython.
     _dir = [
@@ -216,7 +219,7 @@ class BaseRegistry(metaclass=RegistryMeta):
         self.auto_reduce_dimensions = auto_reduce_dimensions
 
         #: Default locale identifier string, used when calling format_babel without explicit locale.
-        self.fmt_locale = self.set_fmt_locale(fmt_locale)
+        self.set_fmt_locale(fmt_locale)
 
         #: Map between name (string) and value (string) of defaults stored in the
         #: definitions file.

--- a/pint/testsuite/helpers.py
+++ b/pint/testsuite/helpers.py
@@ -67,6 +67,10 @@ def requires_babel():
     return unittest.skipUnless(HAS_BABEL, "Requires Babel with units support")
 
 
+def requires_not_babel():
+    return unittest.skipIf(HAS_BABEL, "Requires Babel is not installed")
+
+
 def requires_uncertainties():
     return unittest.skipUnless(HAS_UNCERTAINTIES, "Requires Uncertainties")
 

--- a/pint/testsuite/test_babel.py
+++ b/pint/testsuite/test_babel.py
@@ -5,6 +5,14 @@ from pint.testsuite import BaseTestCase, helpers
 
 
 class TestBabel(BaseTestCase):
+    @helpers.requires_not_babel()
+    def test_no_babel(self):
+        ureg = UnitRegistry()
+        distance = 24.0 * ureg.meter
+        self.assertRaises(
+            Exception, distance.format_babel, locale="fr_FR", length="long"
+        )
+
     @helpers.requires_babel()
     def test_format(self):
         ureg = UnitRegistry()
@@ -46,9 +54,32 @@ class TestBabel(BaseTestCase):
         mks = ureg.get_system("mks")
         self.assertEqual(mks.format_babel(locale="fr_FR"), "métrique")
 
-    def test_nobabel(self):
+    @helpers.requires_babel()
+    def test_no_registry_locale(self):
         ureg = UnitRegistry()
         distance = 24.0 * ureg.meter
         self.assertRaises(
-            Exception, distance.format_babel, locale="fr_FR", length="long"
+            Exception, distance.format_babel,
         )
+
+    @helpers.requires_babel()
+    def test_str(self):
+        ureg = UnitRegistry()
+        d = 24.0 * ureg.meter
+
+        s = "24.0 meter"
+        self.assertEqual(str(d), s)
+        self.assertEqual("%s" % d, s)
+        self.assertEqual("{}".format(d), s)
+
+        ureg.set_fmt_locale("fr_FR")
+        s = "24.0 mètres"
+        self.assertEqual(str(d), s)
+        self.assertEqual("%s" % d, s)
+        self.assertEqual("{}".format(d), s)
+
+        ureg.set_fmt_locale(None)
+        s = "24.0 meter"
+        self.assertEqual(str(d), s)
+        self.assertEqual("%s" % d, s)
+        self.assertEqual("{}".format(d), s)


### PR DESCRIPTION
With this commit, all string formatting operations are locale aware

    >>> ureg.set_fmt_locale('fr_FR')
    >>> str(accel)
    '1.3 mètre par seconde²'
    >>> "%s" % accel
    '1.3 mètre par seconde²'
    >>> "{}".format(accel)
    '1.3 mètre par seconde²'

It should not break any code as the default locale value for the
Registry is `None` (meaning do not localize).

Close #984

- [x] Closes #984 (insert issue number)
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
