### PR TITLE
Implement Dask collection interface

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Pint Changelog
 0.15 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Implement Dask collection interface to support Pint Quantity wrapped Dask arrays.
 
 
 0.14 (2020-07-01)

--- a/docs/numpy.ipynb
+++ b/docs/numpy.ipynb
@@ -384,6 +384,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "**Pint Quantity wrapping Dask Array**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask.array as da\n",
+    "\n",
+    "d = da.arange(500, chunks=50)\n",
+    "\n",
+    "# Must create using Quantity class, otherwise Dask will wrap Pint Quantity\n",
+    "q = ureg.Quantity(d, ureg.kelvin)\n",
+    "\n",
+    "print(repr(q))\n",
+    "print()\n",
+    "print(repr(d * ureg.kelvin))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "**xarray wrapping Pint Quantity wrapping Dask array wrapping Sparse COO**"
    ]
   },
@@ -465,7 +490,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/docs/numpy.ipynb
+++ b/docs/numpy.ipynb
@@ -402,7 +402,12 @@
     "\n",
     "print(repr(q))\n",
     "print()\n",
-    "print(repr(d * ureg.kelvin))"
+    "\n",
+    "# DO NOT create using multiplication on the right until\n",
+    "# https://github.com/dask/dask/issues/4583 is resolved, as\n",
+    "# unexpected behavior may result\n",
+    "print(repr(d * ureg.kelvin))\n",
+    "print(repr(ureg.kelvin * d))"
    ]
   },
   {
@@ -490,7 +495,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/pint/compat.py
+++ b/pint/compat.py
@@ -157,6 +157,14 @@ try:
 except ImportError:
     pass
 
+try:
+    from dask.base import compute, persist, visualize
+    import dask.array as dask_array
+
+except ImportError:
+    compute, persist, visualize = None, None, None
+    dask_array = None
+
 
 def is_upcast_type(other) -> bool:
     """Check if the type object is a upcast type using preset list.

--- a/pint/compat.py
+++ b/pint/compat.py
@@ -39,7 +39,8 @@ class BehaviorChangeWarning(UserWarning):
 
 try:
     import numpy as np
-    from numpy import ndarray, datetime64 as np_datetime64
+    from numpy import datetime64 as np_datetime64
+    from numpy import ndarray
 
     HAS_NUMPY = True
     NUMPY_VER = np.__version__
@@ -158,8 +159,8 @@ except ImportError:
     pass
 
 try:
+    from dask import array as dask_array
     from dask.base import compute, persist, visualize
-    import dask.array as dask_array
 
 except ImportError:
     compute, persist, visualize = None, None, None

--- a/pint/pint-convert
+++ b/pint/pint-convert
@@ -36,6 +36,7 @@ ureg.default_system = args.system
 
 if args.unc:
     import uncertainties
+
     # Measured constans subject to correlation
     #  R_i: Rydberg constant
     #  g_e: Electron g factor

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1951,49 +1951,43 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
     @check_dask_array
     def compute(self, **kwargs):
-        """Compute a dask collection wrapped by pint.Quantity.
+        """Compute the Dask array wrapped by pint.Quantity.
 
         Parameters
         ----------
         **kwargs : dict
-            Any keyword arguments to pass to the ``dask.base.compute`` function.
+            Any keyword arguments to pass to ``dask.compute``.
 
         Returns
         -------
         pint.Quantity
-            Returns either the result of calling ``dask.base.compute``, in the case
-            that dask is enabled, or the object on which the ``compute`` method was
-            called without any modifications.
+            A pint.Quantity wrapped numpy array.
         """
         (result,) = compute(self, **kwargs)
         return result
 
     @check_dask_array
     def persist(self, **kwargs):
-        """Compute a dask collection, and keep as a dask collection, wrapped by
-        pint.Quantity.
+        """Persist the Dask Array wrapped by pint.Quantity.
 
         Parameters
         ----------
         **kwargs : dict
-            Any keyword arguments to pass to the ``dask.base.persist`` function.
+            Any keyword arguments to pass to ``dask.persist``.
 
         Returns
         -------
         pint.Quantity
-            Returns either the result of calling ``dask.base.persist``, in the case
-            that dask is enabled, or the object on which the ``persist`` method was
-            called without any modifications.
+            A pint.Quantity wrapped Dask array.
         """
         (result,) = persist(self, **kwargs)
         return result
 
     @check_dask_array
     def visualize(self, **kwargs):
-        """Produce a visual representation of the graph contained in the wrapped
-        Dask collection.
+        """Produce a visual representation of the Dask graph.
 
-        The graphviz and python-graphviz libraries are required.
+        The graphviz library is required.
 
         Parameters
         ----------

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1928,13 +1928,13 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     def __dask_keys__(self):
         return self._magnitude.__dask_keys__()
 
-    @staticmethod
-    def __dask_optimize__(dsk, keys, **kwargs):
-        return dask_array.Array.__dask_optimize__(dsk, keys, **kwargs)
+    @property
+    def __dask_optimize__(self):
+        return dask_array.Array.__dask_optimize__
 
-    @staticmethod
-    def __dask_scheduler__(dsk, keys, **kwargs):
-        return dask_array.Array.__dask_scheduler__(dsk, keys, **kwargs)
+    @property
+    def __dask_scheduler__(self):
+        return dask_array.Array.__dask_scheduler__
 
     def __dask_postcompute__(self):
         func, args = self._magnitude.__dask_postcompute__()

--- a/pint/testsuite/test_compat_downcast.py
+++ b/pint/testsuite/test_compat_downcast.py
@@ -5,6 +5,7 @@ from pint import UnitRegistry
 # Conditionally import NumPy and any upcast type libraries
 np = pytest.importorskip("numpy", reason="NumPy is not available")
 sparse = pytest.importorskip("sparse", reason="sparse is not available")
+da = pytest.importorskip("dask.array", reason="Dask is not available")
 
 # Set up unit registry and sample
 ureg = UnitRegistry(force_ndarray_like=True)
@@ -16,7 +17,7 @@ def identity(x):
     return x
 
 
-@pytest.fixture(params=["sparse", "masked_array"])
+@pytest.fixture(params=["sparse", "masked_array", "dask_array"])
 def array(request):
     """Generate 5x5 arrays of given type for tests."""
     if request.param == "sparse":
@@ -30,6 +31,8 @@ def array(request):
             np.arange(25, dtype=np.float).reshape((5, 5)),
             mask=np.logical_not(np.triu(np.ones((5, 5)))),
         )
+    elif request.param == "dask_array":
+        return da.arange(25, chunks=5, dtype=float).reshape((5, 5))
 
 
 @pytest.mark.parametrize(
@@ -57,8 +60,8 @@ def array(request):
         pytest.param(np.sum, np.sum, identity, id="sum ufunc"),
         pytest.param(np.sqrt, np.sqrt, lambda u: u ** 0.5, id="sqrt ufunc"),
         pytest.param(
-            lambda x: np.reshape(x, 25),
-            lambda x: np.reshape(x, 25),
+            lambda x: np.reshape(x, (25,)),
+            lambda x: np.reshape(x, (25,)),
             identity,
             id="reshape function",
         ),

--- a/pint/testsuite/test_dask.py
+++ b/pint/testsuite/test_dask.py
@@ -4,9 +4,16 @@ import pytest
 
 from pint import UnitRegistry
 
-# Conditionally import NumPy and Dask
+# Conditionally import NumPy, Dask, and Distributed
 np = pytest.importorskip("numpy", reason="NumPy is not available")
 dask = pytest.importorskip("dask", reason="Dask is not available")
+distributed = pytest.importorskip("distributed", reason="Distributed is not available")
+
+from dask.distributed import Client  # isort:skip
+from distributed.client import futures_of  # isort:skip
+from distributed.utils_test import cluster, gen_cluster, loop  # isort:skip
+
+loop = loop  # flake8
 
 ureg = UnitRegistry(force_ndarray_like=True)
 units_ = "kilogram"
@@ -26,26 +33,16 @@ def numpy_array():
     return np.arange(0, 25, dtype=float).reshape((5, 5)) + 5
 
 
-@pytest.mark.parametrize("component", ["__dask_graph__", "__dask_keys__"])
-def test_has_dask_components(dask_array, component):
-    """Test that a pint.Quantity wrapped Dask array has a Dask graph and keys"""
+def test_is_dask_collection(dask_array):
+    """Test that a pint.Quantity wrapped Dask array is a Dask collection."""
     q = ureg.Quantity(dask_array, units_)
-
-    q_method = getattr(q, component)
-    component_q = q_method()
-
-    truth_method = getattr(dask_array, component)
-    component_truth = truth_method()
-
-    assert component_q == component_truth
+    assert dask.is_dask_collection(q)
 
 
-def test_has_no_dask_graph(numpy_array):
-    """Test that a pint.Quantity wrapped NumPy array does not have a Dask graph
-    and that attempting to access it returns None.
-    """
+def test_is_not_dask_collection(numpy_array):
+    """Test that other pint.Quantity wrapped objects are not Dask collections."""
     q = ureg.Quantity(numpy_array, units_)
-    assert q.__dask_graph__() is None
+    assert not dask.is_dask_collection(q)
 
 
 def test_dask_scheduler(dask_array):
@@ -68,34 +65,30 @@ def test_dask_optimize(dask_array):
     assert q.__dask_optimize__ == dask.array.Array.__dask_optimize__
 
 
-@pytest.mark.parametrize("method", ["compute", "persist"])
-def test_convenience_methods(dask_array, numpy_array, method):
-    """Test convenience methods compute() and persist() on a pint.Quantity
-    wrapped Dask array.
-    """
+def test_compute(dask_array, numpy_array):
+    """Test the compute() method on a pint.Quantity wrapped Dask array."""
     q = ureg.Quantity(dask_array, units_)
 
     comps = add_five(q)
-    obj_method = getattr(comps, method)
-    res = obj_method()
+    res = comps.compute()
 
     assert np.all(res.m == numpy_array)
+    assert not dask.is_dask_collection(res)
     assert res.units == units_
     assert q.magnitude is dask_array
 
 
-def test_compute_persist_equivalent_single_machine(dask_array, numpy_array):
-    """Test that compute() and persist() return the same result for calls made
-    on a single machine.
-    """
+def test_persist(dask_array, numpy_array):
+    """Test the persist() method on a pint.Quantity wrapped Dask array."""
     q = ureg.Quantity(dask_array, units_)
 
     comps = add_five(q)
-    res_compute = comps.compute()
-    res_persist = comps.persist()
+    res = comps.persist()
 
-    assert np.all(res_compute == res_persist)
-    assert res_compute.units == res_persist.units == units_
+    assert np.all(res.m == numpy_array)
+    assert dask.is_dask_collection(res)
+    assert res.units == units_
+    assert q.magnitude is dask_array
 
 
 def test_visualize(dask_array):
@@ -109,6 +102,18 @@ def test_visualize(dask_array):
     # These commands only work on Unix and Windows
     assert os.path.exists("mydask.png")
     os.remove("mydask.png")
+
+
+def test_compute_persist_equivalent(dask_array, numpy_array):
+    """Test that compute() and persist() return the same result."""
+    q = ureg.Quantity(dask_array, units_)
+
+    comps = add_five(q)
+    res_compute = comps.compute()
+    res_persist = comps.persist()
+
+    assert np.all(res_compute == res_persist)
+    assert res_compute.units == res_persist.units == units_
 
 
 @pytest.mark.parametrize("method", ["compute", "persist", "visualize"])
@@ -126,3 +131,62 @@ def test_exception_method_not_implemented(numpy_array, method):
     with pytest.raises(AttributeError, match=exctruth):
         obj_method = getattr(q, method)
         obj_method()
+
+
+def test_distributed_compute(loop, dask_array, numpy_array):
+    """Test compute() for distributed machines."""
+    q = ureg.Quantity(dask_array, units_)
+
+    with cluster() as (s, [a, b]):
+        with Client(s["address"], loop=loop):
+            comps = add_five(q)
+            res = comps.compute()
+
+            assert np.all(res.m == numpy_array)
+            assert not dask.is_dask_collection(res)
+            assert res.units == units_
+
+    assert q.magnitude is dask_array
+
+
+def test_distributed_persist(loop, dask_array):
+    """Test persist() for distributed machines."""
+    q = ureg.Quantity(dask_array, units_)
+
+    with cluster() as (s, [a, b]):
+        with Client(s["address"], loop=loop):
+            comps = add_five(q)
+            persisted_q = comps.persist()
+
+            comps_truth = dask_array + 5
+            persisted_truth = comps_truth.persist()
+
+            assert np.all(persisted_q.m == persisted_truth)
+            assert dask.is_dask_collection(persisted_q)
+            assert persisted_q.units == units_
+
+    assert q.magnitude is dask_array
+
+
+@gen_cluster(client=True, timeout=None)
+async def test_async(c, s, a, b):
+    """Test asynchronous operations."""
+    da = dask.array.arange(0, 25, chunks=5, dtype=float).reshape((5, 5))
+    q = ureg.Quantity(da, units_)
+
+    x = q + ureg.Quantity(5, units_)
+    y = x.persist()
+    assert str(y)
+
+    assert dask.is_dask_collection(y)
+    assert len(x.__dask_graph__()) > len(y.__dask_graph__())
+
+    assert not futures_of(x)
+    assert futures_of(y)
+
+    future = c.compute(y)
+    w = await future
+    assert not dask.is_dask_collection(w)
+
+    truth = np.arange(0, 25, dtype=float).reshape((5, 5)) + 5
+    assert np.all(truth == w.m)

--- a/pint/testsuite/test_dask.py
+++ b/pint/testsuite/test_dask.py
@@ -1,0 +1,108 @@
+import pytest
+
+from pint import UnitRegistry
+
+# Conditionally import NumPy and Dask
+np = pytest.importorskip("numpy", reason="NumPy is not available")
+da = pytest.importorskip("dask.array", reason="Dask is not available")
+
+ureg = UnitRegistry(force_ndarray_like=True)
+units_ = "kilogram"
+
+
+@pytest.fixture
+def dask_array():
+    return da.arange(0, 25, chunks=5, dtype=float).reshape((5, 5))
+
+
+@pytest.fixture
+def numpy_array():
+    return np.arange(0, 25, dtype=float).reshape((5, 5)) + 5
+
+
+def test_has_dask_graph(dask_array):
+    """Test that a pint.Quantity wrapped Dask array has a Dask graph."""
+    q = ureg.Quantity(dask_array, units_)
+    assert q.__dask_graph__() == dask_array.__dask_graph__()
+
+
+def test_has_no_dask_graph(numpy_array):
+    """Test that a pint.Quantity wrapped NumPy array does not have a Dask graph,
+    and that attempting to access it returns None.
+    """
+    q = ureg.Quantity(numpy_array, units_)
+    assert q.__dask_graph__() is None
+
+
+def test_has_dask_keys(dask_array):
+    """Test that a pint.Quantity wrapped Dask array has Dask keys."""
+    q = ureg.Quantity(dask_array, units_)
+    assert q.__dask_keys__() == dask_array.__dask_keys__()
+
+
+def test_compute(dask_array, numpy_array):
+    """Test the compute() method on a pint.Quantity wrapped Dask array."""
+    q = ureg.Quantity(dask_array, units_)
+    comps = q + 5 * ureg(units_)
+    res = comps.compute()
+
+    assert np.all(res.m == numpy_array)
+    assert res.units == units_
+    assert q.magnitude is dask_array
+
+
+def test_persist(dask_array, numpy_array):
+    """Test the persist() method on a pint.Quantity wrapped Dask array.
+
+    For single machines, persist() is expected to return the computed result(s).
+    """
+    q = ureg.Quantity(dask_array, units_)
+    comps = q + 5 * ureg(units_)
+    res = comps.persist()
+
+    assert np.all(res.m == numpy_array)
+    assert res.units == units_
+    assert q.magnitude is dask_array
+
+
+def test_visualize():
+    pass
+
+
+def test_compute_exception(numpy_array):
+    """Test exception handling for calling compute() on a pint.Quantity wrapped object
+    that is not a dask.array.core.Array object.
+    """
+    q = ureg.Quantity(numpy_array, units_)
+    comps = q + 5 * ureg(units_)
+    with pytest.raises(AttributeError) as excinfo:
+        comps.compute()
+
+    exctruth = "Method compute only implemented for objects of <class 'dask.array.core.Array'>, not <class 'numpy.ndarray'>"
+    assert str(excinfo.value) == exctruth
+
+
+def test_persist_exception(numpy_array):
+    """Test exception handling for calling persist() on a pint.Quantity wrapped object
+    that is not a dask.array.core.Array object.
+    """
+    q = ureg.Quantity(numpy_array, units_)
+    comps = q + 5 * ureg(units_)
+    with pytest.raises(AttributeError) as excinfo:
+        comps.persist()
+
+    exctruth = "Method persist only implemented for objects of <class 'dask.array.core.Array'>, not <class 'numpy.ndarray'>"
+    assert str(excinfo.value) == exctruth
+
+
+def test_visualize_exception(numpy_array):
+    """Test exception handling for calling visualize() on a pint.Quantity wrapped object
+    that is not a dask.array.core.Array object.
+    """
+    q = ureg.Quantity(numpy_array, units_)
+    comps = q + 5 * ureg(units_)
+    with pytest.raises(AttributeError) as excinfo:
+        comps.visualize()
+
+    exctruth = "Method visualize only implemented for objects of <class 'dask.array.core.Array'>, not <class 'numpy.ndarray'>"
+    assert str(excinfo.value) == exctruth

--- a/pint/testsuite/test_dask.py
+++ b/pint/testsuite/test_dask.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from pint import UnitRegistry
@@ -82,8 +84,31 @@ def test_convenience_methods(dask_array, numpy_array, method):
     assert q.magnitude is dask_array
 
 
-def test_visualize():
-    pass
+def test_compute_persist_equivalent_single_machine(dask_array, numpy_array):
+    """Test that compute() and persist() return the same result for calls made
+    on a single machine.
+    """
+    q = ureg.Quantity(dask_array, units_)
+
+    comps = add_five(q)
+    res_compute = comps.compute()
+    res_persist = comps.persist()
+
+    assert np.all(res_compute == res_persist)
+    assert res_compute.units == res_persist.units == units_
+
+
+def test_visualize(dask_array):
+    """Test the visualize() method on a pint.Quantity wrapped Dask array."""
+    q = ureg.Quantity(dask_array, units_)
+
+    comps = add_five(q)
+    res = comps.visualize()
+
+    assert res is None
+    # These commands only work on Unix and Windows
+    assert os.path.exists("mydask.png")
+    os.remove("mydask.png")
 
 
 @pytest.mark.parametrize("method", ["compute", "persist", "visualize"])

--- a/pint/testsuite/test_dask.py
+++ b/pint/testsuite/test_dask.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 
 import pytest
@@ -91,6 +92,9 @@ def test_persist(dask_array, numpy_array):
     assert q.magnitude is dask_array
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("graphviz") is None, reason="GraphViz is not available"
+)
 def test_visualize(dask_array):
     """Test the visualize() method on a pint.Quantity wrapped Dask array."""
     q = ureg.Quantity(dask_array, units_)
@@ -105,7 +109,7 @@ def test_visualize(dask_array):
 
 
 def test_compute_persist_equivalent(dask_array, numpy_array):
-    """Test that compute() and persist() return the same result."""
+    """Test that compute() and persist() return the same numeric results."""
     q = ureg.Quantity(dask_array, units_)
 
     comps = add_five(q)

--- a/pint/testsuite/test_dask.py
+++ b/pint/testsuite/test_dask.py
@@ -24,32 +24,36 @@ def numpy_array():
     return np.arange(0, 25, dtype=float).reshape((5, 5)) + 5
 
 
-def test_has_dask_graph(dask_array):
-    """Test that a pint.Quantity wrapped Dask array has a Dask graph."""
+@pytest.mark.parametrize("component", ["__dask_graph__", "__dask_keys__"])
+def test_has_dask_components(dask_array, component):
+    """Test that a pint.Quantity wrapped Dask array has a Dask graph and keys"""
     q = ureg.Quantity(dask_array, units_)
-    assert q.__dask_graph__() == dask_array.__dask_graph__()
+
+    q_method = getattr(q, component)
+    component_q = q_method()
+
+    truth_method = getattr(dask_array, component)
+    component_truth = truth_method()
+
+    assert component_q == component_truth
 
 
 def test_has_no_dask_graph(numpy_array):
-    """Test that a pint.Quantity wrapped NumPy array does not have a Dask graph,
+    """Test that a pint.Quantity wrapped NumPy array does not have a Dask graph
     and that attempting to access it returns None.
     """
     q = ureg.Quantity(numpy_array, units_)
     assert q.__dask_graph__() is None
 
 
-def test_has_dask_keys(dask_array):
-    """Test that a pint.Quantity wrapped Dask array has Dask keys."""
-    q = ureg.Quantity(dask_array, units_)
-    assert q.__dask_keys__() == dask_array.__dask_keys__()
-
-
 def test_dask_scheduler(dask_array):
     """Test that a pint.Quantity wrapped Dask array has the correct default scheduler."""
     q = ureg.Quantity(dask_array, units_)
+
     scheduler = q.__dask_scheduler__
-    scheduler_name = f'{scheduler.__module__}.{scheduler.__name__}'
-    true_name = 'dask.threaded.get'
+    scheduler_name = f"{scheduler.__module__}.{scheduler.__name__}"
+
+    true_name = "dask.threaded.get"
 
     assert scheduler == dask.array.Array.__dask_scheduler__
     assert scheduler_name == true_name
@@ -62,25 +66,16 @@ def test_dask_optimize(dask_array):
     assert q.__dask_optimize__ == dask.array.Array.__dask_optimize__
 
 
-def test_compute(dask_array, numpy_array):
-    """Test the compute() method on a pint.Quantity wrapped Dask array."""
-    q = ureg.Quantity(dask_array, units_)
-    comps = add_five(q)
-    res = comps.compute()
-
-    assert np.all(res.m == numpy_array)
-    assert res.units == units_
-    assert q.magnitude is dask_array
-
-
-def test_persist(dask_array, numpy_array):
-    """Test the persist() method on a pint.Quantity wrapped Dask array.
-
-    For single machines, persist() is expected to return the computed result(s).
+@pytest.mark.parametrize("method", ["compute", "persist"])
+def test_convenience_methods(dask_array, numpy_array, method):
+    """Test convenience methods compute() and persist() on a pint.Quantity
+    wrapped Dask array.
     """
     q = ureg.Quantity(dask_array, units_)
+
     comps = add_five(q)
-    res = comps.persist()
+    obj_method = getattr(comps, method)
+    res = obj_method()
 
     assert np.all(res.m == numpy_array)
     assert res.units == units_
@@ -91,40 +86,18 @@ def test_visualize():
     pass
 
 
-def test_compute_exception(numpy_array):
-    """Test exception handling for calling compute() on a pint.Quantity wrapped object
-    that is not a dask.array.core.Array object.
+@pytest.mark.parametrize("method", ["compute", "persist", "visualize"])
+def test_exception_method_not_implemented(numpy_array, method):
+    """Test exception handling for convenience methods on a pint.Quantity wrapped
+    object that is not a dask.array.Array object.
     """
     q = ureg.Quantity(numpy_array, units_)
-    comps = add_five(q)
-    with pytest.raises(AttributeError) as excinfo:
-        comps.compute()
 
-    exctruth = "Method compute only implemented for objects of <class 'dask.array.core.Array'>, not <class 'numpy.ndarray'>"
-    assert str(excinfo.value) == exctruth
-
-
-def test_persist_exception(numpy_array):
-    """Test exception handling for calling persist() on a pint.Quantity wrapped object
-    that is not a dask.array.core.Array object.
-    """
-    q = ureg.Quantity(numpy_array, units_)
-    comps = add_five(q)
-    with pytest.raises(AttributeError) as excinfo:
-        comps.persist()
-
-    exctruth = "Method persist only implemented for objects of <class 'dask.array.core.Array'>, not <class 'numpy.ndarray'>"
-    assert str(excinfo.value) == exctruth
-
-
-def test_visualize_exception(numpy_array):
-    """Test exception handling for calling visualize() on a pint.Quantity wrapped object
-    that is not a dask.array.core.Array object.
-    """
-    q = ureg.Quantity(numpy_array, units_)
-    comps = add_five(q)
-    with pytest.raises(AttributeError) as excinfo:
-        comps.visualize()
-
-    exctruth = "Method visualize only implemented for objects of <class 'dask.array.core.Array'>, not <class 'numpy.ndarray'>"
-    assert str(excinfo.value) == exctruth
+    exctruth = (
+        f"Method {method} only implemented for objects of"
+        " <class 'dask.array.core.Array'>, not"
+        " <class 'numpy.ndarray'>"
+    )
+    with pytest.raises(AttributeError, match=exctruth):
+        obj_method = getattr(q, method)
+        obj_method()

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -219,6 +219,7 @@ class TestRegistry(QuantityTestCase):
 
     def test_load(self):
         import pkg_resources
+
         from pint import unit
 
         data = pkg_resources.resource_filename(unit.__name__, "default_en.txt")


### PR DESCRIPTION
This pull request implements the [Dask collection interface](https://docs.dask.org/en/latest/custom-collections.html) for the Quantity class and adds convenience methods `compute()`, `persist()`, and `visualize()`. As is, only the convenience methods are wrapped to check that the magnitude of the Quantity is a dask array, which should cover current use cases. Ping @jthielen since we've been discussing this.

I have not tested `persist()` on a HPC cluster, which will have different behavior than when it is called on a single machine (e.g., desktop). Is there a way to integrate tests for distributed cases? If not, I can test this independently if needed.

- [X] Closes #883 
- [X] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [X] The change is fully covered by automated unit tests
- [X] Documented in docs/ as appropriate
- [X] Added an entry to the CHANGES file