### PR TITLE
Update docs with guidelines on when to create extension packages

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -63,6 +63,32 @@ To build the documentation, invoke Sphinx from the ``docs`` directory::
     $ cd docs
     $ make html
 
+Extension Packages
+------------------
+
+Pint naturally integrates with other libraries in the scientific Python ecosystem, and
+a small number of
+`extension/compatibility packages<numpy.html#Compatibility-Packages>`_ have arisen to
+aid in compatibility between certain packages. Pint's rule of thumb for integration
+features that work best as an extension pacakage versus direct inclusion in Pint is:
+
+* Extension (separate packages)
+
+  * Duck array types that wrap Pint (come above Pint in
+    `the type casting hierarchy<numpy.html#Technical-Commentary>`_)
+
+  * Uses features independent/on top of the libraries
+
+  * Examples: xarray, Pandas
+
+* Integration (built in to Pint)
+
+  * Duck array types wrapped by Pint (below Pint in the type casting hierarchy)
+
+  * Intermingling of APIs occurs
+
+  * Examples: Dask
+
 
 .. _github: http://github.com/hgrecco/pint
 .. _`issue tracker`: https://github.com/hgrecco/pint/issues

--- a/docs/numpy.ipynb
+++ b/docs/numpy.ipynb
@@ -453,7 +453,7 @@
     "To aid in integration between various array types and Pint (such as by providing convenience methods), the following compatibility packages are available:\n",
     "\n",
     "- [pint-pandas](https://github.com/hgrecco/pint-pandas)\n",
-    "- [pint-xarray](https://github.com/TomNicholas/pint-xarray/) (in early development as of April 2020, with [extra discussion here](https://github.com/hgrecco/pint/issues/849#issuecomment-579992247) - please come and help!)\n",
+    "- [pint-xarray](https://github.com/xarray-contrib/pint-xarray/)\n",
     "\n",
     "(Note: if you have developed a compatibility package for Pint, please submit a pull request to add it to this list!)"
    ]


### PR DESCRIPTION
Implement the doc changes suggested in #1130, and updates `pint-xarray` link.

- [x] Closes #1130
- ~~Executed ``black -t py36 . && isort -rc . && flake8`` with no errors~~
- ~~The change is fully covered by automated unit tests~~
- [x] Documented in docs/ as appropriate
- ~~Added an entry to the CHANGES file~~
