### PR TITLE
Add np.linalg.norm implementation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,12 +9,13 @@ Pint Changelog
 - Fix comparisons between Quantities and Measurements.
    (Issue #1134, thanks lewisamarshall)
 - Implemented benchmarks based on airspeed velocity.
-- Fix tolist function with scalar ndarray. 
+- Fix tolist function with scalar ndarray.
   (Issue #1195, thanks jules-ch)
 - UnitsContainer returns false if other is str and cannnot be parsed
   (Issue #1179, thanks rfrowe)
 - Add Github Actions CI. (Issue #1236)
 - Fix numpy.linalg.solve unit output. (Issue #1246)
+- Add numpy.linalg.norm implementation. (Issue #1250)
 
 
 0.16.1 (2020-09-22)

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -879,7 +879,15 @@ for func_str in [
     implement_func("function", func_str, input_units=None, output_unit=None)
 
 # Handle functions with output unit defined by operation
-for func_str in ["std", "nanstd", "sum", "nansum", "cumsum", "nancumsum"]:
+for func_str in [
+    "std",
+    "nanstd",
+    "sum",
+    "nansum",
+    "cumsum",
+    "nancumsum",
+    "linalg.norm",
+]:
     implement_func("function", func_str, input_units=None, output_unit="sum")
 for func_str in ["cross", "trapz", "dot"]:
     implement_func("function", func_str, input_units=None, output_unit="mul")

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -817,6 +817,12 @@ class TestIssues(QuantityTestCase):
             np.array((0.04, 0.09)),
         )
 
+    @helpers.requires_numpy
+    def test_issue_1250(self):
+        q = np.array([[3, 4], [5, 12], [8, 15]]) * self.ureg.m
+        expected = np.array([5, 13, 17]) * self.ureg.m
+        helpers.assert_quantity_equal(np.linalg.norm(q, axis=1), expected)
+
 
 if np is not None:
 

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1308,6 +1308,12 @@ class TestNumpyUnclassified(TestNumpyMethods):
             [1, 3] * self.ureg.m,
         )
 
+    @helpers.requires_array_function_protocol()
+    def test_linalg_norm(self):
+        q = np.array([[3, 5, 8], [4, 12, 15]]) * self.ureg.m
+        expected = [5, 13, 17] * self.ureg.m
+        helpers.assert_quantity_equal(np.linalg.norm(q, axis=0), expected)
+
 
 @pytest.mark.skip
 class TestBitTwiddlingUfuncs(TestUFuncs):


### PR DESCRIPTION
- [x] Closes #1250 
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

Doc entry in _docs/numpy.ipynb_ already covered by print statement here:
```python
from pint.numpy_func import HANDLED_FUNCTIONS
print(sorted(list(HANDLED_FUNCTIONS)))
``` 