### PR TITLE
Rely on stdlib importlib.resources for package files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ install:
   # this is superslow but suck it up until updates to pandas are made
   # - if [[ $PANDAS == '1' ]]; then pip install numpy cython pytest pytest-cov nbval; pip install git+https://github.com/pandas-dev/pandas.git@bdb7a1603f1e0948ca0cab011987f616e7296167; python -c 'import pandas; print(pandas.__version__)'; fi
   - conda list
+  - pip install .
 
 script:
   # if we're doing the pandas tests and hence have pytest available, we can

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,8 @@ Pint Changelog
 
 - Implements Logarithmic Units like dBm, dB or decade
   (Issue #71, Thanks Dima Pustakhod, Clark Willison, Giorgio Signorello, Steven Casagrande, Jonathan Wheeler)
+- Drop dependency on setuptools pkg_resources to read package resources, using std lib importlib.resources instead.
+  (Issue #1080)
 
 
 0.15 (2020-08-22)

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -40,13 +40,17 @@ import locale
 import os
 import re
 from collections import ChainMap, defaultdict
-from contextlib import closing, contextmanager
+from contextlib import contextmanager
 from decimal import Decimal
 from fractions import Fraction
 from io import StringIO
 from tokenize import NAME, NUMBER
 
-import pkg_resources
+try:
+    import importlib.resources as importlib_resources
+except ImportError:
+    # Backport for Python < 3.7
+    import importlib_resources
 
 from . import registry_helpers, systems
 from .compat import babel_parse, tokenizer
@@ -531,8 +535,7 @@ class BaseRegistry(metaclass=RegistryMeta):
         if isinstance(file, str):
             try:
                 if is_resource:
-                    with closing(pkg_resources.resource_stream(__name__, file)) as fp:
-                        rbytes = fp.read()
+                    rbytes = importlib_resources.read_binary(__package__, file)
                     return self.load_definitions(
                         StringIO(rbytes.decode("utf-8")), is_resource
                     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,9 +28,9 @@ zip_safe = True
 include_package_data = True
 python_requires = >=3.6
 install_requires =
-    setuptools
     packaging
     importlib-metadata; python_version < '3.8'
+    importlib-resources; python_version < '3.7'
 setup_requires = setuptools; setuptools_scm
 test_suite = pint.testsuite.testsuite
 scripts = pint/pint-convert


### PR DESCRIPTION
- [x] Closes #1080 
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] ~Documented in docs/ as appropriate~
- [x] Added an entry to the CHANGES file

Replace setuptools pkg_resources to standard lib importlib.resources.
Use backport importlib-resources for python < 3.7
Removed setuptools from `install_requires` in the `setup.cfg`.

The package and its runtime dependencies (packaging, importlib backports) are not installed on the CI during the install process.
I've fixed that with a `pip install .`
