### PR TITLE
revise the unit computation for np.prod

### DIFF
--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -680,8 +680,6 @@ def _prod(a, *args, **kwargs):
     if axis is not None and where is not None:
         raise ValueError("passing axis and where is not supported")
 
-    result = np.prod(a._magnitude, *args, **kwargs)
-
     if axis is not None:
         units = a.units ** a.shape[axis]
     elif where is not None:
@@ -689,6 +687,8 @@ def _prod(a, *args, **kwargs):
         units = a.units ** exponent
     else:
         units = a.units ** a.size
+
+    result = np.prod(a._magnitude, *args, **kwargs)
 
     return units._REGISTRY.Quantity(result, units)
 

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -679,8 +679,7 @@ def _prod(a, *args, **kwargs):
 
     if axis is not None and where is not None:
         raise ValueError("passing axis and where is not supported")
-
-    if axis is not None:
+    elif axis is not None:
         units = a.units ** a.shape[axis]
     elif where is not None:
         exponent = np.asarray(where, dtype=np.bool_).sum()

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -683,8 +683,7 @@ def _prod(a, *args, **kwargs):
     result = np.prod(a._magnitude, *args, **kwargs)
 
     if axis is not None:
-        exponent = a.size // result.size
-        units = a.units ** exponent
+        units = a.units ** a.shape[axis]
     elif where is not None:
         exponent = np.asarray(where, dtype=np.bool_).sum()
         units = a.units ** exponent

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -682,7 +682,7 @@ def _prod(a, *args, **kwargs):
     elif axis is not None:
         units = a.units ** a.shape[axis]
     elif where is not None:
-        exponent = np.asarray(where, dtype=np.bool_).sum()
+        exponent = np.sum(where)
         units = a.units ** exponent
     else:
         units = a.units ** a.size

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -295,7 +295,14 @@ class TestNumpyMathematicalFunctions(TestNumpyMethods):
         self.assertQuantityEqual(np.prod(self.q, axis=axis), [3, 8] * self.ureg.m ** 2)
         self.assertQuantityEqual(np.prod(self.q, where=where), 12 * self.ureg.m ** 3)
 
-        self.assertRaises(ValueError, np.prod, self.q, axis=axis, where=where)
+        self.assertRaises(DimensionalityError, np.prod, self.q, axis=axis, where=where)
+        self.assertQuantityEqual(
+            np.prod(self.q, axis=axis, where=[[True, False], [False, True]]),
+            [1, 4] * self.ureg.m,
+        )
+        self.assertQuantityEqual(
+            np.prod(self.q, axis=axis, where=[True, False]), [3, 1] * self.ureg.m ** 2
+        )
 
     def test_sum(self):
         self.assertEqual(self.q.sum(), 10 * self.ureg.m)


### PR DESCRIPTION
#1087 left out the case where `axis` and `where` are specified and also used the size of the result to compute the output unit if only `axis` was specified. This changes that to use `a.shape[axis]` instead and also implements the support for both `axis` and `where` by broadcasting `where` against the array, applying `np.sum` along `axis` and using the only one unique value (`0` doesn't count) as an exponent. In case there's more than that, it will try to cast to `dimensionless`.

I'm not quite sure if using `np.broadcast_arrays` is the best way to get the exponents, though.

Edit: **Todo**: make the error message easier to understand

- [x] Closes #867
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
