### PR TITLE
Fix scalar ndarray tolist function

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Pint Changelog
 0.17 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fix tolist function with scalar ndarray. (Issue #1195)
 
 
 0.16.1 (2020-09-22)

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1879,12 +1879,22 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
     def tolist(self):
         units = self._units
-        return [
-            self.__class__(value, units).tolist()
-            if isinstance(value, list)
-            else self.__class__(value, units)
-            for value in self._magnitude.tolist()
-        ]
+
+        try:
+            values = self._magnitude.tolist()
+            if not isinstance(values, list):
+                return self.__class__(values, units)
+
+            return [
+                self.__class__(value, units).tolist()
+                if isinstance(value, list)
+                else self.__class__(value, units)
+                for value in self._magnitude.tolist()
+            ]
+        except AttributeError:
+            raise AttributeError(
+                f"Magnitude '{type(self._magnitude).__name__}' does not support tolist."
+            )
 
     # Measurement support
     def plus_minus(self, error, relative=False):

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -27,6 +27,10 @@ class TestNumpyMethods(QuantityTestCase):
         return [[1, 2], [3, 4]] * self.ureg.m
 
     @property
+    def q_scalar(self):
+        return np.array(5) * self.ureg.m
+
+    @property
     def q_nan(self):
         return [[1, 2], [3, np.nan]] * self.ureg.m
 
@@ -497,6 +501,10 @@ class TestNumpyUnclassified(TestNumpyMethods):
             self.q.tolist(),
             [[1 * self.ureg.m, 2 * self.ureg.m], [3 * self.ureg.m, 4 * self.ureg.m]],
         )
+        self.assertEqual(self.q_scalar.tolist(), 5 * self.ureg.m)
+
+        with self.assertRaises(AttributeError):
+            (5 * self.ureg.m).tolist()
 
     def test_fill(self):
         tmp = self.q


### PR DESCRIPTION
- [x] Closes #1195
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

Returning scalar Quantity if magnitude.tolist() is not Iterable.
Better AttributeError messaging.