### PR TITLE
make __eq__ always return a duck array

### DIFF
--- a/pint/compat.py
+++ b/pint/compat.py
@@ -212,7 +212,7 @@ def eq(lhs, rhs, check_all: bool):
     bool or array_like of bool
     """
     out = lhs == rhs
-    if check_all and isinstance(out, ndarray):
+    if check_all and is_duck_array_type(type(out)):
         return out.all()
     return out
 

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1470,11 +1470,16 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     @check_implemented
     def __eq__(self, other):
         def bool_result(value):
+            nonlocal other
+
             if not is_duck_array_type(type(self._magnitude)):
                 return value
 
-            shape = np.broadcast(self._magnitude, other).shape
-            return np.full(shape=shape, fill_value=False)
+            if isinstance(other, Quantity):
+                other = other._magnitude
+
+            template, _ = np.broadcast_arrays(self._magnitude, other)
+            return np.full_like(template, fill_value=False)
 
         # We compare to the base class of Quantity because
         # each Quantity class is unique.
@@ -1498,6 +1503,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
             return bool_result(False)
 
+        # TODO: this might be expensive. Do we even need it?
         if eq(self._magnitude, 0, True) and eq(other._magnitude, 0, True):
             return bool_result(self.dimensionality == other.dimensionality)
 

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1469,6 +1469,13 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
     @check_implemented
     def __eq__(self, other):
+        def bool_result(value):
+            if not is_duck_array_type(type(self._magnitude)):
+                return value
+
+            shape = np.broadcast(self._magnitude, other).shape
+            return np.full(shape=shape, fill_value=False)
+
         # We compare to the base class of Quantity because
         # each Quantity class is unique.
         if not isinstance(other, Quantity):
@@ -1486,12 +1493,13 @@ class Quantity(PrettyIPython, SharedRegistryObject):
                     else:
                         raise OffsetUnitCalculusError(self._units)
 
-            return self.dimensionless and eq(
-                self._convert_magnitude(self.UnitsContainer()), other, False
-            )
+            if self.dimensionless:
+                return eq(self._convert_magnitude(self.UnitsContainer()), other, False)
+
+            return bool_result(False)
 
         if eq(self._magnitude, 0, True) and eq(other._magnitude, 0, True):
-            return self.dimensionality == other.dimensionality
+            return bool_result(self.dimensionality == other.dimensionality)
 
         if self._units == other._units:
             return eq(self._magnitude, other._magnitude, False)
@@ -1503,7 +1511,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
                 False,
             )
         except DimensionalityError:
-            return False
+            return bool_result(False)
 
     @check_implemented
     def __ne__(self, other):

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1479,7 +1479,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
                 other = other._magnitude
 
             template, _ = np.broadcast_arrays(self._magnitude, other)
-            return np.full_like(template, fill_value=False, dtype=np.bool_)
+            return np.full_like(template, fill_value=value, dtype=np.bool_)
 
         # We compare to the base class of Quantity because
         # each Quantity class is unique.

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1479,7 +1479,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
                 other = other._magnitude
 
             template, _ = np.broadcast_arrays(self._magnitude, other)
-            return np.full_like(template, fill_value=False)
+            return np.full_like(template, fill_value=False, dtype=np.bool_)
 
         # We compare to the base class of Quantity because
         # each Quantity class is unique.

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -878,6 +878,7 @@ class TestNumpyUnclassified(TestNumpyMethods):
     def test_equal(self):
         x = self.q.magnitude
         u = self.Q_(np.ones(x.shape))
+        true = np.ones_like(x, dtype=np.bool_)
         false = np.zeros_like(x, dtype=np.bool_)
 
         self.assertQuantityEqual(u, u)
@@ -890,6 +891,7 @@ class TestNumpyUnclassified(TestNumpyMethods):
         self.assertNDArrayEqual(
             self.Q_(np.zeros_like(x), "m") == self.Q_(np.zeros_like(x), "s"), false,
         )
+        self.assertNDArrayEqual(v == v, true)
         self.assertNDArrayEqual(v == w, false)
         self.assertNDArrayEqual(v == w.to("mm"), false)
         self.assertNDArrayEqual(u == v, false)

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -888,8 +888,7 @@ class TestNumpyUnclassified(TestNumpyMethods):
         w = self.Q_(np.ones(x.shape), "m")
         self.assertNDArrayEqual(v == 1, false)
         self.assertNDArrayEqual(
-            self.Q_(np.zeros_like(x), "m") == self.Q_(np.zeros_like(x), "s"),
-            false,
+            self.Q_(np.zeros_like(x), "m") == self.Q_(np.zeros_like(x), "s"), false,
         )
         self.assertNDArrayEqual(v == w, false)
         self.assertNDArrayEqual(v == w.to("mm"), false)

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -878,10 +878,22 @@ class TestNumpyUnclassified(TestNumpyMethods):
     def test_equal(self):
         x = self.q.magnitude
         u = self.Q_(np.ones(x.shape))
+        false = np.zeros_like(x, dtype=np.bool_)
 
         self.assertQuantityEqual(u, u)
         self.assertQuantityEqual(u == u, u.magnitude == u.magnitude)
         self.assertQuantityEqual(u == 1, u.magnitude == 1)
+
+        v = self.Q_(np.zeros(x.shape), "m")
+        w = self.Q_(np.ones(x.shape), "m")
+        self.assertNDArrayEqual(v == 1, false)
+        self.assertNDArrayEqual(
+            self.Q_(np.zeros_like(x), "m") == self.Q_(np.zeros_like(x), "s"),
+            false,
+        )
+        self.assertNDArrayEqual(v == w, false)
+        self.assertNDArrayEqual(v == w.to("mm"), false)
+        self.assertNDArrayEqual(u == v, false)
 
     def test_shape(self):
         u = self.Q_(np.arange(12))


### PR DESCRIPTION
When comparing quantities with different units / dimensionalities but containing duck arrays for equality, the returned value tends to change between boolean arrays and python boolean objects depending on the input. This makes it somewhat difficult to write code / tests against it and with this I'd propose to change that to always return arrays if we're using array magnitudes.

I'm not quite sure where `bool_result` should live, maybe `compat.py`?

- [x] Closes #351
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
