### PR TITLE
Add `__contains__` magic to UnitRegistry

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -36,13 +36,14 @@ Pint Changelog
   (Issue #1108, Thanks Guido Imperiale)
 - Fixed crash when some specific combinations of contexts were enabled
   (Issue #1112, Thanks Guido Imperiale)
+- Added support for checking prefixed units using `in` keyword (Issue #1086)
 
 
 0.12 (2020-05-29)
 -----------------
 
 - Add full support for Decimal and Fraction at the registry level.
-  **BREAKING CHANGE**: 
+  **BREAKING CHANGE**:
   `use_decimal` is deprecated. Use `non_int_type=Decimal` when instantiating
   the registry.
 - Fixed bug where numpy.pad didn't work without specifying constant_values or

--- a/docs/defining.rst
+++ b/docs/defining.rst
@@ -152,3 +152,17 @@ leading underscore:
    >>> ureg.define('mpg = 1 * mile / gallon')
    >>> fuel_ec_europe = 5 * ureg.L / ureg._100km
    >>> fuel_ec_us = (1 / fuel_ec_europe).to(ureg.mpg)
+
+
+Checking if a unit is already defined
+-------------------------------------
+
+The python ``in`` keyword works as expected with unit registries. Check if
+a unit has been defined with the following:
+
+.. doctest::
+
+   >>> 'MHz' in ureg
+   True
+   >>> 'gigatrees' in ureg
+   False

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -289,6 +289,15 @@ class BaseRegistry(metaclass=RegistryMeta):
         )
         return self.parse_expression(item)
 
+    def __contains__(self, item):
+        """Support checking prefixed units with the `in` operator
+        """
+        try:
+            self.__getattr__(item)
+            return True
+        except UndefinedUnitError:
+            return False
+
     def __dir__(self):
         #: Calling dir(registry) gives all units, methods, and attributes.
         #: Also used for autocompletion in IPython.

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -702,6 +702,17 @@ class TestIssues(QuantityTestCase):
                 q = ureg.Quantity(1, "nm")
                 q.to("J")
 
+    def test_issue1086(self):
+        # units with prefixes should correctly test as 'in' the registry
+        assert "bits" in ureg
+        assert "gigabits" in ureg
+        assert "meters" in ureg
+        assert "kilometers" in ureg
+        # unknown or incorrect units should test as 'not in' the registry
+        assert "magicbits" not in ureg
+        assert "unknownmeters" not in ureg
+        assert "gigatrees" not in ureg
+
     def test_issue1112(self):
         ureg = UnitRegistry(
             """


### PR DESCRIPTION
- [x] Closes #1806
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

This change allows someone to check if a unit (even a prefixed unit) is defined in a `UnitRegistry` using the python `in` keyword like so:

```python
>>> 'MHz' in ureg
True
>>> 'gigatrees' in ureg
False
```