### PR TITLE
implement quantile

### DIFF
--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -260,7 +260,10 @@ def implement_func(func_type, func_str, input_units=None, output_unit=None):
 
     # Handle functions in submodules
     func_str_split = func_str.split(".")
-    func = getattr(np, func_str_split[0])
+    func = getattr(np, func_str_split[0], None)
+    # If the function is not available, do not attempt to implement it
+    if func is None:
+        return
     for func_str_piece in func_str_split[1:]:
         func = getattr(func, func_str_piece)
 

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -675,7 +675,10 @@ def implement_consistent_units_by_argument(func_str, unit_arguments, wrap_output
     if np is None:
         return
 
-    func = getattr(np, func_str)
+    func = getattr(np, func_str, None)
+    # if NumPy does not implement it, do not implement it either
+    if func is None:
+        return
 
     @implements(func_str, "function")
     def implementation(*args, **kwargs):

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -726,6 +726,8 @@ for func_str, unit_arguments, wrap_output in [
     ("nanmax", "a", True),
     ("percentile", "a", True),
     ("nanpercentile", "a", True),
+    ("quantile", "a", True),
+    ("nanquantile", "a", True),
     ("flip", "m", True),
     ("fix", "x", True),
     ("trim_zeros", ["filt"], True),

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -190,7 +190,7 @@ class TestNumpyArrayManipulation(TestNumpyMethods):
         for func in (np.concatenate, np.stack, np.hstack, np.vstack, np.dstack):
             with self.subTest(func=func):
                 self.assertQuantityEqual(
-                    func([self.q] * 2), self.Q_(func([self.q.m] * 2), self.ureg.m),
+                    func([self.q] * 2), self.Q_(func([self.q.m] * 2), self.ureg.m)
                 )
                 # One or more of the args is a bare array full of zeros or NaNs
                 self.assertQuantityEqual(
@@ -1019,7 +1019,6 @@ class TestNumpyUnclassified(TestNumpyMethods):
     @helpers.requires_array_function_protocol()
     def test_nanquantile(self):
         self.assertQuantityEqual(np.nanquantile(self.q_nan, 0.25), self.Q_(1.5, "m"))
-
 
     @helpers.requires_array_function_protocol()
     def test_copyto(self):

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1013,6 +1013,15 @@ class TestNumpyUnclassified(TestNumpyMethods):
         self.assertQuantityEqual(np.nanpercentile(self.q_nan, 25), self.Q_(1.5, "m"))
 
     @helpers.requires_array_function_protocol()
+    def test_quantile(self):
+        self.assertQuantityEqual(np.quantile(self.q, 0.25), self.Q_(1.75, "m"))
+
+    @helpers.requires_array_function_protocol()
+    def test_nanquantile(self):
+        self.assertQuantityEqual(np.nanquantile(self.q_nan, 0.25), self.Q_(1.5, "m"))
+
+
+    @helpers.requires_array_function_protocol()
     def test_copyto(self):
         a = self.q.m
         q = copy.copy(self.q)


### PR DESCRIPTION
This implements `numpy.quantile` and `numpy.nanquantile`.

- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
