### PR TITLE
Return expected empty type for parse_pattern function

### DIFF
--- a/pint/registry.py
+++ b/pint/registry.py
@@ -1183,7 +1183,7 @@ class BaseRegistry(metaclass=RegistryMeta):
         """
 
         if not input_string:
-            return self.Quantity(1)
+            return [] if many else None
 
         # Parse string
         pattern = pattern_to_regex(pattern)


### PR DESCRIPTION
N.B. Pardon me if I didn't follow convention by opening an issue before making this PR.

Whilst using the `parse_pattern` function with `pandas` I realised the `return self.Quantity(1)` returned a dimensionless quantity which would be out of place compared to all of the other returned values causing parsing issues. The error I was getting was:
```
  File "/usr/lib/python3.6/site-packages/pandas/core/frame.py", line 1598, in from_records
    arrays, arr_columns = to_arrays(data, columns, coerce_float=coerce_float)
  File "/usr/lib/python3.6/site-packages/pandas/core/internals/construction.py", line 464, in to_arrays
    return _list_to_arrays(data, columns, coerce_float=coerce_float, dtype=dtype)
  File "/usr/lib/python3.6/site-packages/pandas/core/internals/construction.py", line 496, in _list_to_arrays
    content = list(lib.to_object_array(data).T)
  File "pandas/_libs/lib.pyx", line 2275, in pandas._libs.lib.to_object_array
  File "/usr/lib/python3.6/site-packages/pint/quantity.py", line 1693, in __len__
    return len(self._magnitude)
TypeError: object of type 'int' has no len()
```

This simple fix returns a value which conforms with the expected output type.