### PR TITLE
Avoid warning when setting a masked value

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Pint Changelog
 - Implement Dask collection interface to support Pint Quantity wrapped Dask arrays.
 - Started automatically testing examples in the documentation
 - Fixed right operand power for dimensionless Quantity to reflect numpy behavior. (Issue #1136)
+- Eliminated warning when setting a masked value on an underlying MaskedArray.
 
 0.14 (2020-07-01)
 -----------------

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1808,7 +1808,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
     def __setitem__(self, key, value):
         try:
-            if math.isnan(value):
+            if np.ma.is_masked(value) or math.isnan(value):
                 self._magnitude[key] = value
                 return
         except TypeError:

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -2,6 +2,7 @@ import copy
 import operator as op
 import pickle
 import unittest
+import warnings
 
 from pint import DimensionalityError, OffsetUnitCalculusError, UnitStrippedWarning
 from pint.compat import np
@@ -849,6 +850,16 @@ class TestNumpyUnclassified(TestNumpyMethods):
         q = [0.0, 1.0, 2.0, 3.0] * self.ureg.m / self.ureg.mm
         q[0] = 1.0
         self.assertQuantityEqual(q, [0.001, 1, 2, 3] * self.ureg.m / self.ureg.mm)
+
+        # Check that this properly masks the first item without warning
+        q = self.ureg.Quantity(
+            np.ma.array([0.0, 1.0, 2.0, 3.0], mask=[False, True, False, False]), "m"
+        )
+        with warnings.catch_warnings(record=True) as w:
+            q[0] = np.ma.masked
+            # Check for no warnings
+            assert not w
+            assert q.mask[0]
 
     def test_iterator(self):
         for q, v in zip(self.q.flatten(), [1, 2, 3, 4]):


### PR DESCRIPTION
When the underlying data is a masked array, __setitem__ can be given a sentintel np.ma.masked or masked values. This avoids passing them to math.isnan which causes a warning:
```
miniconda3/envs/py38/lib/python3.8/site-packages/pint/quantity.py:1782: UserWarning: Warning: converting a masked element to nan.
    if math.isnan(value):
```

- [ ] Closes # (insert issue number)
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
