### PR TITLE
Updated dir(ureg) and added iter(ureg)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,6 +43,7 @@ Other contributors, listed alphabetically, are:
 * Sundar Raman <cybertoast@gmail.com>
 * Tiago Coutinho <coutinho@esrf.fr>
 * Thomas Kluyver <takowl@gmail.com>
+* Tom Nicholas <tomnicholas1@gmail.com>
 * Tom Ritchford <tom@swirly.com>
 * Virgil Dupras <virgil.dupras@savoirfairelinux.com>
 * Zebedee Nicholls <zebedee.nicholls@climate-energy-college.org>

--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,9 @@ Pint Changelog
   when using to_compact()
 - Fixed crash when a Unit with prefix is declared for the first time while a Context
   containing unit redefinitions is active (Issue #1062, Thanks Guido Imperiale)
+- Removed outdated `_dir` attribute of `UnitsRegistry`, and added `__iter__`
+  method so that now `list(ureg)` returns a list of all units in registry.
+  (Issue #1072, Thanks Tom Nicholas)
 
 
 0.11 (2020-02-19)

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -177,26 +177,6 @@ class BaseRegistry(metaclass=RegistryMeta):
     #: Babel.Locale instance or None
     fmt_locale = None
 
-    #: List to be used in addition of units when dir(registry) is called.
-    #: Also used for autocompletion in IPython.
-    _dir = [
-        "Quantity",
-        "Unit",
-        "UnitsContainer",
-        "Measurement",
-        "define",
-        "load_definitions",
-        "get_name",
-        "get_symbol",
-        "get_dimensionality",
-        "get_base_units",
-        "get_root_units",
-        "parse_unit_name",
-        "parse_units",
-        "parse_expression",
-        "convert",
-    ]
-
     def __init__(
         self,
         filename="",
@@ -310,7 +290,18 @@ class BaseRegistry(metaclass=RegistryMeta):
         return self.parse_expression(item)
 
     def __dir__(self):
-        return list(self._units.keys()) + self._dir
+        #: Calling dir(registry) gives all units, methods, and attributes.
+        #: Also used for autocompletion in IPython.
+        return list(self._units.keys()) + list(object.__dir__(self))
+
+    def __iter__(self):
+        """Allows for listing all units in registry with `list(ureg)`.
+
+        Returns
+        -------
+        Iterator over names of all units in registry, ordered alphabetically.
+        """
+        return iter(sorted(self._units.keys()))
 
     def set_fmt_locale(self, loc):
         """Change the locale used by default by `format_babel`.

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -240,6 +240,10 @@ class TestRegistry(QuantityTestCase):
         self.assertNotEqual(s1, s3)
         self.assertEqual(ureg.default_format, "~")
 
+    def test_iterate(self):
+        ureg = UnitRegistry()
+        self.assertTrue('meter' in list(ureg))
+
     def test_parse_number(self):
         self.assertEqual(self.ureg.parse_expression("pi"), math.pi)
         self.assertEqual(self.ureg.parse_expression("x", x=2), 2)

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -242,7 +242,7 @@ class TestRegistry(QuantityTestCase):
 
     def test_iterate(self):
         ureg = UnitRegistry()
-        self.assertTrue('meter' in list(ureg))
+        self.assertTrue("meter" in list(ureg))
 
     def test_parse_number(self):
         self.assertEqual(self.ureg.parse_expression("pi"), math.pi)


### PR DESCRIPTION
Updated `UnitRegistry`'s `dir()` as suggested in #1072.

Also added an `__iter__` method, which means you can now list all the units defined in the registry with `list(ureg)`. I feel that feature should be in the docs, but unsure where to add it.

- [x] Closes #1072
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
