### PR TITLE
Addition, equality, and disequality to bare NaN

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,8 @@ Pint Changelog
   end_values (Issue #1026)
 - Reinstated support for pickle protocol 0 and 1, which is required by pytables
   (Issue #1036, Thanks Guido Imperiale)
+- NaN is now treated the same as zero in addition, equality, and disequality
+  (Issue #1051, Thanks Guido Imperiale)
 
 
 0.11 (2020-02-19)

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -10,7 +10,7 @@ import warnings
 from inspect import signature
 from itertools import chain
 
-from .compat import eq, is_upcast_type, np
+from .compat import is_upcast_type, np, zero_or_nan
 from .errors import DimensionalityError
 from .util import iterable, sized
 
@@ -485,12 +485,13 @@ def _power(x1, x2):
 
 
 def _add_subtract_handle_non_quantity_zero(x1, x2):
-    # As in #121/#122, if a value is 0 (but not Quantity 0) do the operation without
-    # checking units. We do the calculation instead of just returning the same value to
-    # enforce any shape checking and type casting due to the operation.
-    if eq(x1, 0, True):
+    # As in #121, #122, and #1051, if a value is 0 or NaN (but not a Quantity) do the
+    # operation without checking units. We do the calculation instead of just returning
+    # the same value to enforce any shape checking and type casting due to the
+    # operation.
+    if zero_or_nan(x1, True):
         (x2,), output_wrap = unwrap_and_wrap_consistent_units(x2)
-    elif eq(x2, 0, True):
+    elif zero_or_nan(x2, True):
         (x1,), output_wrap = unwrap_and_wrap_consistent_units(x1)
     else:
         (x1, x2), output_wrap = unwrap_and_wrap_consistent_units(x1, x2)

--- a/pint/testsuite/__init__.py
+++ b/pint/testsuite/__init__.py
@@ -101,6 +101,10 @@ class QuantityTestCase(BaseTestCase):
 
         if isinstance(m1, ndarray) or isinstance(m2, ndarray):
             np.testing.assert_array_equal(m1, m2, err_msg=msg)
+        elif math.isnan(m1):
+            self.assertTrue(math.isnan(m2), msg)
+        elif math.isnan(m2):
+            self.assertTrue(math.isnan(m1), msg)
         else:
             self.assertEqual(m1, m2, msg)
 
@@ -118,6 +122,10 @@ class QuantityTestCase(BaseTestCase):
 
         if isinstance(m1, ndarray) or isinstance(m2, ndarray):
             np.testing.assert_allclose(m1, m2, rtol=rtol, atol=atol, err_msg=msg)
+        elif math.isnan(m1):
+            self.assertTrue(math.isnan(m2), msg)
+        elif math.isnan(m2):
+            self.assertTrue(math.isnan(m1), msg)
         else:
             self.assertLessEqual(abs(m1 - m2), atol + rtol * abs(m2), msg=msg)
 

--- a/pint/testsuite/test_compat.py
+++ b/pint/testsuite/test_compat.py
@@ -1,0 +1,104 @@
+import math
+from datetime import datetime, timedelta
+
+import pytest
+
+from pint.compat import eq, isnan, zero_or_nan
+
+from .helpers import requires_numpy
+
+
+@pytest.mark.parametrize("check_all", [False, True])
+def test_eq(check_all):
+    assert eq(0, 0, check_all)
+    assert not eq(0, 1, check_all)
+
+
+@requires_numpy()
+def test_eq_numpy():
+    import numpy as np
+
+    assert eq(np.array([1, 2]), np.array([1, 2]), True)
+    assert not eq(np.array([1, 2]), np.array([1, 3]), True)
+    np.testing.assert_equal(
+        eq(np.array([1, 2]), np.array([1, 2]), False), np.array([True, True])
+    )
+    np.testing.assert_equal(
+        eq(np.array([1, 2]), np.array([1, 3]), False), np.array([True, False])
+    )
+
+    # Mixed numpy/scalar
+    assert eq(1, np.array([1, 1]), True)
+    assert eq(np.array([1, 1]), 1, True)
+    assert not eq(1, np.array([1, 2]), True)
+    assert not eq(np.array([1, 2]), 1, True)
+
+
+@pytest.mark.parametrize("check_all", [False, True])
+def test_isnan(check_all):
+    assert not isnan(0, check_all)
+    assert not isnan(0.0, check_all)
+    assert isnan(math.nan, check_all)
+    assert not isnan(datetime(2000, 1, 1), check_all)
+    assert not isnan(timedelta(seconds=1), check_all)
+    assert not isnan("foo", check_all)
+
+
+@requires_numpy()
+def test_isnan_numpy():
+    import numpy as np
+
+    assert isnan(np.nan, True)
+    assert isnan(np.nan, False)
+    assert not isnan(np.array([0, 0]), True)
+    assert isnan(np.array([0, np.nan]), True)
+    assert not isnan(np.array(["A", "B"]), True)
+    np.testing.assert_equal(
+        isnan(np.array([1, np.nan]), False), np.array([False, True])
+    )
+    np.testing.assert_equal(
+        isnan(np.array(["A", "B"]), False), np.array([False, False])
+    )
+
+
+@requires_numpy()
+def test_isnan_nat():
+    import numpy as np
+
+    a = np.array(["2000-01-01", "NaT"], dtype="M8")
+    b = np.array(["2000-01-01", "2000-01-02"], dtype="M8")
+    assert isnan(a, True)
+    assert not isnan(b, True)
+    np.testing.assert_equal(isnan(a, False), np.array([False, True]))
+    np.testing.assert_equal(isnan(b, False), np.array([False, False]))
+
+    # Scalar numpy.datetime64
+    assert not isnan(a[0], True)
+    assert not isnan(a[0], False)
+    assert isnan(a[1], True)
+    assert isnan(a[1], False)
+
+
+@pytest.mark.parametrize("check_all", [False, True])
+def test_zero_or_nan(check_all):
+    assert zero_or_nan(0, check_all)
+    assert zero_or_nan(math.nan, check_all)
+    assert not zero_or_nan(1, check_all)
+    assert not zero_or_nan(datetime(2000, 1, 1), check_all)
+    assert not zero_or_nan(timedelta(seconds=1), check_all)
+    assert not zero_or_nan("foo", check_all)
+
+
+@requires_numpy()
+def test_zero_or_nan_numpy():
+    import numpy as np
+
+    assert zero_or_nan(np.nan, True)
+    assert zero_or_nan(np.nan, False)
+    assert zero_or_nan(np.array([0, np.nan]), True)
+    assert not zero_or_nan(np.array([1, np.nan]), True)
+    assert not zero_or_nan(np.array([0, 1]), True)
+    assert not zero_or_nan(np.array(["A", "B"]), True)
+    np.testing.assert_equal(
+        zero_or_nan(np.array([0, 1, np.nan]), False), np.array([True, False, True])
+    )

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -357,40 +357,6 @@ class TestIssues(QuantityTestCase):
                 func("METER")
             self.assertEqual(val, func("METER", False))
 
-    def test_issue121(self):
-        z, v = 0, 2.0
-        self.assertEqual(z + v * ureg.meter, v * ureg.meter)
-        self.assertEqual(z - v * ureg.meter, -v * ureg.meter)
-        self.assertEqual(v * ureg.meter + z, v * ureg.meter)
-        self.assertEqual(v * ureg.meter - z, v * ureg.meter)
-
-        self.assertEqual(sum([v * ureg.meter, v * ureg.meter]), 2 * v * ureg.meter)
-
-    @helpers.requires_numpy()
-    def test_issue121b(self):
-        sh = (2, 1)
-
-        z, v = 0, 2.0
-        self.assertEqual(z + v * ureg.meter, v * ureg.meter)
-        self.assertEqual(z - v * ureg.meter, -v * ureg.meter)
-        self.assertEqual(v * ureg.meter + z, v * ureg.meter)
-        self.assertEqual(v * ureg.meter - z, v * ureg.meter)
-
-        self.assertEqual(sum([v * ureg.meter, v * ureg.meter]), 2 * v * ureg.meter)
-
-        z, v = np.zeros(sh), 2.0 * np.ones(sh)
-        self.assertQuantityEqual(z + v * ureg.meter, v * ureg.meter)
-        self.assertQuantityEqual(z - v * ureg.meter, -v * ureg.meter)
-        self.assertQuantityEqual(v * ureg.meter + z, v * ureg.meter)
-        self.assertQuantityEqual(v * ureg.meter - z, v * ureg.meter)
-
-        z, v = np.zeros((3, 1)), 2.0 * np.ones(sh)
-        for x, y in ((z, v), (z, v * ureg.meter), (v * ureg.meter, z)):
-            with self.assertRaises(ValueError):
-                x + y
-            with self.assertRaises(ValueError):
-                x - y
-
     @helpers.requires_numpy()
     def test_issue127(self):
         q = [1.0, 2.0, 3.0, 4.0] * self.ureg.meter

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -843,6 +843,106 @@ class TestQuantityBasicMath(QuantityTestCase):
             self.assertRaises(DimensionalityError, fun, z)
 
 
+class TestQuantityNeutralAdd(QuantityTestCase):
+    """Addition to zero or NaN is allowed between a Quantity and a non-Quantity
+    """
+
+    FORCE_NDARRAY = False
+
+    def test_bare_zero(self):
+        v = self.Q_(2.0, "m")
+        self.assertEqual(v + 0, v)
+        self.assertEqual(v - 0, v)
+        self.assertEqual(0 + v, v)
+        self.assertEqual(0 - v, -v)
+
+    def test_bare_zero_inplace(self):
+        v = self.Q_(2.0, "m")
+        v2 = self.Q_(2.0, "m")
+        v2 += 0
+        self.assertEqual(v2, v)
+        v2 = self.Q_(2.0, "m")
+        v2 -= 0
+        self.assertEqual(v2, v)
+        v2 = 0
+        v2 += v
+        self.assertEqual(v2, v)
+        v2 = 0
+        v2 -= v
+        self.assertEqual(v2, -v)
+
+    def test_bare_nan(self):
+        v = self.Q_(2.0, "m")
+        self.assertQuantityEqual(v + math.nan, self.Q_(math.nan, v.units))
+        self.assertQuantityEqual(v - math.nan, self.Q_(math.nan, v.units))
+        self.assertQuantityEqual(math.nan + v, self.Q_(math.nan, v.units))
+        self.assertQuantityEqual(math.nan - v, self.Q_(math.nan, v.units))
+
+    def test_bare_nan_inplace(self):
+        v = self.Q_(2.0, "m")
+        v2 = self.Q_(2.0, "m")
+        v2 += math.nan
+        self.assertQuantityEqual(v2, self.Q_(math.nan, v.units))
+        v2 = self.Q_(2.0, "m")
+        v2 -= math.nan
+        self.assertQuantityEqual(v2, self.Q_(math.nan, v.units))
+        v2 = math.nan
+        v2 += v
+        self.assertQuantityEqual(v2, self.Q_(math.nan, v.units))
+        v2 = math.nan
+        v2 -= v
+        self.assertQuantityEqual(v2, self.Q_(math.nan, v.units))
+
+    @helpers.requires_numpy()
+    def test_bare_zero_or_nan_numpy(self):
+        z = np.array([0.0, np.nan])
+        v = self.Q_([1.0, 2.0], "m")
+        e = self.Q_([1.0, np.nan], "m")
+        self.assertQuantityEqual(z + v, e)
+        self.assertQuantityEqual(z - v, -e)
+        self.assertQuantityEqual(v + z, e)
+        self.assertQuantityEqual(v - z, e)
+
+        # If any element is non-zero and non-NaN, raise DimensionalityError
+        nz = np.array([0.0, 1.0])
+        with self.assertRaises(DimensionalityError):
+            nz + v
+        with self.assertRaises(DimensionalityError):
+            nz - v
+        with self.assertRaises(DimensionalityError):
+            v + nz
+        with self.assertRaises(DimensionalityError):
+            v - nz
+
+        # Mismatched shape
+        z = np.array([0.0, np.nan, 0.0])
+        v = self.Q_([1.0, 2.0], "m")
+        for x, y in ((z, v), (v, z)):
+            with self.assertRaises(ValueError):
+                x + y
+            with self.assertRaises(ValueError):
+                x - y
+
+    @helpers.requires_numpy()
+    def test_bare_zero_or_nan_numpy_inplace(self):
+        z = np.array([0.0, np.nan])
+        v = self.Q_([1.0, 2.0], "m")
+        e = self.Q_([1.0, np.nan], "m")
+        v += z
+        self.assertQuantityEqual(v, e)
+        v = self.Q_([1.0, 2.0], "m")
+        v -= z
+        self.assertQuantityEqual(v, e)
+        v = self.Q_([1.0, 2.0], "m")
+        z = np.array([0.0, np.nan])
+        z += v
+        self.assertQuantityEqual(z, e)
+        v = self.Q_([1.0, 2.0], "m")
+        z = np.array([0.0, np.nan])
+        z -= v
+        self.assertQuantityEqual(z, -e)
+
+
 class TestDimensions(QuantityTestCase):
 
     FORCE_NDARRAY = False
@@ -1506,38 +1606,36 @@ class TestTimedelta(QuantityTestCase):
             after -= d
 
 
-class TestCompareZero(QuantityTestCase):
-    """This test case checks the special treatment that the zero value
-    receives in the comparisons: pint>=0.9 supports comparisons against zero
-    even for non-dimensionless quantities
-
-    Parameters
-    ----------
-
-    Returns
-    -------
-
+class TestCompareNeutral(QuantityTestCase):
+    """Test comparisons against non-Quantity zero or NaN values for for
+    non-dimensionless quantities
     """
 
     def test_equal_zero(self):
-        ureg = self.ureg
-        ureg.autoconvert_offset_to_baseunit = False
-        self.assertTrue(ureg.Quantity(0, ureg.J) == 0)
-        self.assertFalse(ureg.Quantity(0, ureg.J) == ureg.Quantity(0, ""))
-        self.assertFalse(ureg.Quantity(5, ureg.J) == 0)
+        self.ureg.autoconvert_offset_to_baseunit = False
+        self.assertTrue(self.Q_(0, "J") == 0)
+        self.assertFalse(self.Q_(0, "J") == self.Q_(0, ""))
+        self.assertFalse(self.Q_(5, "J") == 0)
+
+    def test_equal_nan(self):
+        # nan == nan returns False
+        self.ureg.autoconvert_offset_to_baseunit = False
+        self.assertFalse(self.Q_(math.nan, "J") == 0)
+        self.assertFalse(self.Q_(math.nan, "J") == math.nan)
+        self.assertFalse(self.Q_(math.nan, "J") == self.Q_(math.nan, ""))
+        self.assertFalse(self.Q_(5, "J") == math.nan)
 
     @helpers.requires_numpy()
-    def test_equal_zero_NP(self):
-        ureg = self.ureg
-        ureg.autoconvert_offset_to_baseunit = False
+    def test_equal_zero_nan_NP(self):
+        self.ureg.autoconvert_offset_to_baseunit = False
         aeq = np.testing.assert_array_equal
-        aeq(ureg.Quantity(0, ureg.J) == np.zeros(3), np.asarray([True, True, True]))
-        aeq(ureg.Quantity(5, ureg.J) == np.zeros(3), np.asarray([False, False, False]))
+        aeq(self.Q_(0, "J") == np.array([0, np.nan]), np.array([True, False]))
+        aeq(self.Q_(5, "J") == np.array([0, np.nan]), np.array([False, False]))
         aeq(
-            ureg.Quantity(np.arange(3), ureg.J) == np.zeros(3),
+            self.Q_([0, 1, 2], "J") == np.array([0, 0, np.nan]),
             np.asarray([True, False, False]),
         )
-        self.assertFalse(ureg.Quantity(np.arange(4), ureg.J) == np.zeros(3))
+        self.assertFalse(self.Q_(np.arange(4), "J") == np.zeros(3))
 
     def test_offset_equal_zero(self):
         ureg = self.ureg
@@ -1562,39 +1660,47 @@ class TestCompareZero(QuantityTestCase):
         self.assertFalse(q0 == ureg.Quantity(0, ""))
 
     def test_gt_zero(self):
-        ureg = self.ureg
-        ureg.autoconvert_offset_to_baseunit = False
-        q0 = ureg.Quantity(0, "J")
-        q0m = ureg.Quantity(0, "m")
-        q0less = ureg.Quantity(0, "")
-        qpos = ureg.Quantity(5, "J")
-        qneg = ureg.Quantity(-5, "J")
+        self.ureg.autoconvert_offset_to_baseunit = False
+        q0 = self.Q_(0, "J")
+        q0m = self.Q_(0, "m")
+        q0less = self.Q_(0, "")
+        qpos = self.Q_(5, "J")
+        qneg = self.Q_(-5, "J")
         self.assertTrue(qpos > q0)
         self.assertTrue(qpos > 0)
         self.assertFalse(qneg > 0)
-        self.assertRaises(DimensionalityError, qpos.__gt__, q0less)
-        self.assertRaises(DimensionalityError, qpos.__gt__, q0m)
+        with self.assertRaises(DimensionalityError):
+            qpos > q0less
+        with self.assertRaises(DimensionalityError):
+            qpos > q0m
+
+    def test_gt_nan(self):
+        self.ureg.autoconvert_offset_to_baseunit = False
+        qn = self.Q_(math.nan, "J")
+        qnm = self.Q_(math.nan, "m")
+        qnless = self.Q_(math.nan, "")
+        qpos = self.Q_(5, "J")
+        self.assertFalse(qpos > qn)
+        self.assertFalse(qpos > math.nan)
+        with self.assertRaises(DimensionalityError):
+            qpos > qnless
+        with self.assertRaises(DimensionalityError):
+            qpos > qnm
 
     @helpers.requires_numpy()
-    def test_gt_zero_NP(self):
-        ureg = self.ureg
-        ureg.autoconvert_offset_to_baseunit = False
-        qpos = ureg.Quantity(5, "J")
-        qneg = ureg.Quantity(-5, "J")
+    def test_gt_zero_nan_NP(self):
+        self.ureg.autoconvert_offset_to_baseunit = False
+        qpos = self.Q_(5, "J")
+        qneg = self.Q_(-5, "J")
         aeq = np.testing.assert_array_equal
-        aeq(qpos > np.zeros(3), np.asarray([True, True, True]))
-        aeq(qneg > np.zeros(3), np.asarray([False, False, False]))
+        aeq(qpos > np.array([0, np.nan]), np.asarray([True, False]))
+        aeq(qneg > np.array([0, np.nan]), np.asarray([False, False]))
         aeq(
-            ureg.Quantity(np.arange(-1, 2), ureg.J) > np.zeros(3),
-            np.asarray([False, False, True]),
+            self.Q_(np.arange(-2, 3), "J") > np.array([np.nan, 0, 0, 0, np.nan]),
+            np.asarray([False, False, False, True, False]),
         )
-        aeq(
-            ureg.Quantity(np.arange(-1, 2), ureg.J) > np.zeros(3),
-            np.asarray([False, False, True]),
-        )
-        self.assertRaises(
-            ValueError, ureg.Quantity(np.arange(-1, 2), ureg.J).__gt__, np.zeros(4)
-        )
+        with self.assertRaises(ValueError):
+            self.Q_(np.arange(-1, 2), "J") > np.zeros(4)
 
     def test_offset_gt_zero(self):
         ureg = self.ureg


### PR DESCRIPTION
- [x] Closes #1051 
- [x] All addition, subtraction, equality and disequality operators now treat bare NaNs (not Quantities) the same way they treat bare zeros
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] ~~Documented in docs/ as appropriate~~
- [x] Added an entry to the CHANGES file
