### PR TITLE
Fixed bug with to_compact

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,8 @@ Pint Changelog
   (Issue #1050, Thanks Guido Imperiale)
 - NaN is now treated the same as zero in addition, subtraction, equality, and
   disequality (Issue #1051, Thanks Guido Imperiale)
+- Fixed issue where quantities with a very large magnitude would throw an IndexError 
+  when using to_compact()
 
 
 0.11 (2020-02-19)

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -95,6 +95,7 @@ Sometimes, the magnitude of the quantity will be very large or very small.
 The method 'to_compact' can adjust the units to make the quantity more
 human-readable.
 
+
 .. doctest::
 
    >>> wavelength = 1550 * ureg.nm

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -741,7 +741,12 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         else:
             power = int(math.ceil(math.log10(abs(magnitude)) / unit_power / 3)) * 3
 
-        prefix = SI_bases[bisect.bisect_left(SI_powers, power)]
+        index = bisect.bisect_left(SI_powers, power)
+
+        if index >= len(SI_bases):
+            index = -1
+
+        prefix = SI_bases[index]
 
         new_unit_str = prefix + unit_str
         new_unit_container = q_base._units.rename(unit_str, new_unit_str)

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -190,7 +190,7 @@ class TestNumpyArrayManipulation(TestNumpyMethods):
         for func in (np.concatenate, np.stack, np.hstack, np.vstack, np.dstack):
             with self.subTest(func=func):
                 self.assertQuantityEqual(
-                    func([self.q] * 2), self.Q_(func([self.q.m] * 2), self.ureg.m),
+                    func([self.q] * 2), self.Q_(func([self.q.m] * 2), self.ureg.m)
                 )
                 # One or more of the args is a bare array full of zeros or NaNs
                 self.assertQuantityEqual(

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -608,6 +608,12 @@ class TestQuantityToCompact(QuantityTestCase):
         with self.assertWarns(RuntimeWarning):
             self.compareQuantity_compact(x, x)
 
+    def test_very_large_to_compact(self):
+        # This should not raise an IndexError
+        self.compareQuantity_compact(
+            self.Q_(10000, "yottameter"), self.Q_(10 ** 28, "meter").to_compact()
+        )
+
 
 class TestQuantityBasicMath(QuantityTestCase):
 


### PR DESCRIPTION
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Added an entry to the CHANGES file
