### PR TITLE
Update expected initial release date for pint-xarray

### DIFF
--- a/docs/numpy.ipynb
+++ b/docs/numpy.ipynb
@@ -754,7 +754,7 @@
     "To aid in integration between various array types and Pint (such as by providing convenience methods), the following compatibility packages are available:\n",
     "\n",
     "- [pint-pandas](https://github.com/hgrecco/pint-pandas)\n",
-    "- pint-xarray ([in development](https://github.com/hgrecco/pint/issues/849), initial alpha release planned for January 2020)\n",
+    "- pint-xarray ([in development](https://github.com/hgrecco/pint/issues/849), initial alpha release planned for April-May 2020)\n",
     "\n",
     "(Note: if you have developed a compatibility package for Pint, please submit a pull request to add it to this list!)"
    ]


### PR DESCRIPTION
Just a quick update to the docs delaying the expected release for pint-xarray, since I haven't gotten around to it yet, and unfortunately likely won't get the chance until April. (Though, if someone wanted to take the ideas in #849 and get something put together earlier, that would be great too!)

xref #849 

- ~~Closes # (insert issue number)~~
- ~~Executed ``black -t py36 . && isort -rc . && flake8`` with no errors~~
- ~~The change is fully covered by automated unit tests~~
- [x] Documented in docs/ as appropriate
- ~~Added an entry to the CHANGES file~~
