### PR TITLE
Fix exponent superscripting in HTML

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,7 @@ Pint Changelog
 - Replace pkg_resources.version to importlib.metadata.version. (Issue #1083)
 - Fix typo in docs for wraps example with optional arguments. (Issue #1088)
 - Add momentum as a dimension
+- Fixed a bug where unit exponents were only partially superscripted in HTML format
 
 
 0.11 (2020-02-19)

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -62,8 +62,8 @@ def _pretty_fmt_exponent(num):
     str
 
     """
-    # TODO: Will not work for decimals
-    ret = f"{num:n}".replace("-", "⁻")
+    # unicode dot operator (U+22C5) looks like a superscript decimal
+    ret = f"{num:n}".replace("-", "⁻").replace(".", "\u22C5")
     for n in range(10):
         ret = ret.replace(str(n), _PRETTY_EXPONENTS[n])
     return ret
@@ -95,7 +95,7 @@ _FORMATS = {
         "single_denominator": True,
         "product_fmt": r" ",
         "division_fmt": r"{}/{}",
-        "power_fmt": "{}^{}",
+        "power_fmt": "{{{}}}^{{{}}}",  # braces superscript whole exponent
         "parentheses_fmt": r"({})",
     },
     "": {  # Default format.

--- a/pint/testsuite/test_measurement.py
+++ b/pint/testsuite/test_measurement.py
@@ -48,13 +48,13 @@ class TestMeasurement(QuantityTestCase):
             ("{!r}", "<Measurement(4.0, 0.1, second ** 2)>"),
             ("{:P}", "(4.00 ± 0.10) second²"),
             ("{:L}", r"\left(4.00 \pm 0.10\right)\ \mathrm{second}^{2}"),
-            ("{:H}", r"\[(4.00 &plusmn; 0.10)\ second^2\]"),
+            ("{:H}", r"\[(4.00 &plusmn; 0.10)\ {second}^{2}\]"),
             ("{:C}", "(4.00+/-0.10) second**2"),
             ("{:Lx}", r"\SI{4.00 +- 0.10}{\second\squared}"),
             ("{:.1f}", "(4.0 +/- 0.1) second ** 2"),
             ("{:.1fP}", "(4.0 ± 0.1) second²"),
             ("{:.1fL}", r"\left(4.0 \pm 0.1\right)\ \mathrm{second}^{2}"),
-            ("{:.1fH}", r"\[(4.0 &plusmn; 0.1)\ second^2\]"),
+            ("{:.1fH}", r"\[(4.0 &plusmn; 0.1)\ {second}^{2}\]"),
             ("{:.1fC}", "(4.0+/-0.1) second**2"),
             ("{:.1fLx}", r"\SI{4.0 +- 0.1}{\second\squared}"),
         ):
@@ -70,7 +70,7 @@ class TestMeasurement(QuantityTestCase):
             ("{:.3uS}", "0.2000(100) second ** 2"),
             ("{:.3uSP}", "0.2000(100) second²"),
             ("{:.3uSL}", r"0.2000\left(100\right)\ \mathrm{second}^{2}"),
-            ("{:.3uSH}", r"\[0.2000(100)\ second^2\]"),
+            ("{:.3uSH}", r"\[0.2000(100)\ {second}^{2}\]"),
             ("{:.3uSC}", "0.2000(100) second**2"),
         ):
             with self.subTest(spec):
@@ -84,7 +84,7 @@ class TestMeasurement(QuantityTestCase):
             ("{:.3u}", "(0.2000 +/- 0.0100) second ** 2"),
             ("{:.3uP}", "(0.2000 ± 0.0100) second²"),
             ("{:.3uL}", r"\left(0.2000 \pm 0.0100\right)\ \mathrm{second}^{2}"),
-            ("{:.3uH}", r"\[(0.2000 &plusmn; 0.0100)\ second^2\]"),
+            ("{:.3uH}", r"\[(0.2000 &plusmn; 0.0100)\ {second}^{2}\]"),
             ("{:.3uC}", "(0.2000+/-0.0100) second**2"),
             ("{:.3uLx}", r"\SI{0.2000 +- 0.0100}{\second\squared}",),
             ("{:.1uLx}", r"\SI{0.20 +- 0.01}{\second\squared}"),
@@ -101,7 +101,7 @@ class TestMeasurement(QuantityTestCase):
             ("{:.1u%}", "(20 +/- 1)% second ** 2"),
             ("{:.1u%P}", "(20 ± 1)% second²"),
             ("{:.1u%L}", r"\left(20 \pm 1\right) \%\ \mathrm{second}^{2}"),
-            ("{:.1u%H}", r"\[(20 &plusmn; 1)%\ second^2\]"),
+            ("{:.1u%H}", r"\[(20 &plusmn; 1)%\ {second}^{2}\]"),
             ("{:.1u%C}", "(20+/-1)% second**2"),
         ):
             with self.subTest(spec):
@@ -117,7 +117,7 @@ class TestMeasurement(QuantityTestCase):
                 "{:.1ueL}",
                 r"\left(2.0 \pm 0.1\right) \times 10^{-1}\ \mathrm{second}^{2}",
             ),
-            ("{:.1ueH}", r"\[(2.0 &plusmn; 0.1)×10^{-1}\ second^2\]"),
+            ("{:.1ueH}", r"\[(2.0 &plusmn; 0.1)×10^{-1}\ {second}^{2}\]"),
             ("{:.1ueC}", "(2.0+/-0.1)e-01 second**2"),
         ):
             with self.subTest(spec):
@@ -132,7 +132,7 @@ class TestMeasurement(QuantityTestCase):
             ("{!r}", "<Measurement(4e+20, 1e+19, second ** 2)>"),
             ("{:P}", "(4.00 ± 0.10)×10²⁰ second²"),
             ("{:L}", r"\left(4.00 \pm 0.10\right) \times 10^{20}\ \mathrm{second}^{2}"),
-            ("{:H}", r"\[(4.00 &plusmn; 0.10)×10^{20}\ second^2\]"),
+            ("{:H}", r"\[(4.00 &plusmn; 0.10)×10^{20}\ {second}^{2}\]"),
             ("{:C}", "(4.00+/-0.10)e+20 second**2"),
             ("{:Lx}", r"\SI{4.00 +- 0.10 e+20}{\second\squared}"),
         ):
@@ -149,7 +149,7 @@ class TestMeasurement(QuantityTestCase):
                 "{:L}",
                 r"\left(4.00 \pm 0.10\right) \times 10^{-20}\ \mathrm{second}^{2}",
             ),
-            ("{:H}", r"\[(4.00 &plusmn; 0.10)×10^{-20}\ second^2\]"),
+            ("{:H}", r"\[(4.00 &plusmn; 0.10)×10^{-20}\ {second}^{2}\]"),
             ("{:C}", "(4.00+/-0.10)e-20 second**2"),
             ("{:Lx}", r"\SI{4.00 +- 0.10 e-20}{\second\squared}"),
         ):

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -134,7 +134,7 @@ class TestQuantity(QuantityTestCase):
                 r"4.12345678\ \frac{\mathrm{kilogram} \cdot \mathrm{meter}^{2}}{\mathrm{second}}",
             ),
             ("{:P}", "4.12345678 kilogram·meter²/second"),
-            ("{:H}", r"\[4.12345678\ kilogram\ meter^2/second\]"),
+            ("{:H}", r"\[4.12345678\ kilogram\ {meter}^{2}/second\]"),
             ("{:C}", "4.12345678 kilogram*meter**2/second"),
             ("{:~}", "4.12345678 kg * m ** 2 / s"),
             (
@@ -142,7 +142,7 @@ class TestQuantity(QuantityTestCase):
                 r"4.12345678\ \frac{\mathrm{kg} \cdot \mathrm{m}^{2}}{\mathrm{s}}",
             ),
             ("{:P~}", "4.12345678 kg·m²/s"),
-            ("{:H~}", r"\[4.12345678\ kg\ m^2/s\]"),
+            ("{:H~}", r"\[4.12345678\ kg\ {m}^{2}/s\]"),
             ("{:C~}", "4.12345678 kg*m**2/s"),
             ("{:Lx}", r"\SI[]{4.12345678}{\kilo\gram\meter\squared\per\second}"),
         ):
@@ -209,12 +209,12 @@ class TestQuantity(QuantityTestCase):
                 r"4.12345678\ \frac{\mathrm{kilogram} \cdot \mathrm{meter}^{2}}{\mathrm{second}}",
             ),
             ("P", "4.12345678 kilogram·meter²/second"),
-            ("H", r"\[4.12345678\ kilogram\ meter^2/second\]"),
+            ("H", r"\[4.12345678\ kilogram\ {meter}^{2}/second\]"),
             ("C", "4.12345678 kilogram*meter**2/second"),
             ("~", "4.12345678 kg * m ** 2 / s"),
             ("L~", r"4.12345678\ \frac{\mathrm{kg} \cdot \mathrm{m}^{2}}{\mathrm{s}}"),
             ("P~", "4.12345678 kg·m²/s"),
-            ("H~", r"\[4.12345678\ kg\ m^2/s\]"),
+            ("H~", r"\[4.12345678\ kg\ {m}^{2}/s\]"),
             ("C~", "4.12345678 kg*m**2/s"),
         ):
             with self.subTest(spec):
@@ -250,7 +250,7 @@ class TestQuantity(QuantityTestCase):
 
         ureg = UnitRegistry()
         x = 3.5 * ureg.Unit(UnitsContainer(meter=2, kilogram=1, second=-1))
-        self.assertEqual(x._repr_html_(), r"\[3.5\ kilogram\ meter^2/second\]")
+        self.assertEqual(x._repr_html_(), r"\[3.5\ kilogram\ {meter}^{2}/second\]")
         self.assertEqual(
             x._repr_latex_(),
             r"$3.5\ \frac{\mathrm{kilogram} \cdot "
@@ -259,7 +259,7 @@ class TestQuantity(QuantityTestCase):
         x._repr_pretty_(Pretty, False)
         self.assertEqual("".join(alltext), "3.5 kilogram·meter²/second")
         ureg.default_format = "~"
-        self.assertEqual(x._repr_html_(), r"\[3.5\ kg\ m^2/s\]")
+        self.assertEqual(x._repr_html_(), r"\[3.5\ kg\ {m}^{2}/s\]")
         self.assertEqual(
             x._repr_latex_(),
             r"$3.5\ \frac{\mathrm{kg} \cdot " r"\mathrm{m}^{2}}{\mathrm{s}}$",

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -42,13 +42,13 @@ class TestUnit(QuantityTestCase):
                 r"\frac{\mathrm{kilogram} \cdot \mathrm{meter}^{2}}{\mathrm{second}}",
             ),
             ("{:P}", "kilogram·meter²/second"),
-            ("{:H}", r"\[kilogram\ meter^2/second\]"),
+            ("{:H}", r"\[kilogram\ {meter}^{2}/second\]"),
             ("{:C}", "kilogram*meter**2/second"),
             ("{:Lx}", r"\si[]{\kilo\gram\meter\squared\per\second}"),
             ("{:~}", "kg * m ** 2 / s"),
             ("{:L~}", r"\frac{\mathrm{kg} \cdot \mathrm{m}^{2}}{\mathrm{s}}"),
             ("{:P~}", "kg·m²/s"),
-            ("{:H~}", r"\[kg\ m^2/s\]"),
+            ("{:H~}", r"\[kg\ {m}^{2}/s\]"),
             ("{:C~}", "kg*m**2/s"),
         ):
             with self.subTest(spec):
@@ -63,12 +63,12 @@ class TestUnit(QuantityTestCase):
                 r"\frac{\mathrm{kilogram} \cdot \mathrm{meter}^{2}}{\mathrm{second}}",
             ),
             ("P", "kilogram·meter²/second"),
-            ("H", r"\[kilogram\ meter^2/second\]"),
+            ("H", r"\[kilogram\ {meter}^{2}/second\]"),
             ("C", "kilogram*meter**2/second"),
             ("~", "kg * m ** 2 / s"),
             ("L~", r"\frac{\mathrm{kg} \cdot \mathrm{m}^{2}}{\mathrm{s}}"),
             ("P~", "kg·m²/s"),
-            ("H~", r"\[kg\ m^2/s\]"),
+            ("H~", r"\[kg\ {m}^{2}/s\]"),
             ("C~", "kg*m**2/s"),
         ):
             with self.subTest(spec):
@@ -104,7 +104,7 @@ class TestUnit(QuantityTestCase):
 
         ureg = UnitRegistry()
         x = ureg.Unit(UnitsContainer(meter=2, kilogram=1, second=-1))
-        self.assertEqual(x._repr_html_(), r"\[kilogram\ meter^2/second\]")
+        self.assertEqual(x._repr_html_(), r"\[kilogram\ {meter}^{2}/second\]")
         self.assertEqual(
             x._repr_latex_(),
             r"$\frac{\mathrm{kilogram} \cdot " r"\mathrm{meter}^{2}}{\mathrm{second}}$",
@@ -112,7 +112,7 @@ class TestUnit(QuantityTestCase):
         x._repr_pretty_(Pretty, False)
         self.assertEqual("".join(alltext), "kilogram·meter²/second")
         ureg.default_format = "~"
-        self.assertEqual(x._repr_html_(), r"\[kg\ m^2/s\]")
+        self.assertEqual(x._repr_html_(), r"\[kg\ {m}^{2}/s\]")
         self.assertEqual(
             x._repr_latex_(), r"$\frac{\mathrm{kg} \cdot \mathrm{m}^{2}}{\mathrm{s}}$"
         )


### PR DESCRIPTION
- [ ] Closes # (no issue filed)
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

This PR fixes two issues with exponent rendering of decimal quantities. The first was causing units with exponents that were longer than 1 character not to superscript properly in HTML views, such as used by Jupiter, and the second was causing rendered exponents in the terminal to look less than ideal.

## HTML View
In electronics, noise density is often expressed in units of Volts per sqrt(Hertz), but prior to this change that unit rendered like so:

![image](https://user-images.githubusercontent.com/253574/83940713-0ee6d600-a79b-11ea-8467-0889b46fb311.png)

By adding brackets around the exponent in the format string, we achieve the following:

![image](https://user-images.githubusercontent.com/253574/83941036-f1b30700-a79c-11ea-870e-e457f93c919b.png)

## Terminal Pretty Print
Using the unicode dot operator instead of a plain period (.) makes decimal exponents looks slightly more natural.

Before:
```
nV/Hz⁰.⁵
```
After:
```
nV/Hz⁰⋅⁵
```