### PR TITLE
Implement prod

### DIFF
--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -670,6 +670,28 @@ def _all(a, *args, **kwargs):
         raise ValueError("Boolean value of Quantity with offset unit is ambiguous.")
 
 
+@implements("prod", "function")
+def _prod(a, *args, **kwargs):
+    arg_names = ("axis", "dtype", "out", "keepdims", "initial", "where")
+    all_kwargs = dict(**dict(zip(arg_names, args)), **kwargs)
+    axis = all_kwargs.get("axis", None)
+    where = all_kwargs.get("where", None)
+
+    if axis is not None and where is not None:
+        raise ValueError("passing axis and where is not supported")
+
+    result = np.prod(a._magnitude, *args, **kwargs)
+
+    if axis is not None:
+        exponent = a.size // result.size
+        units = a.units ** exponent
+    elif where is not None:
+        exponent = np.asarray(where, dtype=np.bool_).sum()
+        units = a.units ** exponent
+
+    return units._REGISTRY.Quantity(result, units)
+
+
 # Implement simple matching-unit or stripped-unit functions based on signature
 
 

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -286,6 +286,16 @@ class TestNumpyMathematicalFunctions(TestNumpyMethods):
     def test_prod(self):
         self.assertEqual(self.q.prod(), 24 * self.ureg.m ** 4)
 
+    @helpers.requires_array_function_protocol()
+    def test_prod_numpy_func(self):
+        axis = 0
+        where = [[True, False], [True, True]]
+
+        self.assertQuantityEqual(np.prod(self.q, axis=axis), [3, 8] * self.ureg.m ** 2)
+        self.assertQuantityEqual(np.prod(self.q, where=where), 12 * self.ureg.m ** 3)
+
+        self.assertRaises(ValueError, np.prod, self.q, axis=axis, where=where)
+
     def test_sum(self):
         self.assertEqual(self.q.sum(), 10 * self.ureg.m)
         self.assertQuantityEqual(self.q.sum(0), [4, 6] * self.ureg.m)


### PR DESCRIPTION
This implements `numpy.prod`. Support for passing both `axis` and `where` is not quite there, yet, because I couldn't figure out how to broadcast `where` to match the shape of the input array:
```python
if axis is not None and where is not None:
    # broadcast where to match the shape of a:
    # ↓ this is not reliable and does not work well if a contains a dask.array
    where_ = np.broadcast_to(where, a.shape)

    exponents = np.sum(where_, axis=axis)
    exponent = np.max(exponents)
    if not all((exponents == exponent) | (exponents == 0)):
        # try to convert to dimensionless
        ...

result = np.prod(a._magnitude, *args, **kwargs)

if axis is not None and where is not None:
    units = a._units ** exponent
elif axis is not None:
    ...
else:
    ...
```

cc @jthielen

- [x] Closes #867
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
