### PR TITLE
allow passing python scalars as atol / rtol to isclose

### DIFF
--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -763,7 +763,7 @@ for func_str, unit_arguments, wrap_output in [
     ("amax", ["a", "initial"], True),
     ("amin", ["a", "initial"], True),
     ("searchsorted", ["a", "v"], False),
-    ("isclose", ["a", "b", "rtol", "atol"], False),
+    ("isclose", ["a", "b"], False),
     ("nan_to_num", ["x", "nan", "posinf", "neginf"], True),
     ("clip", ["a", "a_min", "a_max"], True),
     ("append", ["arr", "values"], True),

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -1126,9 +1126,7 @@ class BaseRegistry(metaclass=RegistryMeta):
 
         return ret
 
-    def _eval_token(
-        self, token, case_sensitive=True, use_decimal=False, **values,
-    ):
+    def _eval_token(self, token, case_sensitive=True, use_decimal=False, **values):
 
         # TODO: remove this code when use_decimal is deprecated
         if use_decimal:
@@ -1214,7 +1212,7 @@ class BaseRegistry(metaclass=RegistryMeta):
         return results
 
     def parse_expression(
-        self, input_string, case_sensitive=True, use_decimal=False, **values,
+        self, input_string, case_sensitive=True, use_decimal=False, **values
     ):
         """Parse a mathematical expression including units and return a quantity object.
 

--- a/pint/testsuite/test_babel.py
+++ b/pint/testsuite/test_babel.py
@@ -58,9 +58,7 @@ class TestBabel(BaseTestCase):
     def test_no_registry_locale(self):
         ureg = UnitRegistry()
         distance = 24.0 * ureg.meter
-        self.assertRaises(
-            Exception, distance.format_babel,
-        )
+        self.assertRaises(Exception, distance.format_babel)
 
     @helpers.requires_babel()
     def test_str(self):

--- a/pint/testsuite/test_non_int.py
+++ b/pint/testsuite/test_non_int.py
@@ -220,9 +220,7 @@ class _TestBasic:
 
     def test_dimensionless_units(self):
         twopi = self.NON_INT_TYPE("2") * self.ureg.pi
-        self.assertAlmostEqual(
-            self.QP_("360", "degree").to("radian").magnitude, twopi,
-        )
+        self.assertAlmostEqual(self.QP_("360", "degree").to("radian").magnitude, twopi)
         self.assertAlmostEqual(self.Q_(twopi, "radian"), self.QP_("360", "degree"))
         self.assertEqual(self.QP_("1", "radian").dimensionality, UnitsContainer())
         self.assertTrue(self.QP_("1", "radian").dimensionless)

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1049,7 +1049,7 @@ class TestNumpyUnclassified(TestNumpyMethods):
         b = self.Q_([4.0, 6.0, 8.0, 9.0, -3.0], "degC")
 
         self.assertQuantityEqual(
-            np.pad(a, (2, 3), "constant"), [0, 0, 1, 2, 3, 4, 5, 0, 0, 0] * self.ureg.m,
+            np.pad(a, (2, 3), "constant"), [0, 0, 1, 2, 3, 4, 5, 0, 0, 0] * self.ureg.m
         )
         self.assertQuantityEqual(
             np.pad(a, (2, 3), "constant", constant_values=(0, 600 * self.ureg.cm)),

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -896,6 +896,10 @@ class TestNumpyUnclassified(TestNumpyMethods):
         self.assertNDArrayEqual(
             np.isclose(self.q, q2), np.array([[False, True], [True, False]])
         )
+        self.assertNDArrayEqual(
+            np.isclose(self.q, q2, atol=1e-5, rtol=1e-7),
+            np.array([[False, True], [True, False]]),
+        )
 
     @helpers.requires_array_function_protocol()
     def test_interp_numpy_func(self):


### PR DESCRIPTION
This makes `isclose` match the behaviour of `allclose`.

- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests

Edit: the diff is slightly bigger because `black` touched a few files.