### PR TITLE
Make 'Lx' safe for use with uncertainties

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,11 @@ Pint Changelog
   when using to_compact()
 - Fixed crash when a Unit with prefix is declared for the first time while a Context
   containing unit redefinitions is active (Issue #1062, Thanks Guido Imperiale)
+- New implementation of 'Lx' String Format Type Option
+  The old implementation treated 'Lx' as 'S' as produced by 'uncertainties'
+  package, but that is not fully compatible with SIunitx. The new code protects
+  SIunitx by fixing what unceratinties produces.
+  (Issue #814)
 
 
 0.11 (2020-02-19)

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -389,7 +389,7 @@ The same is true for latex (`L`) and HTML (`H`) specs.
 The formatting specs (ie 'L', 'H', 'P') can be used with Python string 'formatting
 syntax'_ for custom float representations. For example, scientific notation:
 
-..doctest::
+.. doctest::
    >>> 'Scientific notation: {:.3e~L}'.format(accel)
    'Scientific notation: 1.300\\times 10^{0}\\ \\frac{\\mathrm{m}}{\\mathrm{s}^{2}}'
 
@@ -400,7 +400,10 @@ Pint also supports the LaTeX siunitx package:
    >>> accel = 1.3 * ureg['meter/second**2']
    >>> # siunitx Latex print
    >>> print('The siunitx representation is {:Lx}'.format(accel))
-   The siunitx representation is \SI[]{1.3}{\meter\per\second\squared}
+   The siunitx representation is \SI{1.3}{\meter\per\second\squared}
+   >>> accel = accel.plus_minus(0.2)
+   >>> print('The siunitx representation is {:Lx}'.format(accel))
+   The siunitx representation is \SI{1.3 +- 0.2}{\meter\per\second\squared}
 
 Additionally, you can specify a default format specification:
 

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -89,7 +89,7 @@ _FORMATS = {
         "power_fmt": "{}^[{}]",
         "parentheses_fmt": r"\left({}\right)",
     },
-    "Lx": {"siopts": "", "pm_fmt": " +- ", },  # Latex format.
+    "Lx": {"siopts": "", "pm_fmt": " +- "},  # Latex format with SIunitx.
     "H": {  # HTML format.
         "as_ratio": True,
         "single_denominator": True,

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -89,7 +89,7 @@ _FORMATS = {
         "power_fmt": "{}^[{}]",
         "parentheses_fmt": r"\left({}\right)",
     },
-    "Lx": {"siopts": "", "pm_fmt": " +- ",},  # Latex format.
+    "Lx": {"siopts": "", "pm_fmt": " +- ", },  # Latex format.
     "H": {  # HTML format.
         "as_ratio": True,
         "single_denominator": True,

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -89,6 +89,10 @@ _FORMATS = {
         "power_fmt": "{}^[{}]",
         "parentheses_fmt": r"\left({}\right)",
     },
+    "Lx": {  # Latex format.
+        "siopts": "separate-uncertainty=true",
+        "pm_fmt": " +- ",
+    },
     "H": {  # HTML format.
         "as_ratio": True,
         "single_denominator": True,

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -89,10 +89,7 @@ _FORMATS = {
         "power_fmt": "{}^[{}]",
         "parentheses_fmt": r"\left({}\right)",
     },
-    "Lx": {  # Latex format.
-        "siopts": "",
-        "pm_fmt": " +- ",
-    },
+    "Lx": {"siopts": "", "pm_fmt": " +- ",},  # Latex format.
     "H": {  # HTML format.
         "as_ratio": True,
         "single_denominator": True,

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -90,7 +90,7 @@ _FORMATS = {
         "parentheses_fmt": r"\left({}\right)",
     },
     "Lx": {  # Latex format.
-        "siopts": "separate-uncertainty=true",
+        "siopts": "",
         "pm_fmt": " +- ",
     },
     "H": {  # HTML format.

--- a/pint/measurement.py
+++ b/pint/measurement.py
@@ -104,6 +104,8 @@ class Measurement(Quantity):
             # get SIunitx options
             # TODO: allow user to set this value, somehow
             opts = _FORMATS["Lx"]["siopts"]
+            if opts != '' :
+                opts = r'[' + opts +  r']'
             # SI requires space between "+-" (or "\pm") and the nominal value
             # and uncertainty, and doesn't accept "+/-", so this setting
             # selects the desired replacement.
@@ -113,7 +115,7 @@ class Measurement(Quantity):
             # scientific notation ('e' or 'E' and somtimes 'g' or 'G').
             mstr = mstr.replace('(','').replace(')',' ')
             ustr = siunitx_format_unit(self.units)
-            return r"\SI[%s]{%s}{%s}" % (opts, mstr, ustr)
+            return r"\SI%s{%s}{%s}" % (opts, mstr, ustr)
 
         # standard cases
         if "L" in spec:

--- a/pint/measurement.py
+++ b/pint/measurement.py
@@ -95,25 +95,25 @@ class Measurement(Quantity):
             # TODO: add support for extracting options
             #
             # Get rid of this code, we'll deal with it here
-            spec = spec.replace("Lx", '')
+            spec = spec.replace("Lx", "")
             # The most compatible format from uncertainties is the default format,
             # but even this requires fixups.
             # For one, SIUnitx does not except some formats that unc does, like 'P',
             # and 'S' is broken as stated, so...
-            spec = spec.replace("S",'').replace("P",'')
+            spec = spec.replace("S", "").replace("P", "")
             # get SIunitx options
             # TODO: allow user to set this value, somehow
             opts = _FORMATS["Lx"]["siopts"]
-            if opts != '' :
-                opts = r'[' + opts +  r']'
+            if opts != "":
+                opts = r"[" + opts + r"]"
             # SI requires space between "+-" (or "\pm") and the nominal value
             # and uncertainty, and doesn't accept "+/-", so this setting
             # selects the desired replacement.
             pm_fmt = _FORMATS["Lx"]["pm_fmt"]
-            mstr = format(self.magnitude, spec).replace(r"+/-",pm_fmt)
+            mstr = format(self.magnitude, spec).replace(r"+/-", pm_fmt)
             # Also, SIunitx doesn't accept parentheses, which uncs uses with
             # scientific notation ('e' or 'E' and somtimes 'g' or 'G').
-            mstr = mstr.replace('(','').replace(')',' ')
+            mstr = mstr.replace("(", "").replace(")", " ")
             ustr = siunitx_format_unit(self.units)
             return r"\SI%s{%s}{%s}" % (opts, mstr, ustr)
 

--- a/pint/measurement.py
+++ b/pint/measurement.py
@@ -89,12 +89,29 @@ class Measurement(Quantity):
         if "Lx" in spec:  # the LaTeX siunitx code
             # the uncertainties module supports formatting
             # numbers in value(unc) notation (i.e. 1.23(45) instead of 1.23 +/- 0.45),
-            # which siunitx actually accepts as input. we just need to give the 'S'
-            # formatting option for the uncertainties module.
-            spec = spec.replace("Lx", "S")
-            # todo: add support for extracting options
-            opts = "separate-uncertainty=true"
-            mstr = format(self.magnitude, spec)
+            # using type code 'S', which siunitx actually accepts as input.
+            # However, the implimentation is incompatible with siunitx.
+            # Uncertainties will do 9.1(1.1), which is invalid, should be 9.1(11).
+            # TODO: add support for extracting options
+            #
+            # Get rid of this code, we'll deal with it here
+            spec = spec.replace("Lx", '')
+            # The most compatible format from uncertainties is the default format,
+            # but even this requires fixups.
+            # For one, SIUnitx does not except some formats that unc does, like 'P',
+            # and 'S' is broken as stated, so...
+            spec = spec.replace("S",'').replace("P",'')
+            # get SIunitx options
+            # TODO: allow user to set this value, somehow
+            opts = _FORMATS["Lx"]["siopts"]
+            # SI requires space between "+-" (or "\pm") and the nominal value
+            # and uncertainty, and doesn't accept "+/-", so this setting
+            # selects the desired replacement.
+            pm_fmt = _FORMATS["Lx"]["pm_fmt"]
+            mstr = format(self.magnitude, spec).replace(r"+/-",pm_fmt)
+            # Also, SIunitx doesn't accept parentheses, which uncs uses with
+            # scientific notation ('e' or 'E' and somtimes 'g' or 'G').
+            mstr = mstr.replace('(','').replace(')',' ')
             ustr = siunitx_format_unit(self.units)
             return r"\SI[%s]{%s}{%s}" % (opts, mstr, ustr)
 

--- a/pint/testsuite/test_measurement.py
+++ b/pint/testsuite/test_measurement.py
@@ -50,13 +50,13 @@ class TestMeasurement(QuantityTestCase):
             ("{:L}", r"\left(4.00 \pm 0.10\right)\ \mathrm{second}^{2}"),
             ("{:H}", r"\[(4.00 &plusmn; 0.10)\ second^2\]"),
             ("{:C}", "(4.00+/-0.10) second**2"),
-            ("{:Lx}", r"\SI[separate-uncertainty=true]{4.00 +- 0.10}{\second\squared}"),
+            ("{:Lx}", r"\SI{4.00 +- 0.10}{\second\squared}"),
             ("{:.1f}", "(4.0 +/- 0.1) second ** 2"),
             ("{:.1fP}", "(4.0 ± 0.1) second²"),
             ("{:.1fL}", r"\left(4.0 \pm 0.1\right)\ \mathrm{second}^{2}"),
             ("{:.1fH}", r"\[(4.0 &plusmn; 0.1)\ second^2\]"),
             ("{:.1fC}", "(4.0+/-0.1) second**2"),
-            ("{:.1fLx}", r"\SI[separate-uncertainty=true]{4.0 +- 0.1}{\second\squared}"),
+            ("{:.1fLx}", r"\SI{4.0 +- 0.1}{\second\squared}"),
         ):
             with self.subTest(spec):
                 self.assertEqual(spec.format(m), result)
@@ -88,9 +88,9 @@ class TestMeasurement(QuantityTestCase):
             ("{:.3uC}", "(0.2000+/-0.0100) second**2"),
             (
                 "{:.3uLx}",
-                r"\SI[separate-uncertainty=true]{0.2000 +- 0.0100}{\second\squared}",
+                r"\SI{0.2000 +- 0.0100}{\second\squared}",
             ),
-            ("{:.1uLx}", r"\SI[separate-uncertainty=true]{0.20 +- 0.01}{\second\squared}"),
+            ("{:.1uLx}", r"\SI{0.20 +- 0.01}{\second\squared}"),
         ):
             with self.subTest(spec):
                 self.assertEqual(spec.format(m), result)
@@ -137,7 +137,7 @@ class TestMeasurement(QuantityTestCase):
             ("{:L}", r"\left(4.00 \pm 0.10\right) \times 10^{20}\ \mathrm{second}^{2}"),
             ("{:H}", r"\[(4.00 &plusmn; 0.10)×10^{20}\ second^2\]"),
             ("{:C}", "(4.00+/-0.10)e+20 second**2"),
-            ("{:Lx}", r"\SI[separate-uncertainty=true]{4.00 +- 0.10 e+20}{\second\squared}"),
+            ("{:Lx}", r"\SI{4.00 +- 0.10 e+20}{\second\squared}"),
         ):
             with self.subTest(spec):
                 self.assertEqual(spec.format(m), result)
@@ -154,7 +154,7 @@ class TestMeasurement(QuantityTestCase):
             ),
             ("{:H}", r"\[(4.00 &plusmn; 0.10)×10^{-20}\ second^2\]"),
             ("{:C}", "(4.00+/-0.10)e-20 second**2"),
-            ("{:Lx}", r"\SI[separate-uncertainty=true]{4.00 +- 0.10 e-20}{\second\squared}"),
+            ("{:Lx}", r"\SI{4.00 +- 0.10 e-20}{\second\squared}"),
         ):
             with self.subTest(spec):
                 self.assertEqual(spec.format(m), result)

--- a/pint/testsuite/test_measurement.py
+++ b/pint/testsuite/test_measurement.py
@@ -50,13 +50,13 @@ class TestMeasurement(QuantityTestCase):
             ("{:L}", r"\left(4.00 \pm 0.10\right)\ \mathrm{second}^{2}"),
             ("{:H}", r"\[(4.00 &plusmn; 0.10)\ second^2\]"),
             ("{:C}", "(4.00+/-0.10) second**2"),
-            ("{:Lx}", r"\SI[separate-uncertainty=true]{4.00(10)}{\second\squared}"),
+            ("{:Lx}", r"\SI[separate-uncertainty=true]{4.00 +- 0.10}{\second\squared}"),
             ("{:.1f}", "(4.0 +/- 0.1) second ** 2"),
             ("{:.1fP}", "(4.0 ± 0.1) second²"),
             ("{:.1fL}", r"\left(4.0 \pm 0.1\right)\ \mathrm{second}^{2}"),
             ("{:.1fH}", r"\[(4.0 &plusmn; 0.1)\ second^2\]"),
             ("{:.1fC}", "(4.0+/-0.1) second**2"),
-            ("{:.1fLx}", r"\SI[separate-uncertainty=true]{4.0(1)}{\second\squared}"),
+            ("{:.1fLx}", r"\SI[separate-uncertainty=true]{4.0 +- 0.1}{\second\squared}"),
         ):
             with self.subTest(spec):
                 self.assertEqual(spec.format(m), result)
@@ -88,9 +88,9 @@ class TestMeasurement(QuantityTestCase):
             ("{:.3uC}", "(0.2000+/-0.0100) second**2"),
             (
                 "{:.3uLx}",
-                r"\SI[separate-uncertainty=true]{0.2000(100)}{\second\squared}",
+                r"\SI[separate-uncertainty=true]{0.2000 +- 0.0100}{\second\squared}",
             ),
-            ("{:.1uLx}", r"\SI[separate-uncertainty=true]{0.20(1)}{\second\squared}"),
+            ("{:.1uLx}", r"\SI[separate-uncertainty=true]{0.20 +- 0.01}{\second\squared}"),
         ):
             with self.subTest(spec):
                 self.assertEqual(spec.format(m), result)
@@ -137,7 +137,7 @@ class TestMeasurement(QuantityTestCase):
             ("{:L}", r"\left(4.00 \pm 0.10\right) \times 10^{20}\ \mathrm{second}^{2}"),
             ("{:H}", r"\[(4.00 &plusmn; 0.10)×10^{20}\ second^2\]"),
             ("{:C}", "(4.00+/-0.10)e+20 second**2"),
-            ("{:Lx}", r"\SI[separate-uncertainty=true]{4.00(10)e+20}{\second\squared}"),
+            ("{:Lx}", r"\SI[separate-uncertainty=true]{4.00 +- 0.10 e+20}{\second\squared}"),
         ):
             with self.subTest(spec):
                 self.assertEqual(spec.format(m), result)
@@ -154,7 +154,7 @@ class TestMeasurement(QuantityTestCase):
             ),
             ("{:H}", r"\[(4.00 &plusmn; 0.10)×10^{-20}\ second^2\]"),
             ("{:C}", "(4.00+/-0.10)e-20 second**2"),
-            ("{:Lx}", r"\SI[separate-uncertainty=true]{4.00(10)e-20}{\second\squared}"),
+            ("{:Lx}", r"\SI[separate-uncertainty=true]{4.00 +- 0.10 e-20}{\second\squared}"),
         ):
             with self.subTest(spec):
                 self.assertEqual(spec.format(m), result)

--- a/pint/testsuite/test_measurement.py
+++ b/pint/testsuite/test_measurement.py
@@ -86,10 +86,7 @@ class TestMeasurement(QuantityTestCase):
             ("{:.3uL}", r"\left(0.2000 \pm 0.0100\right)\ \mathrm{second}^{2}"),
             ("{:.3uH}", r"\[(0.2000 &plusmn; 0.0100)\ second^2\]"),
             ("{:.3uC}", "(0.2000+/-0.0100) second**2"),
-            (
-                "{:.3uLx}",
-                r"\SI{0.2000 +- 0.0100}{\second\squared}",
-            ),
+            ("{:.3uLx}", r"\SI{0.2000 +- 0.0100}{\second\squared}",),
             ("{:.1uLx}", r"\SI{0.20 +- 0.01}{\second\squared}"),
         ):
             with self.subTest(spec):


### PR DESCRIPTION
- [x] Pertains to issue # 814
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

Here is my suggested patch related to issue #814. After working on it for a while, I considered several solutions and this seemed the best, immediately available option.
This patch set avoids a compilation error thrown by LaTeX when SIunitx is given uncertainty value containing a decimal place, i.e. "\SI{123.4(1.2)}{\meter}%wrong!".

I think a better solution would be to work with 'uncertainties' to implement a fully compatible string format type implementation, as the current implementation for 'S' is not compatible and, as best I can tell, incorrect. (See NIST "concise" form for representing uncertain values in a single figure, which is what SIunitx is expecting.) If this is fixed, I think 'pint' could go back to the original code and achieve even more compatibility.

As part of this patch set, I removed the hard-coded SIunitx option "separate-uncertainty=true". It wasn't clear why this option was hard set and it did not appear to be necessary to pass any tests, nor any additional use case I tried.  Also, I could not think of a good way to reverse this option for the user of pint; it is not configurable.  It could be added back without much trouble, if required.

An alternative solution would be to check for '.' in the () part of the "concise" uncertainty value and just remove it. I did not do this because it requires that 'uncertainties' always produces nominal and unc values aligned with the same least significant digit, which I think is the case, but I wasn't confident.

However, '.1Lx' still produces invalid LaTeX code. Such a format spec may be invalid, though; I'm not sure. This is a separate issue and not related to #814, in any case.

I already opened a bug with 'uncertainties' regarding the implementation of 'S'.