### PR TITLE
fix reduce dimensions when previous dimension was zeroed out

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,8 @@ Pint Changelog
 
 - Implement Dask collection interface to support Pint Quantity wrapped Dask arrays.
 - Started automatically testing examples in the documentation
+- Fixed an exception generated when reducing dimensions with three or more
+  units of the same type
 
 0.14 (2020-07-01)
 -----------------

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -677,8 +677,8 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
     def ito_reduced_units(self):
         """Return Quantity scaled in place to reduced units, i.e. one unit per
-        dimension. This will not reduce compound units (intentionally), nor
-        can it make use of contexts at this time.
+        dimension. This will not reduce compound units (e.g., 'J/kg' will not 
+        be reduced to m**2/s**2), nor can it make use of contexts at this time.
         """
 
         # shortcuts in case we're dimensionless or only a single unit
@@ -691,6 +691,9 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         # loop through individual units and compare to each other unit
         # can we do better than a nested loop here?
         for unit1, exp in self._units.items():
+            # make sure it wasn't already reduced to zero exponent on prior pass
+            if unit1 not in newunits:
+                continue
             for unit2 in newunits:
                 if unit1 != unit2:
                     power = self._REGISTRY._get_dimensionality_ratio(unit1, unit2)

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -677,7 +677,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
     def ito_reduced_units(self):
         """Return Quantity scaled in place to reduced units, i.e. one unit per
-        dimension. This will not reduce compound units (e.g., 'J/kg' will not 
+        dimension. This will not reduce compound units (e.g., 'J/kg' will not
         be reduced to m**2/s**2), nor can it make use of contexts at this time.
         """
 

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -693,6 +693,13 @@ class TestIssues(QuantityTestCase):
         assert isinstance(q1, ureg.Quantity)
         assert len(q0) == len(q1) == 0
 
+    def test_issue1058(self):
+        """ verify that auto-reducing quantities with three or more units
+        of same base type succeeds """
+        q = 1 * ureg.mg / ureg.g / ureg.kg
+        q.ito_reduced_units()
+        self.assertIsInstance(q, ureg.Quantity)
+
     def test_issue1062_issue1097(self):
         # Must not be used by any other tests
         assert "nanometer" not in ureg._units


### PR DESCRIPTION
…1058

- [1058] Closes # (insert issue number)
- [+] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [+] The change is fully covered by automated unit tests
- [+] Documented in docs/ as appropriate
- [+] Added an entry to the CHANGES file
