### PR TITLE
Use setuptools_scm via pyproject.toml

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.11 (unreleased)
 -----------------
 
+- Now we use `pyproject.toml` for providing `setuptools_scm` settings
 - Remove `default_en_0.6.txt`
 - Reorganize long_description.
 - Moved Pi to defintions files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = ["setuptools>=41", "wheel", "setuptools_scm[toml]>=3.4.3"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -2,4 +2,4 @@
 from setuptools import setup
 
 if __name__ == "__main__":
-    setup(use_scm_version=True)
+    setup()


### PR DESCRIPTION
- [x] Executed ``black -t py36 . && isort -rc .`` with no errors
`flake8`:
```
./pint/measurement.py:53:17: F999 '...'.format(...) has unused arguments at position(s): 0, 1
./pint/testsuite/test_numpy.py:1051:21: F999 f-string is missing placeholders
```
But this PR doesn't touch this files.

- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
