### PR TITLE
Fix error on UnitsContainer equality check

### DIFF
--- a/pint/util.py
+++ b/pint/util.py
@@ -431,7 +431,11 @@ class UnitsContainer(Mapping):
             other = other._d
 
         elif isinstance(other, str):
-            other = ParserHelper.from_string(other, self._non_int_type)
+            try:
+                other = ParserHelper.from_string(other, self._non_int_type)
+            except DefinitionSyntaxError:
+                return False
+
             other = other._d
 
         return dict.__eq__(self._d, other)


### PR DESCRIPTION
- [x] Closes #1178
- [ ] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
