### PR TITLE
Remove array interface protocol fallback and NEP 18 warning

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,9 @@ Pint Changelog
 0.11 (unreleased)
 -----------------
 
+- **BREAKING CHANGE**:
+  The array protocol fallback deprecated in version 0.10 has been removed.
+  (Issue #1029, Thanks Jon Thielen)
 - Now we use `pyproject.toml` for providing `setuptools_scm` settings
 - Remove `default_en_0.6.txt`
 - Reorganize long_description.

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,9 @@ Pint Changelog
 0.11 (unreleased)
 -----------------
 
+- Quantities wrapping NumPy arrays will no longer warning for the changed
+  array function behavior introduced in 0.10.
+  (Issue #1029, Thanks Jon Thielen)
 - **BREAKING CHANGE**:
   The array protocol fallback deprecated in version 0.10 has been removed.
   (Issue #1029, Thanks Jon Thielen)

--- a/docs/numpy.ipynb
+++ b/docs/numpy.ipynb
@@ -24,10 +24,6 @@
     "# Import NumPy\n",
     "import numpy as np\n",
     "\n",
-    "# Disable Pint's old fallback behavior (must come before importing Pint)\n",
-    "import os\n",
-    "os.environ['PINT_ARRAY_PROTOCOL_FALLBACK'] = \"0\"\n",
-    "\n",
     "# Import Pint\n",
     "import pint\n",
     "ureg = pint.UnitRegistry()\n",
@@ -780,8 +776,7 @@
     "\n",
     "This behaviour introduces some performance penalties and increased memory usage. Quantities that must be converted to other units require additional memory and CPU cycles. Therefore, for numerically intensive code, you might want to convert the objects first and then use directly the magnitude, such as by using Pint's `wraps` utility (see [wrapping](wrapping.rst)).\n",
     "\n",
-    "Array interface protocol attributes (such as `__array_struct__` and\n",
-    "`__array_interface__`) are available on Pint Quantities by deferring to the corresponding `__array_*` attribute on the magnitude as casted to an ndarray. This has been found to be potentially incorrect and to cause unexpected behavior, and has therefore been deprecated. As of the next minor version of Pint (or when the `PINT_ARRAY_PROTOCOL_FALLBACK` environment variable is set to 0 prior to importing Pint as done at the beginning of this page), attempting to access these attributes will instead raise an AttributeError."
+    "Attempting to access array interface protocol attributes (such as `__array_struct__` and `__array_interface__`) on Pint Quantities will raise an AttributeError, since a Quantity is meant to behave as a \"duck array,\" and not a pure ndarray."
    ]
   }
  ],
@@ -801,7 +796,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/pint/compat.py
+++ b/pint/compat.py
@@ -7,7 +7,6 @@
     :copyright: 2013 by Pint Authors, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
-import os
 import tokenize
 from decimal import Decimal
 from io import BytesIO
@@ -97,8 +96,6 @@ try:
 
     NP_NO_VALUE = np._NoValue
 
-    ARRAY_FALLBACK = bool(int(os.environ.get("PINT_ARRAY_PROTOCOL_FALLBACK", 1)))
-
 except ImportError:
 
     np = None
@@ -112,7 +109,6 @@ except ImportError:
     HAS_NUMPY_ARRAY_FUNCTION = False
     SKIP_ARRAY_FUNCTION_CHANGE_WARNING = True
     NP_NO_VALUE = None
-    ARRAY_FALLBACK = False
 
     def _to_magnitude(value, force_ndarray=False, force_ndarray_like=False):
         if force_ndarray or force_ndarray_like:

--- a/pint/compat.py
+++ b/pint/compat.py
@@ -36,27 +36,6 @@ class BehaviorChangeWarning(UserWarning):
     pass
 
 
-array_function_change_msg = """The way Pint handles NumPy operations has changed with the
-implementation of NEP 18. Unimplemented NumPy operations will now fail instead of making
-assumptions about units. Some functions, eg concat, will now return Quanties with units, where
-they returned ndarrays previously. See https://github.com/hgrecco/pint/pull/905.
-
-To hide this warning, wrap your first creation of an array Quantity with
-warnings.catch_warnings(), like the following:
-
-import numpy as np
-import warnings
-from pint import Quantity
-
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    Quantity([])
-
-To disable the new behavior, see
-https://www.numpy.org/neps/nep-0018-array-function-protocol.html#implementation
-"""
-
-
 try:
     import numpy as np
     from numpy import ndarray
@@ -92,7 +71,6 @@ try:
             return False
 
     HAS_NUMPY_ARRAY_FUNCTION = _test_array_function_protocol()
-    SKIP_ARRAY_FUNCTION_CHANGE_WARNING = not HAS_NUMPY_ARRAY_FUNCTION
 
     NP_NO_VALUE = np._NoValue
 
@@ -107,7 +85,6 @@ except ImportError:
     NUMPY_VER = "0"
     NUMERIC_TYPES = (Number, Decimal)
     HAS_NUMPY_ARRAY_FUNCTION = False
-    SKIP_ARRAY_FUNCTION_CHANGE_WARNING = True
     NP_NO_VALUE = None
 
     def _to_magnitude(value, force_ndarray=False, force_ndarray_like=False):

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -22,7 +22,6 @@ from pkg_resources.extern.packaging import version
 
 from .compat import SKIP_ARRAY_FUNCTION_CHANGE_WARNING  # noqa: F401
 from .compat import (
-    ARRAY_FALLBACK,
     NUMPY_VER,
     BehaviorChangeWarning,
     _to_magnitude,
@@ -1658,34 +1657,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     def __getattr__(self, item):
         if item.startswith("__array_"):
             # Handle array protocol attributes other than `__array__`
-            if ARRAY_FALLBACK:
-                # Deprecated fallback behavior
-                warnings.warn(
-                    (
-                        f"Array protocol attribute {item} accessed, with unit of the "
-                        "Quantity being stripped. This attribute will become unavailable "
-                        "in the next minor version of Pint. To make this potentially "
-                        "incorrect attribute unavailable now, set the "
-                        "PINT_ARRAY_PROTOCOL_FALLBACK environment variable to 0 before "
-                        "importing Pint."
-                    ),
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-
-                if is_duck_array_type(type(self._magnitude)):
-                    # Defer to magnitude, and don't catch any AttributeErrors
-                    return getattr(self._magnitude, item)
-                else:
-                    # If an `__array_` attribute is requested but the magnitude is not
-                    # a duck array, we convert the magnitude to a numpy ndarray.
-                    magnitude_as_array = _to_magnitude(
-                        self._magnitude, force_ndarray=True
-                    )
-                    return getattr(magnitude_as_array, item)
-            else:
-                # TODO (next minor version): ARRAY_FALLBACK is removed and this becomes the standard behavior
-                raise AttributeError(f"Array protocol attribute {item} not available.")
+            raise AttributeError(f"Array protocol attribute {item} not available.")
         elif item in HANDLED_UFUNCS or item in self._wrapped_numpy_methods:
             magnitude_as_duck_array = _to_magnitude(
                 self._magnitude, force_ndarray_like=True

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -20,12 +20,9 @@ import warnings
 
 from pkg_resources.extern.packaging import version
 
-from .compat import SKIP_ARRAY_FUNCTION_CHANGE_WARNING  # noqa: F401
 from .compat import (
     NUMPY_VER,
-    BehaviorChangeWarning,
     _to_magnitude,
-    array_function_change_msg,
     babel_parse,
     eq,
     is_duck_array_type,
@@ -160,8 +157,6 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return _unpickle, (Quantity, self.magnitude, self._units)
 
     def __new__(cls, value, units=None):
-        global SKIP_ARRAY_FUNCTION_CHANGE_WARNING
-
         if is_upcast_type(type(value)):
             raise TypeError(f"Quantity cannot wrap upcast type {type(value)}")
         elif units is None:
@@ -213,12 +208,6 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         inst.__used = False
         inst.__handling = None
-
-        if not SKIP_ARRAY_FUNCTION_CHANGE_WARNING and isinstance(
-            inst._magnitude, ndarray
-        ):
-            warnings.warn(array_function_change_msg, BehaviorChangeWarning)
-            SKIP_ARRAY_FUNCTION_CHANGE_WARNING = True
 
         return inst
 

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1,7 +1,6 @@
 import copy
 import operator as op
 import unittest
-from unittest.mock import patch
 
 from pint import DimensionalityError, OffsetUnitCalculusError, UnitStrippedWarning
 from pint.compat import np

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1031,28 +1031,15 @@ class TestNumpyUnclassified(TestNumpyMethods):
             np.array([[1, 0, 2], [3, 0, 4]]) * self.ureg.m,
         )
 
-    @patch("pint.quantity.ARRAY_FALLBACK", False)
     def test_ndarray_downcast(self):
         with self.assertWarns(UnitStrippedWarning):
             np.asarray(self.q)
 
-    @patch("pint.quantity.ARRAY_FALLBACK", False)
     def test_ndarray_downcast_with_dtype(self):
         with self.assertWarns(UnitStrippedWarning):
             qarr = np.asarray(self.q, dtype=np.float64)
             self.assertEqual(qarr.dtype, np.float64)
 
-    def test_array_protocol_fallback(self):
-        with self.assertWarns(DeprecationWarning) as cm:
-            for attr in ("__array_struct__", "__array_interface__"):
-                getattr(self.q, attr)
-                warning_text = str(cm.warnings[0].message)
-                self.assertTrue(
-                    f"unit of the Quantity being stripped" in warning_text
-                    and "will become unavailable" in warning_text
-                )
-
-    @patch("pint.quantity.ARRAY_FALLBACK", False)
     def test_array_protocol_unavailable(self):
         for attr in ("__array_struct__", "__array_interface__"):
             self.assertRaises(AttributeError, getattr, self.q, attr)

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -6,7 +6,7 @@ import warnings
 from unittest.mock import patch
 
 from pint import DimensionalityError, OffsetUnitCalculusError, UnitRegistry
-from pint.compat import BehaviorChangeWarning, np
+from pint.compat import np
 from pint.testsuite import QuantityTestCase, helpers
 from pint.testsuite.parameterized import ParameterizedTestCase
 from pint.unit import UnitsContainer
@@ -531,11 +531,8 @@ class TestQuantity(QuantityTestCase):
             iter(x)
 
     @helpers.requires_array_function_protocol()
-    @patch("pint.quantity.SKIP_ARRAY_FUNCTION_CHANGE_WARNING", False)
-    def test_array_function_warning_on_creation(self):
-        # Test that warning is raised on first creation, but not second
-        with self.assertWarns(BehaviorChangeWarning):
-            self.Q_([])
+    def test_no_longer_array_function_warning_on_creation(self):
+        # Test that warning is no longer raised on first creation
         with warnings.catch_warnings():
             warnings.filterwarnings("error")
             self.Q_([])


### PR DESCRIPTION
As mentioned in #1011, this PR removes the array interface protocol fallback that was deprecated in 0.10, as well as the NEP 18 warning on first array Quantity creation.

- ~~Closes # (insert issue number)~~
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
