### PR TITLE
fix calling prod without additional args

### DIFF
--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -688,6 +688,8 @@ def _prod(a, *args, **kwargs):
     elif where is not None:
         exponent = np.asarray(where, dtype=np.bool_).sum()
         units = a.units ** exponent
+    else:
+        units = a.units ** a.size
 
     return units._REGISTRY.Quantity(result, units)
 

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -291,6 +291,7 @@ class TestNumpyMathematicalFunctions(TestNumpyMethods):
         axis = 0
         where = [[True, False], [True, True]]
 
+        self.assertQuantityEqual(np.prod(self.q), 24 * self.ureg.m ** 4)
         self.assertQuantityEqual(np.prod(self.q, axis=axis), [3, 8] * self.ureg.m ** 2)
         self.assertQuantityEqual(np.prod(self.q, where=where), 12 * self.ureg.m ** 3)
 


### PR DESCRIPTION
When implementing `prod` in #1087 I seem to have forgotten the case of `np.prod(q)`, which would fail because the units were not computed in that case.

- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
