### PR TITLE
fix for key error in numpy.pad

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ Pint Changelog
 - Allow constants in units by using a leading underscore (Issue #989, Thanks
   Juan Nunez-Iglesias)
 - Fixed bug where to_compact handled prefix units incorrectly (Issue #960)
+- Fixed bug where numpy.pad didn't work without specifying constant_values or
+  end_values (Issue #1026)
 
 0.10.1 (2020-01-07)
 -------------------
@@ -235,7 +237,7 @@ Pint Changelog
 - Added several new units and Systems
   (Issues #749, #737, )
 - Started experimental pandas support
-  (Issue #746 and others. Thanks andrewgsavage, znicholls and others)  
+  (Issue #746 and others. Thanks andrewgsavage, znicholls and others)
 - wraps and checks now supports kwargs and defaults.
   (Issue #660, thanks jondoesntgit)
 

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -667,10 +667,9 @@ def _pad(array, pad_width, mode="constant", **kwargs):
 
     # Handle flexible constant_values and end_values, converting to units if Quantity
     # and ignoring if not
-    if mode == "constant":
-        kwargs["constant_values"] = _recursive_convert(kwargs["constant_values"], units)
-    elif mode == "linear_ramp":
-        kwargs["end_values"] = _recursive_convert(kwargs["end_values"], units)
+    for key in ("constant_values", "end_values"):
+        if key in kwargs:
+            kwargs[key] = _recursive_convert(kwargs[key], units)
 
     return units._REGISTRY.Quantity(
         np.pad(array._magnitude, pad_width, mode=mode, **kwargs), units

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1070,6 +1070,9 @@ class TestNumpyUnclassified(TestNumpyMethods):
         b = self.Q_([4.0, 6.0, 8.0, 9.0, -3.0], "degC")
 
         self.assertQuantityEqual(
+            np.pad(a, (2, 3), "constant"), [0, 0, 1, 2, 3, 4, 5, 0, 0, 0] * self.ureg.m,
+        )
+        self.assertQuantityEqual(
             np.pad(a, (2, 3), "constant", constant_values=(0, 600 * self.ureg.cm)),
             [0, 0, 1, 2, 3, 4, 5, 6, 6, 6] * self.ureg.m,
         )
@@ -1084,6 +1087,10 @@ class TestNumpyUnclassified(TestNumpyMethods):
         )
         self.assertQuantityEqual(
             np.pad(a, (2, 3), "edge"), [1, 1, 1, 2, 3, 4, 5, 5, 5, 5] * self.ureg.m
+        )
+        self.assertQuantityEqual(
+            np.pad(a, (2, 3), "linear_ramp"),
+            [0, 0, 1, 2, 3, 4, 5, 3, 1, 0] * self.ureg.m,
         )
         self.assertQuantityEqual(
             np.pad(a, (2, 3), "linear_ramp", end_values=(5, -4) * self.ureg.m),


### PR DESCRIPTION
- [x] Closes #1026
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
