### PR TITLE
allow passing mixed args to interp

### DIFF
--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -120,6 +120,9 @@ def unwrap_and_wrap_consistent_units(*args):
     first arg with units, along with a wrapper to restore that unit to the output.
 
     """
+    if all(not _is_quantity(arg) for arg in args):
+        return args, lambda x: x
+
     first_input_units = _get_first_input_units(args)
     args, _ = convert_to_consistent_units(*args, pre_calc_units=first_input_units)
     return (

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -929,6 +929,17 @@ class TestNumpyUnclassified(TestNumpyMethods):
             np.interp(x, xp, fp), self.Q_([6.66667, 20.0], self.ureg.degC), rtol=1e-5
         )
 
+        x_ = np.array([1, 4])
+        xp_ = np.linspace(0, 3, 5)
+        fp_ = [0, 5, 10, 15, 20]
+
+        self.assertQuantityAlmostEqual(
+            np.interp(x_, xp_, fp), self.Q_([6.6667, 20.0], self.ureg.degC), rtol=1e-5
+        )
+        self.assertQuantityAlmostEqual(
+            np.interp(x, xp, fp_), [6.6667, 20.0], rtol=1e-5
+        )
+
     def test_comparisons(self):
         self.assertNDArrayEqual(
             self.q > 2 * self.ureg.m, np.array([[False, False], [True, True]])

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -936,9 +936,7 @@ class TestNumpyUnclassified(TestNumpyMethods):
         self.assertQuantityAlmostEqual(
             np.interp(x_, xp_, fp), self.Q_([6.6667, 20.0], self.ureg.degC), rtol=1e-5
         )
-        self.assertQuantityAlmostEqual(
-            np.interp(x, xp, fp_), [6.6667, 20.0], rtol=1e-5
-        )
+        self.assertQuantityAlmostEqual(np.interp(x, xp, fp_), [6.6667, 20.0], rtol=1e-5)
 
     def test_comparisons(self):
         self.assertNDArrayEqual(


### PR DESCRIPTION
When trying to pass something that I would consider as valid to `interp`, it fails:
```python
In [4]: x = np.arange(10) 
   ...: xi = np.arange(11, 13) 
   ...: y = np.linspace(0, 1, 10) * ureg.m 
   ...:  
   ...: np.interp(xi, x, y)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-0f23c156c96d> in <module>
      3 y = np.linspace(0, 1, 10) * ureg.m
      4 
----> 5 np.interp(xi, x, y)

<__array_function__ internals> in interp(*args, **kwargs)

.../pint/quantity.py in __array_function__(self, func, types, args, kwargs)
   1548 
   1549     def __array_function__(self, func, types, args, kwargs):
-> 1550         return numpy_wrap("function", func, args, kwargs, types)
   1551 
   1552     _wrapped_numpy_methods = ["flatten", "astype", "item"]

.../pint/numpy_func.py in numpy_wrap(func_type, func, args, kwargs, types)
    870     if name not in handled or any(is_upcast_type(t) for t in types):
    871         return NotImplemented
--> 872     return handled[name](*args, **kwargs)

.../pint/numpy_func.py in _interp(x, xp, fp, left, right, period)
    534     # Need to handle x and y units separately
    535     print("x, xp", x, xp, sep="\n -- ")
--> 536     (x, xp, period), _ = unwrap_and_wrap_consistent_units(x, xp, period)
    537     (fp, right, left), output_wrap = unwrap_and_wrap_consistent_units(fp, left, right)
    538     return output_wrap(np.interp(x, xp, fp, left=left, right=right, period=period))

.../pint/numpy_func.py in unwrap_and_wrap_consistent_units(*args)
    121 
    122     """
--> 123     first_input_units = _get_first_input_units(args)
    124     args, _ = convert_to_consistent_units(*args, pre_calc_units=first_input_units)
    125     return (

.../pint/numpy_func.py in _get_first_input_units(args, kwargs)
     68         elif _is_sequence_with_quantity_elements(arg):
     69             return next(arg_i.units for arg_i in arg if _is_quantity(arg_i))
---> 70     raise TypeError("Expected at least one Quantity; found none")
     71 
     72 

TypeError: Expected at least one Quantity; found none
```
this fixes that in `unwrap_and_wrap_consistent_units` so it affects all other calls to it. From what I saw that should not matter, but do tell me if I should move the check to `_interp` instead.

cc @jthielen

- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
