### PR TITLE
add packaging to the dependencies

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -19,7 +19,7 @@ import re
 import warnings
 from typing import List
 
-from pkg_resources.extern.packaging import version
+from packaging import version
 
 from .compat import (
     NUMPY_VER,

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = pint
 zip_safe = True
 include_package_data = True
 python_requires = >=3.6
-install_requires = setuptools
+install_requires = setuptools; packaging
 setup_requires = setuptools; setuptools_scm
 test_suite = pint.testsuite.testsuite
 scripts = pint/pint-convert


### PR DESCRIPTION
Since a few people reported trouble with the `setuptools` vendoring mechanism (mainly because the ArchLinux package of `setuptools` does not include the vendoring part), this makes `pint` depend directly on `packaging`. We also depend on `setuptools` which in turn depends on `packaging`, but this way the dependency graph is more explicit.

We can revert this once we require `numpy >= 1.16` and are able to remove the version check.

- [x] Closes #1008 (@hgrecco, could you reopen that issue so we can close it?)
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
