### PR TITLE
Added link to pint-xarray

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,8 @@ Pint Changelog
   when using to_compact()
 - Fixed crash when a Unit with prefix is declared for the first time while a Context
   containing unit redefinitions is active (Issue #1062, Thanks Guido Imperiale)
+- Added link to budding `pint-xarray` interface library to the docs, next to
+  the link to pint-pandas. (Thanks Tom Nicholas.)
 
 
 0.11 (2020-02-19)

--- a/docs/numpy.ipynb
+++ b/docs/numpy.ipynb
@@ -423,7 +423,7 @@
     "To aid in integration between various array types and Pint (such as by providing convenience methods), the following compatibility packages are available:\n",
     "\n",
     "- [pint-pandas](https://github.com/hgrecco/pint-pandas)\n",
-    "- pint-xarray ([in development](https://github.com/hgrecco/pint/issues/849), initial alpha release planned for April-May 2020)\n",
+    "- [pint-xarray](https://github.com/TomNicholas/pint-xarray/) (in early development as of April 2020, with [extra discussion here](https://github.com/hgrecco/pint/issues/849#issuecomment-579992247) - please come and help!)\n",
     "\n",
     "(Note: if you have developed a compatibility package for Pint, please submit a pull request to add it to this list!)"
    ]


### PR DESCRIPTION
Added link to the budding [`pint-xarray`](https://github.com/TomNicholas/pint-xarray) interface package.

- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
