### PR TITLE
Fix numpy.linalg.solve units output.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@ Pint Changelog
 - UnitsContainer returns false if other is str and cannnot be parsed
   (Issue #1179, thanks rfrowe)
 - Add Github Actions CI. (Issue #1236)
+- Fix numpy.linalg.solve unit output. (Issue #1246)
 
 0.16.1 (2020-09-22)
 -------------------

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -449,10 +449,13 @@ class TestNumpyMathematicalFunctions(TestNumpyMethods):
 
     @helpers.requires_array_function_protocol()
     def test_solve(self):
-        helpers.assert_quantity_almost_equal(
-            np.linalg.solve(self.q, [[3], [7]] * self.ureg.s),
-            self.Q_([[1], [1]], "m / s"),
-        )
+        A = self.q
+        b = [[3], [7]] * self.ureg.s
+        x = np.linalg.solve(A, b)
+
+        helpers.assert_quantity_almost_equal(x, self.Q_([[1], [1]], "s / m"))
+
+        helpers.assert_quantity_almost_equal(np.dot(A, x), b)
 
     # Arithmetic operations
     def test_addition_with_scalar(self):


### PR DESCRIPTION
Update get_op_output_unit with new type invdiv.
It outputs the product of the following units over the first one in the args list.

Update tests with values & np.dot(A, x) == b.
Where x = np.linalg.solve(A, b) just like numpy documentation https://numpy.org/doc/stable/reference/generated/numpy.linalg.solve.html

- [x] Closes #1246
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
