### PR TITLE
Run notebooks on docs build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 
   - PKGS="python=3.7 flake8 black isort"  # Have linters fail first and quickly
   # Pinned packages to match readthedocs CI https://readthedocs.org/projects/pint/
-  - PKGS="python=3.7 ipython matplotlib nbsphinx numpy sphinx Pygments==2.3.1 docutils==0.14 alabaster commonmark==0.8.1 recommonmark==0.5.0"
+  - PKGS="python=3.7 ipython matplotlib nbsphinx numpy pandas git+https://github.com/hgrecco/pint-pandas.git jupyter_client ipykernel graphviz xarray sparse dask[complete] sphinx Pygments==2.3.1 docutils==0.14 alabaster commonmark==0.8.1 recommonmark==0.5.0"
   - PKGS="python=3.6"
   - PKGS="python=3.7"
   - PKGS="python=3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 
   - PKGS="python=3.7 flake8 black isort"  # Have linters fail first and quickly
   # Pinned packages to match readthedocs CI https://readthedocs.org/projects/pint/
-  - PKGS="python=3.7 ipython matplotlib nbsphinx numpy pandas jupyter_client ipykernel graphviz xarray sparse dask[complete] sphinx Pygments==2.3.1 docutils==0.14 alabaster commonmark==0.8.1 recommonmark==0.5.0"
+  - PKGS="python=3.7 ipython matplotlib nbsphinx numpy pandas jupyter_client ipykernel python-graphviz graphviz xarray sparse dask[complete] sphinx Pygments==2.3.1 docutils==0.14 alabaster commonmark==0.8.1 recommonmark==0.5.0"
   - PKGS="python=3.6"
   - PKGS="python=3.7"
   - PKGS="python=3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ install:
   - if [[ $PKGS =~ flake8 ]]; then LINT=1; else LINT=0; fi
   - if [[ $PKGS =~ sphinx ]]; then DOCS=1; else DOCS=0; fi
   - if [[ $PKGS =~ matplotlib && $DOCS == 0 ]]; then pip install pytest-mpl; export TEST_OPTS="$TEST_OPTS --mpl"; fi
+  - if [[ $DOCS == 1 ]]; then pip install git+https://github.com/hgrecco/pint-pandas.git; fi
   # this is superslow but suck it up until updates to pandas are made
   # - if [[ $PANDAS == '1' ]]; then pip install numpy cython pytest pytest-cov nbval; pip install git+https://github.com/pandas-dev/pandas.git@bdb7a1603f1e0948ca0cab011987f616e7296167; python -c 'import pandas; print(pandas.__version__)'; fi
   - conda list
@@ -73,7 +74,7 @@ script:
   # - if [[ $PANDAS == '1' ]]; then pip install -e .; pytest --nbval notebooks/*; fi
   - if [[ $PANDAS == 0 && $LINT == 0 && $DOCS == 0 ]]; then python -bb -m pytest $TEST_OPTS; fi
   - if [[ $LINT == 1 ]]; then black -t py36 --check . && isort -rc -c . && flake8; fi
-  - if [[ $DOCS == 1 ]]; then pip install git+https://github.com/hgrecco/pint-pandas.git && PYTHONPATH=$PWD sphinx-build -n -j auto -b html -d build/doctrees docs build/html; fi
+  - if [[ $DOCS == 1 ]]; then PYTHONPATH=$PWD sphinx-build -n -j auto -b html -d build/doctrees docs build/html; fi
   - if [[ $LINT == 0 && $DOCS == 0 ]]; then coverage report -m; fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 
   - PKGS="python=3.7 flake8 black isort"  # Have linters fail first and quickly
   # Pinned packages to match readthedocs CI https://readthedocs.org/projects/pint/
-  - PKGS="python=3.7 ipython matplotlib nbsphinx numpy pandas git+https://github.com/hgrecco/pint-pandas.git jupyter_client ipykernel graphviz xarray sparse dask[complete] sphinx Pygments==2.3.1 docutils==0.14 alabaster commonmark==0.8.1 recommonmark==0.5.0"
+  - PKGS="python=3.7 ipython matplotlib nbsphinx numpy pandas jupyter_client ipykernel graphviz xarray sparse dask[complete] sphinx Pygments==2.3.1 docutils==0.14 alabaster commonmark==0.8.1 recommonmark==0.5.0"
   - PKGS="python=3.6"
   - PKGS="python=3.7"
   - PKGS="python=3.8"
@@ -73,7 +73,7 @@ script:
   # - if [[ $PANDAS == '1' ]]; then pip install -e .; pytest --nbval notebooks/*; fi
   - if [[ $PANDAS == 0 && $LINT == 0 && $DOCS == 0 ]]; then python -bb -m pytest $TEST_OPTS; fi
   - if [[ $LINT == 1 ]]; then black -t py36 --check . && isort -rc -c . && flake8; fi
-  - if [[ $DOCS == 1 ]]; then PYTHONPATH=$PWD sphinx-build -n -j auto -b html -d build/doctrees docs build/html; fi
+  - if [[ $DOCS == 1 ]]; then pip install git+https://github.com/hgrecco/pint-pandas.git && PYTHONPATH=$PWD sphinx-build -n -j auto -b html -d build/doctrees docs build/html; fi
   - if [[ $LINT == 0 && $DOCS == 0 ]]; then coverage report -m; fi
 
 after_success:

--- a/docs/numpy.ipynb
+++ b/docs/numpy.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,17 +45,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[3.0 4.0] meter\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "legs1 = Q_(np.asarray([3., 4.]), 'meter')\n",
     "print(legs1)"
@@ -63,17 +55,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[3.0 4.0] meter\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "legs1 = [3., 4.] * ureg.meter\n",
     "print(legs1)"
@@ -88,51 +72,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[0.003 0.004] kilometer\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(legs1.to('kilometer'))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[length]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(legs1.dimensionality)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Cannot convert from 'meter' ([length]) to 'joule' ([length] ** 2 * [mass] / [time] ** 2)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "try:\n",
     "    legs1.to('joule')\n",
@@ -149,17 +109,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[400.0 300.0] centimeter\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "legs2 = [400., 300.] * ureg.centimeter\n",
     "print(legs2)"
@@ -174,17 +126,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[5.0 5.0] meter\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "hyps = np.hypot(legs1, legs2)\n",
     "print(hyps)"
@@ -203,17 +147,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[0.6435011087932843 0.9272952180016123] radian\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "angles = np.arccos(legs2/hyps)\n",
     "print(angles)"
@@ -228,17 +164,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[36.86989764584401 53.13010235415599] degree\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(angles.to('degree'))"
    ]
@@ -253,17 +181,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Cannot convert from 'centimeter' ([length]) to 'dimensionless' (dimensionless)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "try:\n",
     "    np.arccos(legs2)\n",
@@ -290,17 +210,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['alen', 'all', 'allclose', 'amax', 'amin', 'any', 'append', 'argmax', 'argmin', 'argsort', 'around', 'atleast_1d', 'atleast_2d', 'atleast_3d', 'average', 'block', 'broadcast_to', 'clip', 'column_stack', 'compress', 'concatenate', 'copy', 'copyto', 'count_nonzero', 'cross', 'cumprod', 'cumproduct', 'cumsum', 'diagonal', 'diff', 'dot', 'dstack', 'ediff1d', 'einsum', 'empty_like', 'expand_dims', 'fix', 'flip', 'full_like', 'gradient', 'hstack', 'insert', 'interp', 'intersect1d', 'isclose', 'iscomplex', 'isin', 'isreal', 'linalg.solve', 'linspace', 'mean', 'median', 'meshgrid', 'moveaxis', 'nan_to_num', 'nanargmax', 'nanargmin', 'nancumprod', 'nancumsum', 'nanmax', 'nanmean', 'nanmedian', 'nanmin', 'nanpercentile', 'nanstd', 'nansum', 'nanvar', 'ndim', 'nonzero', 'ones_like', 'pad', 'percentile', 'ptp', 'ravel', 'reshape', 'resize', 'result_type', 'rollaxis', 'rot90', 'round_', 'searchsorted', 'shape', 'size', 'sort', 'squeeze', 'stack', 'std', 'sum', 'swapaxes', 'tile', 'transpose', 'trapz', 'trim_zeros', 'unwrap', 'var', 'vstack', 'where', 'zeros_like']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from pint.numpy_func import HANDLED_FUNCTIONS\n",
     "print(sorted(list(HANDLED_FUNCTIONS)))"
@@ -357,175 +269,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/svg+xml": [
-       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n",
-       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
-       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
-       "<!-- Generated by graphviz version 2.38.0 (20140413.2041)\n",
-       " -->\n",
-       "<!-- Title: %3 Pages: 1 -->\n",
-       "<svg width=\"576pt\" height=\"288pt\"\n",
-       " viewBox=\"0.00 0.00 576.00 288.25\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
-       "<g id=\"graph0\" class=\"graph\" transform=\"scale(0.86823 0.86823) rotate(0) translate(4 328)\">\n",
-       "<title>%3</title>\n",
-       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-328 659.419,-328 659.419,4 -4,4\"/>\n",
-       "<!-- Dask array -->\n",
-       "<g id=\"node1\" class=\"node\"><title>Dask array</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" cx=\"186.393\" cy=\"-162\" rx=\"64.189\" ry=\"18\"/>\n",
-       "<text text-anchor=\"middle\" x=\"186.393\" y=\"-158.3\" font-family=\"Courier,monospace\" font-size=\"14.00\">Dask array</text>\n",
-       "</g>\n",
-       "<!-- NumPy ndarray -->\n",
-       "<g id=\"node2\" class=\"node\"><title>NumPy ndarray</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" cx=\"362.393\" cy=\"-18\" rx=\"80.6858\" ry=\"18\"/>\n",
-       "<text text-anchor=\"middle\" x=\"362.393\" y=\"-14.3\" font-family=\"Courier,monospace\" font-size=\"14.00\">NumPy ndarray</text>\n",
-       "</g>\n",
-       "<!-- Dask array&#45;&gt;NumPy ndarray -->\n",
-       "<g id=\"edge1\" class=\"edge\"><title>Dask array&#45;&gt;NumPy ndarray</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M183.487,-143.823C181.189,-124.181 180.714,-92.1479 197.393,-72 217.389,-47.8459 248.45,-34.5744 278.253,-27.3279\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"279.293,-30.6823 288.294,-25.0944 277.773,-23.8493 279.293,-30.6823\"/>\n",
-       "</g>\n",
-       "<!-- CuPy ndarray -->\n",
-       "<g id=\"node3\" class=\"node\"><title>CuPy ndarray</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" cx=\"75.3933\" cy=\"-90\" rx=\"75.2868\" ry=\"18\"/>\n",
-       "<text text-anchor=\"middle\" x=\"75.3933\" y=\"-86.3\" font-family=\"Courier,monospace\" font-size=\"14.00\">CuPy ndarray</text>\n",
-       "</g>\n",
-       "<!-- Dask array&#45;&gt;CuPy ndarray -->\n",
-       "<g id=\"edge2\" class=\"edge\"><title>Dask array&#45;&gt;CuPy ndarray</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M161.483,-145.291C146.133,-135.611 126.244,-123.068 109.45,-112.477\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"111.316,-109.516 100.991,-107.142 107.582,-115.437 111.316,-109.516\"/>\n",
-       "</g>\n",
-       "<!-- Sparse COO -->\n",
-       "<g id=\"node4\" class=\"node\"><title>Sparse COO</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" cx=\"270.393\" cy=\"-90\" rx=\"64.189\" ry=\"18\"/>\n",
-       "<text text-anchor=\"middle\" x=\"270.393\" y=\"-86.3\" font-family=\"Courier,monospace\" font-size=\"14.00\">Sparse COO</text>\n",
-       "</g>\n",
-       "<!-- Dask array&#45;&gt;Sparse COO -->\n",
-       "<g id=\"edge3\" class=\"edge\"><title>Dask array&#45;&gt;Sparse COO</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M205.876,-144.765C216.823,-135.642 230.668,-124.105 242.723,-114.059\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"245.284,-116.48 250.726,-107.39 240.803,-111.103 245.284,-116.48\"/>\n",
-       "</g>\n",
-       "<!-- NumPy masked array -->\n",
-       "<g id=\"node5\" class=\"node\"><title>NumPy masked array</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" cx=\"497.393\" cy=\"-90\" rx=\"107.482\" ry=\"18\"/>\n",
-       "<text text-anchor=\"middle\" x=\"497.393\" y=\"-86.3\" font-family=\"Courier,monospace\" font-size=\"14.00\">NumPy masked array</text>\n",
-       "</g>\n",
-       "<!-- Dask array&#45;&gt;NumPy masked array -->\n",
-       "<g id=\"edge4\" class=\"edge\"><title>Dask array&#45;&gt;NumPy masked array</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M234.987,-150.062C286.262,-138.522 367.594,-120.215 426.124,-107.041\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"427.055,-110.419 436.043,-104.809 425.518,-103.59 427.055,-110.419\"/>\n",
-       "</g>\n",
-       "<!-- CuPy ndarray&#45;&gt;NumPy ndarray -->\n",
-       "<g id=\"edge5\" class=\"edge\"><title>CuPy ndarray&#45;&gt;NumPy ndarray</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M126.043,-76.6465C174.571,-64.8104 247.927,-46.9187 300.028,-34.211\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"300.939,-37.5915 309.825,-31.8216 299.28,-30.7909 300.939,-37.5915\"/>\n",
-       "</g>\n",
-       "<!-- Sparse COO&#45;&gt;NumPy ndarray -->\n",
-       "<g id=\"edge6\" class=\"edge\"><title>Sparse COO&#45;&gt;NumPy ndarray</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M291.731,-72.7646C303.952,-63.4665 319.469,-51.6599 332.847,-41.4806\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"335.013,-44.2305 340.852,-35.3898 330.775,-38.6596 335.013,-44.2305\"/>\n",
-       "</g>\n",
-       "<!-- NumPy masked array&#45;&gt;NumPy ndarray -->\n",
-       "<g id=\"edge7\" class=\"edge\"><title>NumPy masked array&#45;&gt;NumPy ndarray</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M466.082,-72.7646C447.034,-62.8879 422.527,-50.1806 402.122,-39.5999\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"403.558,-36.402 393.069,-34.906 400.336,-42.6163 403.558,-36.402\"/>\n",
-       "</g>\n",
-       "<!-- Jax array -->\n",
-       "<g id=\"node6\" class=\"node\"><title>Jax array</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" cx=\"583.393\" cy=\"-162\" rx=\"59.2899\" ry=\"18\"/>\n",
-       "<text text-anchor=\"middle\" x=\"583.393\" y=\"-158.3\" font-family=\"Courier,monospace\" font-size=\"14.00\">Jax array</text>\n",
-       "</g>\n",
-       "<!-- Jax array&#45;&gt;NumPy ndarray -->\n",
-       "<g id=\"edge8\" class=\"edge\"><title>Jax array&#45;&gt;NumPy ndarray</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M597.707,-144.223C612.335,-124.957 630.647,-93.2771 613.393,-72 592.658,-46.4286 512.161,-32.7163 447.843,-25.6941\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"447.982,-22.1895 437.671,-24.6237 447.25,-29.1511 447.982,-22.1895\"/>\n",
-       "</g>\n",
-       "<!-- Pint Quantity -->\n",
-       "<g id=\"node7\" class=\"node\"><title>Pint Quantity</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" cx=\"387.393\" cy=\"-234\" rx=\"80.6858\" ry=\"18\"/>\n",
-       "<text text-anchor=\"middle\" x=\"387.393\" y=\"-230.3\" font-family=\"Courier,monospace\" font-size=\"14.00\">Pint Quantity</text>\n",
-       "</g>\n",
-       "<!-- Pint Quantity&#45;&gt;Dask array -->\n",
-       "<g id=\"edge9\" class=\"edge\"><title>Pint Quantity&#45;&gt;Dask array</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M345.746,-218.496C313.407,-207.234 268.515,-191.599 234.617,-179.794\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"235.518,-176.402 224.923,-176.418 233.216,-183.013 235.518,-176.402\"/>\n",
-       "</g>\n",
-       "<!-- Pint Quantity&#45;&gt;NumPy ndarray -->\n",
-       "<g id=\"edge10\" class=\"edge\"><title>Pint Quantity&#45;&gt;NumPy ndarray</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M385.39,-215.849C381.065,-178.832 370.826,-91.1809 365.593,-46.3863\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"369.043,-45.7588 364.406,-36.2325 362.091,-46.5711 369.043,-45.7588\"/>\n",
-       "</g>\n",
-       "<!-- Pint Quantity&#45;&gt;CuPy ndarray -->\n",
-       "<g id=\"edge11\" class=\"edge\"><title>Pint Quantity&#45;&gt;CuPy ndarray</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M313.751,-226.537C243.355,-219.009 143.6,-204.386 113.393,-180 94.4685,-164.722 84.7957,-138.263 79.9628,-118.154\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"83.371,-117.354 77.8533,-108.31 76.5264,-118.821 83.371,-117.354\"/>\n",
-       "</g>\n",
-       "<!-- Pint Quantity&#45;&gt;Sparse COO -->\n",
-       "<g id=\"edge12\" class=\"edge\"><title>Pint Quantity&#45;&gt;Sparse COO</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M373.512,-216.153C353.018,-191.279 314.535,-144.574 290.817,-115.788\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"293.316,-113.317 284.256,-107.825 287.914,-117.768 293.316,-113.317\"/>\n",
-       "</g>\n",
-       "<!-- Pint Quantity&#45;&gt;NumPy masked array -->\n",
-       "<g id=\"edge13\" class=\"edge\"><title>Pint Quantity&#45;&gt;NumPy masked array</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M400.444,-216.153C419.609,-191.413 455.504,-145.075 477.831,-116.253\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"480.66,-118.317 484.017,-108.268 475.126,-114.03 480.66,-118.317\"/>\n",
-       "</g>\n",
-       "<!-- xarray Dataset/DataArray/Variable -->\n",
-       "<g id=\"node8\" class=\"node\"><title>xarray Dataset/DataArray/Variable</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" cx=\"387.393\" cy=\"-306\" rx=\"187.667\" ry=\"18\"/>\n",
-       "<text text-anchor=\"middle\" x=\"387.393\" y=\"-302.3\" font-family=\"Courier,monospace\" font-size=\"14.00\">xarray Dataset/DataArray/Variable</text>\n",
-       "</g>\n",
-       "<!-- xarray Dataset/DataArray/Variable&#45;&gt;Dask array -->\n",
-       "<g id=\"edge14\" class=\"edge\"><title>xarray Dataset/DataArray/Variable&#45;&gt;Dask array</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M335.932,-288.68C312.798,-279.919 285.922,-267.664 264.393,-252 239.936,-234.205 217.813,-207.445 203.428,-187.915\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"206.25,-185.844 197.568,-179.772 200.569,-189.933 206.25,-185.844\"/>\n",
-       "</g>\n",
-       "<!-- xarray Dataset/DataArray/Variable&#45;&gt;NumPy ndarray -->\n",
-       "<g id=\"edge17\" class=\"edge\"><title>xarray Dataset/DataArray/Variable&#45;&gt;NumPy ndarray</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M445.846,-288.873C475.49,-279.738 511.635,-267.11 542.393,-252 594.504,-226.401 623.889,-231.131 651.393,-180 658.973,-165.909 653.554,-159.853 651.393,-144 646.908,-111.093 655.757,-94.57 631.393,-72 604.934,-47.4892 515.533,-33.4248 446.983,-26.0284\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"447.341,-22.5468 437.031,-24.985 446.611,-29.5086 447.341,-22.5468\"/>\n",
-       "</g>\n",
-       "<!-- xarray Dataset/DataArray/Variable&#45;&gt;CuPy ndarray -->\n",
-       "<g id=\"edge15\" class=\"edge\"><title>xarray Dataset/DataArray/Variable&#45;&gt;CuPy ndarray</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M281.369,-291.128C212.822,-276.089 128.448,-244.835 84.3933,-180 72.1516,-161.984 70.6221,-136.994 71.7416,-118.08\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"75.2375,-118.278 72.6151,-108.013 68.2637,-117.673 75.2375,-118.278\"/>\n",
-       "</g>\n",
-       "<!-- xarray Dataset/DataArray/Variable&#45;&gt;Sparse COO -->\n",
-       "<g id=\"edge16\" class=\"edge\"><title>xarray Dataset/DataArray/Variable&#45;&gt;Sparse COO</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M342.591,-288.285C325.913,-279.869 308.387,-267.987 297.393,-252 269.717,-211.751 267.068,-152.724 268.293,-118.445\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"271.799,-118.402 268.799,-108.241 264.808,-118.055 271.799,-118.402\"/>\n",
-       "</g>\n",
-       "<!-- xarray Dataset/DataArray/Variable&#45;&gt;NumPy masked array -->\n",
-       "<g id=\"edge18\" class=\"edge\"><title>xarray Dataset/DataArray/Variable&#45;&gt;NumPy masked array</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M432.544,-288.519C449.273,-280.137 466.743,-268.218 477.393,-252 504.041,-211.424 503.873,-152.51 500.918,-118.34\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"504.378,-117.768 499.891,-108.17 497.414,-118.472 504.378,-117.768\"/>\n",
-       "</g>\n",
-       "<!-- xarray Dataset/DataArray/Variable&#45;&gt;Jax array -->\n",
-       "<g id=\"edge20\" class=\"edge\"><title>xarray Dataset/DataArray/Variable&#45;&gt;Jax array</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M440.005,-288.657C462.977,-279.982 489.402,-267.804 510.393,-252 533.791,-234.384 554.324,-207.77 567.604,-188.233\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"570.577,-190.082 573.179,-179.812 564.74,-186.218 570.577,-190.082\"/>\n",
-       "</g>\n",
-       "<!-- xarray Dataset/DataArray/Variable&#45;&gt;Pint Quantity -->\n",
-       "<g id=\"edge19\" class=\"edge\"><title>xarray Dataset/DataArray/Variable&#45;&gt;Pint Quantity</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M387.393,-287.697C387.393,-279.983 387.393,-270.712 387.393,-262.112\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"390.893,-262.104 387.393,-252.104 383.893,-262.104 390.893,-262.104\"/>\n",
-       "</g>\n",
-       "</g>\n",
-       "</svg>\n"
-      ],
-      "text/plain": [
-       "<graphviz.dot.Digraph at 0x7f68cc084208>"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from graphviz import Digraph\n",
     "\n",
@@ -564,44 +310,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<xarray.DataArray 'air' (lat: 25, lon: 53)>\n",
-      "<Quantity([[241.2     242.5     243.5     ... 232.79999 235.5     238.59999]\n",
-      " [243.79999 244.5     244.7     ... 232.79999 235.29999 239.29999]\n",
-      " [250.      249.79999 248.89    ... 233.2     236.39    241.7    ]\n",
-      " ...\n",
-      " [296.6     296.19998 296.4     ... 295.4     295.1     294.69998]\n",
-      " [295.9     296.19998 296.79    ... 295.9     295.9     295.19998]\n",
-      " [296.29    296.79    297.1     ... 296.9     296.79    296.6    ]], 'kelvin')>\n",
-      "Coordinates:\n",
-      "  * lat      (lat) float32 75.0 72.5 70.0 67.5 65.0 ... 25.0 22.5 20.0 17.5 15.0\n",
-      "  * lon      (lon) float32 200.0 202.5 205.0 207.5 ... 322.5 325.0 327.5 330.0\n",
-      "    time     datetime64[ns] 2013-01-01\n",
-      "Attributes:\n",
-      "    long_name:     4xDaily Air temperature at sigma level 995\n",
-      "    precision:     2\n",
-      "    GRIB_id:       11\n",
-      "    GRIB_name:     TMP\n",
-      "    var_desc:      Air temperature\n",
-      "    dataset:       NMC Reanalysis\n",
-      "    level_desc:    Surface\n",
-      "    statistic:     Individual Obs\n",
-      "    parent_stat:   Other\n",
-      "    actual_range:  [185.16 322.1 ]\n",
-      "\n",
-      "<xarray.DataArray 'air' ()>\n",
-      "<Quantity(302.6000061035156, 'kelvin')>\n",
-      "Coordinates:\n",
-      "    time     datetime64[ns] 2013-01-01\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import xarray as xr\n",
     "\n",
@@ -625,19 +336,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<COO: shape=(100, 100, 100), dtype=float64, nnz=99598, fill_value=0.0> meter\n",
-      "\n",
-      "0.09462606529121113 meter\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from sparse import COO\n",
     "\n",
@@ -663,22 +364,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<Quantity([2 -- 5 --], 'meter')>\n",
-      "\n",
-      "masked_array(data=[<Quantity(2, 'meter')>, --, <Quantity(5, 'meter')>, --],\n",
-      "             mask=[False,  True, False,  True],\n",
-      "       fill_value='?',\n",
-      "            dtype=object)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "m = np.ma.masked_array([2, 3, 5, 7], mask=[False, True, False, True])\n",
     "\n",
@@ -701,28 +389,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<xarray.DataArray 'test' (z: 100, y: 100, x: 100)>\n",
-      "<Quantity(dask.array<COO, shape=(100, 100, 100), dtype=float64, chunksize=(100, 1, 1), chunktype=sparse.COO>, 'meter')>\n",
-      "Coordinates:\n",
-      "  * z        (z) int64 0 1 2 3 4 5 6 7 8 9 10 ... 90 91 92 93 94 95 96 97 98 99\n",
-      "  * y        (y) int64 -50 -49 -48 -47 -46 -45 -44 -43 ... 43 44 45 46 47 48 49\n",
-      "  * x        (x) float64 -20.0 -18.5 -17.0 -15.5 ... 124.0 125.5 127.0 128.5\n",
-      "\n",
-      "<xarray.DataArray 'test' ()>\n",
-      "<Quantity(dask.array<mean_agg-aggregate, shape=(), dtype=float64, chunksize=(), chunktype=numpy.ndarray>, 'meter')>\n",
-      "Coordinates:\n",
-      "    y        int64 -46\n",
-      "    x        float64 125.5\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import dask.array as da\n",
     "\n",

--- a/docs/pint-pandas.ipynb
+++ b/docs/pint-pandas.ipynb
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,72 +63,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>torque</th>\n",
-       "      <th>angular_velocity</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>3</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  torque angular_velocity\n",
-       "0      1                1\n",
-       "1      2                2\n",
-       "2      2                2\n",
-       "3      3                3"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = pd.DataFrame({\n",
     "    \"torque\": pd.Series([1, 2, 2, 3], dtype=\"pint[lbf ft]\"),\n",
@@ -146,77 +83,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>torque</th>\n",
-       "      <th>angular_velocity</th>\n",
-       "      <th>power</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>3</td>\n",
-       "      <td>3</td>\n",
-       "      <td>9</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  torque angular_velocity power\n",
-       "0      1                1     1\n",
-       "1      2                2     4\n",
-       "2      2                2     4\n",
-       "3      3                3     9"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df['power'] = df['torque'] * df['angular_velocity']\n",
     "df"
@@ -231,23 +100,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "torque                                       pint[foot * force_pound]\n",
-       "angular_velocity                         pint[revolutions_per_minute]\n",
-       "power               pint[foot * force_pound * revolutions_per_minute]\n",
-       "dtype: object"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df.dtypes"
    ]
@@ -261,24 +116,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0    1\n",
-       "1    4\n",
-       "2    4\n",
-       "3    9\n",
-       "Name: power, dtype: pint[foot * force_pound * revolutions_per_minute]"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df.power"
    ]
@@ -292,24 +132,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "PintArray([1 foot * force_pound * revolutions_per_minute,\n",
-       "           4 foot * force_pound * revolutions_per_minute,\n",
-       "           4 foot * force_pound * revolutions_per_minute,\n",
-       "           9 foot * force_pound * revolutions_per_minute],\n",
-       "          dtype='pint[foot * force_pound * revolutions_per_minute]')"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df.power.values"
    ]
@@ -323,26 +148,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\\[\\begin{pmatrix}1 & 4 & 4 & 9\\end{pmatrix} foot force_pound revolutions_per_minute\\]"
-      ],
-      "text/latex": [
-       "$\\begin{pmatrix}1 & 4 & 4 & 9\\end{pmatrix}\\ \\mathrm{foot} \\cdot \\mathrm{force_pound} \\cdot \\mathrm{revolutions_per_minute}$"
-      ],
-      "text/plain": [
-       "array([1, 4, 4, 9]) <Unit('foot * force_pound * revolutions_per_minute')>"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df.power.values.quantity"
    ]
@@ -356,48 +164,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "foot force_pound revolutions_per_minute"
-      ],
-      "text/latex": [
-       "$\\mathrm{foot} \\cdot \\mathrm{force_pound} \\cdot \\mathrm{revolutions_per_minute}$"
-      ],
-      "text/plain": [
-       "<Unit('foot * force_pound * revolutions_per_minute')>"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df.power.pint.units"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "PintArray([0.00014198092353610376 kilowatt, 0.000567923694144415 kilowatt,\n",
-       "           0.000567923694144415 kilowatt, 0.0012778283118249339 kilowatt],\n",
-       "          dtype='pint[kilowatt]')"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df.power.pint.to(\"kW\").values"
    ]
@@ -413,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -431,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,102 +231,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead tr th {\n",
-       "        text-align: left;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th></th>\n",
-       "      <th>speed</th>\n",
-       "      <th>mech power</th>\n",
-       "      <th>torque</th>\n",
-       "      <th>rail pressure</th>\n",
-       "      <th>fuel flow rate</th>\n",
-       "      <th>fluid power</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th></th>\n",
-       "      <th>rpm</th>\n",
-       "      <th>kW</th>\n",
-       "      <th>N m</th>\n",
-       "      <th>bar</th>\n",
-       "      <th>l/min</th>\n",
-       "      <th>kW</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1100.0</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>100000000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>1200.0</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>1200.0</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "    speed mech power torque rail pressure fuel flow rate fluid power\n",
-       "      rpm         kW    N m           bar          l/min          kW\n",
-       "0  1000.0        NaN   10.0        1000.0           10.0         NaN\n",
-       "1  1100.0        NaN   10.0   100000000.0           10.0         NaN\n",
-       "2  1200.0        NaN   10.0        1000.0           10.0         NaN\n",
-       "3  1200.0        NaN   10.0        1000.0           10.0         NaN"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = pd.read_csv(io.StringIO(test_data), header=[0, 1])\n",
     "# df = pd.read_csv(\"/path/to/test_data.csv\", header=[0, 1])\n",
@@ -564,118 +249,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "speed           rpm      float64\n",
-       "mech power      kW       float64\n",
-       "torque          N m      float64\n",
-       "rail pressure   bar      float64\n",
-       "fuel flow rate  l/min    float64\n",
-       "fluid power     kW       float64\n",
-       "dtype: object"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df.dtypes"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>speed</th>\n",
-       "      <th>mech power</th>\n",
-       "      <th>torque</th>\n",
-       "      <th>rail pressure</th>\n",
-       "      <th>fuel flow rate</th>\n",
-       "      <th>fluid power</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>nan</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>nan</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1100.0</td>\n",
-       "      <td>nan</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>100000000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>nan</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>1200.0</td>\n",
-       "      <td>nan</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>nan</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>1200.0</td>\n",
-       "      <td>nan</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>nan</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "    speed mech power torque rail pressure fuel flow rate fluid power\n",
-       "0  1000.0        nan   10.0        1000.0           10.0         nan\n",
-       "1  1100.0        nan   10.0   100000000.0           10.0         nan\n",
-       "2  1200.0        nan   10.0        1000.0           10.0         nan\n",
-       "3  1200.0        nan   10.0        1000.0           10.0         nan"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df_ = df.pint.quantify(level=-1)\n",
     "df_"
@@ -690,208 +275,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0    10000.0\n",
-       "1    11000.0\n",
-       "2    12000.0\n",
-       "3    12000.0\n",
-       "dtype: pint[meter * newton * revolutions_per_minute]"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df_.speed * df_.torque"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>speed</th>\n",
-       "      <th>mech power</th>\n",
-       "      <th>torque</th>\n",
-       "      <th>rail pressure</th>\n",
-       "      <th>fuel flow rate</th>\n",
-       "      <th>fluid power</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>nan</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>nan</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1100.0</td>\n",
-       "      <td>nan</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>100000000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>nan</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>1200.0</td>\n",
-       "      <td>nan</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>nan</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>1200.0</td>\n",
-       "      <td>nan</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>nan</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "    speed mech power torque rail pressure fuel flow rate fluid power\n",
-       "0  1000.0        nan   10.0        1000.0           10.0         nan\n",
-       "1  1100.0        nan   10.0   100000000.0           10.0         nan\n",
-       "2  1200.0        nan   10.0        1000.0           10.0         nan\n",
-       "3  1200.0        nan   10.0        1000.0           10.0         nan"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df_"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>speed</th>\n",
-       "      <th>mech power</th>\n",
-       "      <th>torque</th>\n",
-       "      <th>rail pressure</th>\n",
-       "      <th>fuel flow rate</th>\n",
-       "      <th>fluid power</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>10000.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1100.0</td>\n",
-       "      <td>11000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>100000000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000000000.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>1200.0</td>\n",
-       "      <td>12000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>10000.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>1200.0</td>\n",
-       "      <td>12000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>10000.0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "    speed mech power torque rail pressure fuel flow rate   fluid power\n",
-       "0  1000.0    10000.0   10.0        1000.0           10.0       10000.0\n",
-       "1  1100.0    11000.0   10.0   100000000.0           10.0  1000000000.0\n",
-       "2  1200.0    12000.0   10.0        1000.0           10.0       10000.0\n",
-       "3  1200.0    12000.0   10.0        1000.0           10.0       10000.0"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df_['mech power'] = df_.speed * df_.torque\n",
     "df_['fluid power'] = df_['fuel flow rate'] * df_['rail pressure']\n",
@@ -907,109 +311,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead tr th {\n",
-       "        text-align: left;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th></th>\n",
-       "      <th>speed</th>\n",
-       "      <th>mech power</th>\n",
-       "      <th>torque</th>\n",
-       "      <th>rail pressure</th>\n",
-       "      <th>fuel flow rate</th>\n",
-       "      <th>fluid power</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>unit</th>\n",
-       "      <th>revolutions_per_minute</th>\n",
-       "      <th>meter * newton * revolutions_per_minute</th>\n",
-       "      <th>meter * newton</th>\n",
-       "      <th>bar</th>\n",
-       "      <th>liter / minute</th>\n",
-       "      <th>bar * liter / minute</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1.000000e+04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1100.0</td>\n",
-       "      <td>11000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>100000000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1.000000e+09</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>1200.0</td>\n",
-       "      <td>12000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1.000000e+04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>1200.0</td>\n",
-       "      <td>12000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1.000000e+04</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                      speed                              mech power  \\\n",
-       "unit revolutions_per_minute meter * newton * revolutions_per_minute   \n",
-       "0                    1000.0                                 10000.0   \n",
-       "1                    1100.0                                 11000.0   \n",
-       "2                    1200.0                                 12000.0   \n",
-       "3                    1200.0                                 12000.0   \n",
-       "\n",
-       "             torque rail pressure fuel flow rate          fluid power  \n",
-       "unit meter * newton           bar liter / minute bar * liter / minute  \n",
-       "0              10.0        1000.0           10.0         1.000000e+04  \n",
-       "1              10.0   100000000.0           10.0         1.000000e+09  \n",
-       "2              10.0        1000.0           10.0         1.000000e+04  \n",
-       "3              10.0        1000.0           10.0         1.000000e+04  "
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df_.pint.dequantify()"
    ]
@@ -1023,109 +327,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead tr th {\n",
-       "        text-align: left;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th></th>\n",
-       "      <th>speed</th>\n",
-       "      <th>mech power</th>\n",
-       "      <th>torque</th>\n",
-       "      <th>rail pressure</th>\n",
-       "      <th>fuel flow rate</th>\n",
-       "      <th>fluid power</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>unit</th>\n",
-       "      <th>revolutions_per_minute</th>\n",
-       "      <th>kilowatt</th>\n",
-       "      <th>meter * newton</th>\n",
-       "      <th>bar</th>\n",
-       "      <th>liter / minute</th>\n",
-       "      <th>kilowatt</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>1.047198</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1.666667e+01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1100.0</td>\n",
-       "      <td>1.151917</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>100000000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1.666667e+06</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>1200.0</td>\n",
-       "      <td>1.256637</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1.666667e+01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>1200.0</td>\n",
-       "      <td>1.256637</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1.666667e+01</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                      speed mech power         torque rail pressure  \\\n",
-       "unit revolutions_per_minute   kilowatt meter * newton           bar   \n",
-       "0                    1000.0   1.047198           10.0        1000.0   \n",
-       "1                    1100.0   1.151917           10.0   100000000.0   \n",
-       "2                    1200.0   1.256637           10.0        1000.0   \n",
-       "3                    1200.0   1.256637           10.0        1000.0   \n",
-       "\n",
-       "     fuel flow rate   fluid power  \n",
-       "unit liter / minute      kilowatt  \n",
-       "0              10.0  1.666667e+01  \n",
-       "1              10.0  1.666667e+06  \n",
-       "2              10.0  1.666667e+01  \n",
-       "3              10.0  1.666667e+01  "
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df_['fluid power'] = df_['fluid power'].pint.to(\"kW\")\n",
     "df_['mech power'] = df_['mech power'].pint.to(\"kW\")\n",
@@ -1141,102 +345,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead tr th {\n",
-       "        text-align: left;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th></th>\n",
-       "      <th>speed</th>\n",
-       "      <th>mech power</th>\n",
-       "      <th>torque</th>\n",
-       "      <th>rail pressure</th>\n",
-       "      <th>fuel flow rate</th>\n",
-       "      <th>fluid power</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>unit</th>\n",
-       "      <th>rpm</th>\n",
-       "      <th>kW</th>\n",
-       "      <th>N·m</th>\n",
-       "      <th>bar</th>\n",
-       "      <th>l/min</th>\n",
-       "      <th>kW</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>1.047198</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1.666667e+01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1100.0</td>\n",
-       "      <td>1.151917</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>100000000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1.666667e+06</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>1200.0</td>\n",
-       "      <td>1.256637</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1.666667e+01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>1200.0</td>\n",
-       "      <td>1.256637</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1000.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1.666667e+01</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "       speed mech power torque rail pressure fuel flow rate   fluid power\n",
-       "unit     rpm         kW    N·m           bar          l/min            kW\n",
-       "0     1000.0   1.047198   10.0        1000.0           10.0  1.666667e+01\n",
-       "1     1100.0   1.151917   10.0   100000000.0           10.0  1.666667e+06\n",
-       "2     1200.0   1.256637   10.0        1000.0           10.0  1.666667e+01\n",
-       "3     1200.0   1.256637   10.0        1000.0           10.0  1.666667e+01"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pintpandas.PintType.ureg.default_format = \"~P\"\n",
     "df_.pint.dequantify()"
@@ -1251,109 +362,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead tr th {\n",
-       "        text-align: left;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th></th>\n",
-       "      <th>speed</th>\n",
-       "      <th>mech power</th>\n",
-       "      <th>torque</th>\n",
-       "      <th>rail pressure</th>\n",
-       "      <th>fuel flow rate</th>\n",
-       "      <th>fluid power</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>unit</th>\n",
-       "      <th>rad/s</th>\n",
-       "      <th>kg·m²/s³</th>\n",
-       "      <th>kg·m²/s²</th>\n",
-       "      <th>kg/m/s²</th>\n",
-       "      <th>m³/s</th>\n",
-       "      <th>kg·m²/s³</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>104.719755</td>\n",
-       "      <td>1047.197551</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1.000000e+08</td>\n",
-       "      <td>0.000167</td>\n",
-       "      <td>1.666667e+04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>115.191731</td>\n",
-       "      <td>1151.917306</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1.000000e+13</td>\n",
-       "      <td>0.000167</td>\n",
-       "      <td>1.666667e+09</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>125.663706</td>\n",
-       "      <td>1256.637061</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1.000000e+08</td>\n",
-       "      <td>0.000167</td>\n",
-       "      <td>1.666667e+04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>125.663706</td>\n",
-       "      <td>1256.637061</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1.000000e+08</td>\n",
-       "      <td>0.000167</td>\n",
-       "      <td>1.666667e+04</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "           speed   mech power   torque rail pressure fuel flow rate  \\\n",
-       "unit       rad/s     kg·m²/s³ kg·m²/s²       kg/m/s²           m³/s   \n",
-       "0     104.719755  1047.197551     10.0  1.000000e+08       0.000167   \n",
-       "1     115.191731  1151.917306     10.0  1.000000e+13       0.000167   \n",
-       "2     125.663706  1256.637061     10.0  1.000000e+08       0.000167   \n",
-       "3     125.663706  1256.637061     10.0  1.000000e+08       0.000167   \n",
-       "\n",
-       "       fluid power  \n",
-       "unit      kg·m²/s³  \n",
-       "0     1.666667e+04  \n",
-       "1     1.666667e+09  \n",
-       "2     1.666667e+04  \n",
-       "3     1.666667e+04  "
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df_.pint.to_base_units().pint.dequantify()"
    ]
@@ -1370,7 +381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1387,7 +398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1403,7 +414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1420,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1438,69 +449,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>length</th>\n",
-       "      <th>width</th>\n",
-       "      <th>distance</th>\n",
-       "      <th>height</th>\n",
-       "      <th>depth</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>3</td>\n",
-       "      <td>3</td>\n",
-       "      <td>3</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  length width distance height depth\n",
-       "0      1     2        2      2     2\n",
-       "1      2     3        3      3     3"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = pd.DataFrame({\n",
     "        \"length\" : pd.Series([1,2], dtype=\"pint[m]\"),\n",
@@ -1514,26 +465,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "meter"
-      ],
-      "text/latex": [
-       "$\\mathrm{meter}$"
-      ],
-      "text/plain": [
-       "<Unit('meter')>"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df.length.values.units"
    ]
@@ -1556,7 +490,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/docs/pint-pandas.ipynb
+++ b/docs/pint-pandas.ipynb
@@ -41,7 +41,7 @@
    "source": [
     "This example will show the simplist way to use pandas with pint and the underlying objects. It's slightly fiddly as you are not reading from a file. A more normal use case is given in Reading a csv.\n",
     "\n",
-    "First some imports"
+    "First some imports (you don't need to import `pintpandas` for this to work)"
    ]
   },
   {
@@ -197,6 +197,7 @@
    "source": [
     "import pandas as pd \n",
     "import pint\n",
+    "import pintpandas\n",
     "import io"
    ]
   },
@@ -386,7 +387,8 @@
    "outputs": [],
    "source": [
     "import pandas as pd \n",
-    "import pint"
+    "import pint\n",
+    "import pintpandas"
    ]
   },
   {

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -10,4 +10,4 @@ ipykernel
 graphviz
 xarray
 sparse
-dask
+dask[complete]

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -7,3 +7,4 @@ pandas
 git+https://github.com/hgrecco/pint-pandas.git
 jupyter_client
 ipykernel
+graphviz

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -8,3 +8,6 @@ git+https://github.com/hgrecco/pint-pandas.git
 jupyter_client
 ipykernel
 graphviz
+xarray
+sparse
+dask

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -3,3 +3,6 @@ matplotlib
 nbsphinx
 numpy
 pytest
+pandas
+pint-pandas
+jupyter_client

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -4,5 +4,5 @@ nbsphinx
 numpy
 pytest
 pandas
-pint-pandas
+git+https://github.com/hgrecco/pint-pandas.git
 jupyter_client

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -6,3 +6,4 @@ pytest
 pandas
 git+https://github.com/hgrecco/pint-pandas.git
 jupyter_client
+ipykernel

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -11,3 +11,4 @@ graphviz
 xarray
 sparse
 dask[complete]
+setuptools>=41.2


### PR DESCRIPTION
As noted in #1044, the notebooks (`pint-pandas.ipynb` and `numpy.ipynb`) were static, so they would have needed manual reruns. This strips the cell output and updates `requirements_docs.txt` so `nbsphinx` can run the notebook when the documentation is built. I checked it with my own RTD instance to make sure this update does not break building the docs.

Note that since `pint-pandas` has never been released, it is installed from the github repository.

- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
