### PR TITLE
synchronize the Quantity.prod method with np.prod(q)

### DIFF
--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -416,7 +416,6 @@ matching_input_copy_units_output_ufuncs = [
 copy_units_output_ufuncs = ["ldexp", "fmod", "mod", "remainder"]
 op_units_output_ufuncs = {
     "var": "square",
-    "prod": "size",
     "multiply": "mul",
     "true_divide": "div",
     "divide": "div",

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -113,6 +113,9 @@ def check_implemented(f):
 
 
 def method_wraps(numpy_func):
+    if isinstance(numpy_func, str):
+        numpy_func = getattr(np, numpy_func, None)
+
     def wrapper(func):
         func.__wrapped__ = numpy_func
 
@@ -1705,7 +1708,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         return np.dot(self, b)
 
-    @method_wraps(np.prod)
+    @method_wraps("prod")
     def prod(self, *args, **kwargs):
         """ Return the product of quantity elements over a given axis
 

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -22,8 +22,8 @@ from typing import List
 from packaging import version
 
 from .compat import (
-    NUMPY_VER,
     HAS_NUMPY_ARRAY_FUNCTION,
+    NUMPY_VER,
     _to_magnitude,
     babel_parse,
     eq,

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1714,6 +1714,11 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         Wraps np.prod().
         """
+        if version.parse(np.__version__) < version.parse("1.17"):
+            raise NotImplementedError(
+                f"prod is only correctly defined for numpy >= 1.17 ({np.__version__} is installed)."
+                " Please try to update your numpy version."
+            )
         return np.prod(self, *args, **kwargs)
 
     def __ito_if_needed(self, to_units):

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1716,7 +1716,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         Wraps np.prod().
         """
         # TODO: remove after support for 1.16 has been dropped
-        if HAS_NUMPY_ARRAY_FUNCTION:
+        if not HAS_NUMPY_ARRAY_FUNCTION:
             raise NotImplementedError(
                 "prod is only defined for"
                 " numpy == 1.16 with NUMPY_ARRAY_FUNCTION_PROTOCOL enabled"

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -23,6 +23,7 @@ from packaging import version
 
 from .compat import (
     NUMPY_VER,
+    HAS_NUMPY_ARRAY_FUNCTION,
     _to_magnitude,
     babel_parse,
     eq,
@@ -1714,10 +1715,14 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         Wraps np.prod().
         """
-        if version.parse(np.__version__) < version.parse("1.17"):
+        # TODO: remove after support for 1.16 has been dropped
+        if HAS_NUMPY_ARRAY_FUNCTION:
             raise NotImplementedError(
-                f"prod is only correctly defined for numpy >= 1.17 ({np.__version__} is installed)."
-                " Please try to update your numpy version."
+                "prod is only defined for"
+                " numpy == 1.16 with NUMPY_ARRAY_FUNCTION_PROTOCOL enabled"
+                f" or for numpy >= 1.17 ({np.__version__} is installed)."
+                " Please try setting the NUMPY_ARRAY_FUNCTION_PROTOCOL environment variable"
+                " or updating your numpy version."
             )
         return np.prod(self, *args, **kwargs)
 

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -112,6 +112,15 @@ def check_implemented(f):
     return wrapped
 
 
+def method_wraps(numpy_func):
+    def wrapper(func):
+        func.__wrapped__ = numpy_func
+
+        return func
+
+    return wrapper
+
+
 @contextlib.contextmanager
 def printoptions(*args, **kwargs):
     """Numpy printoptions context manager released with version 1.15.0
@@ -1695,6 +1704,14 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         """
 
         return np.dot(self, b)
+
+    @method_wraps(np.prod)
+    def prod(self, *args, **kwargs):
+        """ Return the product of quantity elements over a given axis
+
+        Wraps np.prod().
+        """
+        return np.prod(self, *args, **kwargs)
 
     def __ito_if_needed(self, to_units):
         if self.unitless and to_units == "radian":

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -789,9 +789,6 @@ class TestNumpyUnclassified(TestNumpyMethods):
         self.assertQuantityAlmostEqual(np.std(self.q), 1.11803 * self.ureg.m, rtol=1e-5)
         self.assertRaises(OffsetUnitCalculusError, np.std, self.q_temperature)
 
-    def test_prod(self):
-        self.assertEqual(self.q.prod(), 24 * self.ureg.m ** 4)
-
     def test_cumprod(self):
         self.assertRaises(DimensionalityError, self.q.cumprod)
         self.assertQuantityEqual((self.q / self.ureg.m).cumprod(), [1, 2, 6, 24])

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -284,7 +284,12 @@ class TestNumpyMathematicalFunctions(TestNumpyMethods):
     # Sums, products, differences
 
     def test_prod(self):
-        self.assertEqual(self.q.prod(), 24 * self.ureg.m ** 4)
+        axis = 0
+        where = [[True, False], [True, True]]
+
+        self.assertQuantityEqual(self.q.prod(), 24 * self.ureg.m ** 4)
+        self.assertQuantityEqual(self.q.prod(axis=axis), [3, 8] * self.ureg.m ** 2)
+        self.assertQuantityEqual(self.q.prod(where=where), 12 * self.ureg.m ** 3)
 
     @helpers.requires_array_function_protocol()
     def test_prod_numpy_func(self):

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -283,6 +283,7 @@ class TestNumpyMathematicalFunctions(TestNumpyMethods):
 
     # Sums, products, differences
 
+    @helpers.requires_array_function_protocol()
     def test_prod(self):
         axis = 0
         where = [[True, False], [True, True]]


### PR DESCRIPTION
As suggested in #1118, this makes `q.prod()` an alias of `np.prod(q)`.

- [x] Closes #1118
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
