### PR TITLE
support numpy.lib.stride_tricks.sliding_window_view

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Pint Changelog
   (Issue #1179, thanks rfrowe)
 - Add Github Actions CI. (Issue #1236)
 - Fix numpy.linalg.solve unit output. (Issue #1246)
+- Support numpy.lib.stride_tricks.sliding_window_view. (Issue #1255)
 
 
 0.16.1 (2020-09-22)

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -717,7 +717,13 @@ def implement_consistent_units_by_argument(func_str, unit_arguments, wrap_output
     if np is None:
         return
 
-    func = getattr(np, func_str, None)
+    if "." not in func_str:
+        func = getattr(np, func_str, None)
+    else:
+        func = np
+        for part in func_str.split("."):
+            func = getattr(func, part)
+
     # if NumPy does not implement it, do not implement it either
     if func is None:
         return
@@ -790,6 +796,7 @@ for func_str, unit_arguments, wrap_output in [
     ("compress", "a", True),
     ("linspace", ["start", "stop"], True),
     ("tile", "A", True),
+    ("lib.stride_tricks.sliding_window_view", "x", True),
     ("rot90", "m", True),
     ("insert", ["arr", "values"], True),
     ("resize", "a", True),

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -724,7 +724,7 @@ def implement_consistent_units_by_argument(func_str, unit_arguments, wrap_output
         module = np
         for part in parts[:-1]:
             module = getattr(module, part, None)
-        func = getattr(module, part[-1], None)
+        func = getattr(module, parts[-1], None)
 
     # if NumPy does not implement it, do not implement it either
     if func is None:

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -720,9 +720,11 @@ def implement_consistent_units_by_argument(func_str, unit_arguments, wrap_output
     if "." not in func_str:
         func = getattr(np, func_str, None)
     else:
-        func = np
-        for part in func_str.split("."):
-            func = getattr(func, part)
+        parts = func_str.split(".")
+        module = np
+        for part in parts[:-1]:
+            module = getattr(module, part, None)
+        func = getattr(module, part[-1], None)
 
     # if NumPy does not implement it, do not implement it either
     if func is None:

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1158,7 +1158,10 @@ class TestNumpyUnclassified(TestNumpyMethods):
     def test_sliding_window_view(self):
         q = self.Q_([[1, 2, 2, 1], [2, 1, 1, 2], [1, 2, 2, 1]], "m")
         actual = np.lib.stride_tricks.sliding_window_view(q, window_shape=(3, 3))
-        expected = self.Q_([[[[1, 2, 2], [2, 1, 1], [1, 2, 2]], [[2, 2, 1], [1, 1, 2], [2, 2, 1]]]], "m")
+        expected = self.Q_(
+            [[[[1, 2, 2], [2, 1, 1], [1, 2, 2]], [[2, 2, 1], [1, 1, 2], [2, 2, 1]]]],
+            "m",
+        )
         helpers.assert_quantity_equal(actual, expected)
 
     @helpers.requires_array_function_protocol()

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1155,6 +1155,13 @@ class TestNumpyUnclassified(TestNumpyMethods):
         )
 
     @helpers.requires_array_function_protocol()
+    def test_sliding_window_view(self):
+        q = self.Q_([[1, 2, 2, 1], [2, 1, 1, 2], [1, 2, 2, 1]], "m")
+        actual = np.lib.stride_tricks.sliding_window_view(q, window_shape=(3, 3))
+        expected = self.Q_([[[[1, 2, 2], [2, 1, 1], [1, 2, 2]], [[2, 2, 1], [1, 1, 2], [2, 2, 1]]]], "m")
+        helpers.assert_quantity_equal(actual, expected)
+
+    @helpers.requires_array_function_protocol()
     def test_rot90(self):
         helpers.assert_quantity_equal(
             np.rot90(self.q), np.array([[2, 4], [1, 3]]) * self.ureg.m

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1154,6 +1154,7 @@ class TestNumpyUnclassified(TestNumpyMethods):
             np.tile(self.q, 2), np.array([[1, 2, 1, 2], [3, 4, 3, 4]]) * self.ureg.m
         )
 
+    @helpers.requires_numpy_at_least("1.20")
     @helpers.requires_array_function_protocol()
     def test_sliding_window_view(self):
         q = self.Q_([[1, 2, 2, 1], [2, 1, 1, 2], [1, 2, 2, 1]], "m")


### PR DESCRIPTION
`numpy` version 1.20 introduced a generic sliding window function which is dispatched using `__array_function__`.

- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate (automatic)
- [x] Added an entry to the CHANGES file

cc @jthielen 