### PR TITLE
Support rpow operation on dimensionless array

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Pint Changelog
 
 - Implement Dask collection interface to support Pint Quantity wrapped Dask arrays.
 - Started automatically testing examples in the documentation
+- Fixed right operand power for dimensionless Quantity to reflect numpy behavior. (Issue #1136)
 
 0.14 (2020-07-01)
 -----------------

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1467,9 +1467,6 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         else:
             if not self.dimensionless:
                 raise DimensionalityError(self._units, "dimensionless")
-            if is_duck_array_type(type(self._magnitude)):
-                if np.size(self._magnitude) > 1:
-                    raise DimensionalityError(self._units, "dimensionless")
             new_self = self.to_root_units()
             return other ** new_self._magnitude
 

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -738,6 +738,13 @@ class TestIssues(QuantityTestCase):
         ureg.enable_contexts("c2")
         ureg.enable_contexts("c3")
 
+    @helpers.requires_numpy()
+    def test_issue_1136(self):
+        assert (2 ** ureg.Quantity([2, 3], "") == 2 ** np.array([2, 3])).all()
+
+        with pytest.raises(DimensionalityError):
+            2 ** ureg.Quantity([2, 3], "m")
+
 
 if np is not None:
 


### PR DESCRIPTION
Fixed right operand power for dimensionless Quantity to reflect numpy behavior

- [x] Closes #1136
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] ~Documented in docs/ as appropriate~
- [x] Added an entry to the CHANGES file
