### PR TITLE
Add momentum as dimension

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -35,6 +35,7 @@ Pint Changelog
   (Issue #1072, Thanks Tom Nicholas)
 - Replace pkg_resources.version to importlib.metadata.version. (Issue #1083)
 - Fix typo in docs for wraps example with optional arguments. (Issue #1088)
+- Add momentum as a dimension
 
 0.11 (2020-02-19)
 -----------------

--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -280,6 +280,9 @@ refrigeration_ton = 12e3 * Btu / hour = _ = ton_of_refrigeration  # approximate,
 standard_liter_per_minute = atmosphere * liter / minute = slpm = slm
 conventional_watt_90 = K_J90 ** 2 * R_K90 / (K_J ** 2 * R_K) * watt = W_90
 
+# Momentum
+[momentum] = [length] * [mass] / [time]
+
 # Density (as auxiliary for pressure)
 [density] = [mass] / [volume]
 mercury = 13.5951 * kilogram / liter = Hg = Hg_0C = Hg_32F = conventional_mercury


### PR DESCRIPTION
Allows for example dimension checking for momentum.

x.check("[momentum]")

- [ ] Closes # (insert issue number)
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
