### PR TITLE
Parse NumPy version with LooseVersion

### DIFF
--- a/pint/testsuite/helpers.py
+++ b/pint/testsuite/helpers.py
@@ -1,7 +1,7 @@
 import doctest
 import re
 import unittest
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 from ..compat import (
     HAS_BABEL,
@@ -33,7 +33,7 @@ def requires_numpy_previous_than(version):
     if not HAS_NUMPY:
         return unittest.skip("Requires NumPy")
     return unittest.skipUnless(
-        StrictVersion(NUMPY_VER) < StrictVersion(version),
+        LooseVersion(NUMPY_VER) < LooseVersion(version),
         "Requires NumPy < %s" % version,
     )
 
@@ -42,7 +42,7 @@ def requires_numpy_at_least(version):
     if not HAS_NUMPY:
         return unittest.skip("Requires NumPy")
     return unittest.skipUnless(
-        StrictVersion(NUMPY_VER) >= StrictVersion(version),
+        LooseVersion(NUMPY_VER) >= LooseVersion(version),
         "Requires NumPy >= %s" % version,
     )
 


### PR DESCRIPTION
StrictVersion cannot parse rc versions:

    ValueError: invalid version number '1.20.0rc2'

- [ ] Closes # (insert issue number)
- [ ] Executed ``pre-commit run --all-files`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

Sorry I have not done any of this. I've edited the file on GitHub directly.