### PR TITLE
Add option to disable sorting of formatted unit components

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ Pint Changelog
 - Started automatically testing examples in the documentation
 - Fixed right operand power for dimensionless Quantity to reflect numpy behavior. (Issue #1136)
 - Eliminated warning when setting a masked value on an underlying MaskedArray.
+- Add `sort` option to `formatting.formatter` to permit disabling sorting of component units in format string
 
 0.14 (2020-07-01)
 -----------------

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -129,6 +129,7 @@ def formatter(
     locale=None,
     babel_length="long",
     babel_plural_form="one",
+    sort=True,
 ):
     """Format a list of (name, exponent) pairs.
 
@@ -157,6 +158,8 @@ def formatter(
         the plural form, calculated as defined in babel. (Default value = "one")
     exp_call : callable
          (Default value = lambda x: f"{x:n}")
+    sort : bool, optional
+        True to sort the formatted units alphabetically (Default value = True)
 
     Returns
     -------
@@ -175,7 +178,9 @@ def formatter(
 
     pos_terms, neg_terms = [], []
 
-    for key, value in sorted(items):
+    if sort:
+        items = sorted(items)
+    for key, value in items:
         if locale and babel_length and babel_plural_form and key in _babel_units:
             _key = _babel_units[key]
             locale = babel_parse(locale)


### PR DESCRIPTION
- [ ] Closes # (insert issue number) (*n/a*)
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests (*do I need to address this?*)
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

This is a very simple PR that adds a `sort` keyword argument to `pint.formatting.formatter`. The `sort` keyword can be set to `False` to optionally disable alphabetical sorting of the component units. This can be useful if your units are conventionally placed in a particular order, or conceptually easier to understand in a particular order.

Also, since preserving the dictionary insertion order is [an explicit python 3.6+ feature](https://docs.python.org/3/whatsnew/3.6.html#new-dict-implementation), the `unit: exponent` pairs in the `UnitsContainer` dictionaries can be reliably expected to preserve their original order, making this feature practically useful for formatting existing `Units` objects.

Here's a quick example with the conventional [specific heat capacity](https://en.wikipedia.org/wiki/Specific_heat_capacity) units:

```python

In  [1]: import pint
    ...: ureg = pint.UnitRegistry()
    ...: units = ureg.parse_units('J kg^-1 K^-1') 

In [2]: units.format_babel('C~', sort=True, as_ratio=False, product_fmt=' ')
Out[2]: 'J K**-1 kg**-1'

In [3]: units.format_babel('C~', sort=False, as_ratio=False, product_fmt=' ')
Out[3]: 'J kg**-1 K**-1'
```