### PR TITLE
pint typing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,19 @@
 [run]
 omit = pint/testsuite/*
 
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+    AbstractMethodError
+
+    # Don't complain if non-runnable code isn't run:
+    if TYPE_CHECKING:

--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ Pint Changelog
 
 - pint no longer supports Python 3.6
 - Minimum Numpy version supported is 1.17+
+- Add supports for type hints for Quantity class. Quantity is now a Generic (PEP560).
+- Add support for [PEP561](https://www.python.org/dev/peps/pep-0561/) (Package Type information)
 
 
 0.17 (2021-03-22)

--- a/pint/_typing.py
+++ b/pint/_typing.py
@@ -1,0 +1,18 @@
+from typing import TYPE_CHECKING, Any, Callable, Tuple, TypeVar, Union
+
+if TYPE_CHECKING:
+    from .quantity import Quantity
+    from .unit import Unit
+    from .util import UnitsContainer
+
+UnitLike = Union[str, "UnitsContainer", "Unit"]
+
+QuantityOrUnitLike = Union["Quantity", UnitLike]
+
+Shape = Tuple[int, ...]
+
+_MagnitudeType = TypeVar("_MagnitudeType")
+S = TypeVar("S")
+
+FuncType = Callable[..., Any]
+F = TypeVar("F", bound=FuncType)

--- a/pint/definitions.py
+++ b/pint/definitions.py
@@ -8,9 +8,12 @@
     :license: BSD, see LICENSE for more details.
 """
 
-from collections import namedtuple
+from __future__ import annotations
 
-from .converters import LogarithmicConverter, OffsetConverter, ScaleConverter
+from collections import namedtuple
+from typing import Callable, Iterable, Optional, Union
+
+from .converters import Converter, LogarithmicConverter, OffsetConverter, ScaleConverter
 from .errors import DefinitionSyntaxError
 from .util import ParserHelper, UnitsContainer, _is_dim
 
@@ -42,7 +45,7 @@ class PreprocessedDefinition(
     """
 
     @classmethod
-    def from_string(cls, definition):
+    def from_string(cls, definition: str) -> PreprocessedDefinition:
         name, definition = definition.split("=", 1)
         name = name.strip()
 
@@ -64,7 +67,7 @@ class _NotNumeric(Exception):
         self.value = value
 
 
-def numeric_parse(s, non_int_type=float):
+def numeric_parse(s: str, non_int_type: type = float):
     """Try parse a string into a number (without using eval).
 
     Parameters
@@ -103,7 +106,13 @@ class Definition:
     converter : callable or Converter or None
     """
 
-    def __init__(self, name, symbol, aliases, converter):
+    def __init__(
+        self,
+        name: str,
+        symbol: Optional[str],
+        aliases: Iterable[str],
+        converter: Optional[Union[Callable, Converter]],
+    ):
 
         if isinstance(converter, str):
             raise TypeError(
@@ -112,19 +121,21 @@ class Definition:
 
         self._name = name
         self._symbol = symbol
-        self._aliases = aliases
+        self._aliases = tuple(aliases)
         self._converter = converter
 
     @property
-    def is_multiplicative(self):
+    def is_multiplicative(self) -> bool:
         return self._converter.is_multiplicative
 
     @property
-    def is_logarithmic(self):
+    def is_logarithmic(self) -> bool:
         return self._converter.is_logarithmic
 
     @classmethod
-    def from_string(cls, definition, non_int_type=float):
+    def from_string(
+        cls, definition: Union[str, PreprocessedDefinition], non_int_type: type = float
+    ) -> "Definition":
         """Parse a definition.
 
         Parameters
@@ -150,30 +161,30 @@ class Definition:
             return UnitDefinition.from_string(definition, non_int_type)
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @property
-    def symbol(self):
+    def symbol(self) -> str:
         return self._symbol or self._name
 
     @property
-    def has_symbol(self):
+    def has_symbol(self) -> bool:
         return bool(self._symbol)
 
     @property
-    def aliases(self):
+    def aliases(self) -> Iterable[str]:
         return self._aliases
 
-    def add_aliases(self, *alias):
+    def add_aliases(self, *alias: str) -> None:
         alias = tuple(a for a in alias if a not in self._aliases)
         self._aliases = self._aliases + alias
 
     @property
-    def converter(self):
+    def converter(self) -> Converter:
         return self._converter
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 
@@ -188,7 +199,9 @@ class PrefixDefinition(Definition):
     """
 
     @classmethod
-    def from_string(cls, definition, non_int_type=float):
+    def from_string(
+        cls, definition: Union[str, PreprocessedDefinition], non_int_type: type = float
+    ) -> "PrefixDefinition":
         if isinstance(definition, str):
             definition = PreprocessedDefinition.from_string(definition)
 
@@ -226,14 +239,24 @@ class UnitDefinition(Definition):
 
     """
 
-    def __init__(self, name, symbol, aliases, converter, reference=None, is_base=False):
+    def __init__(
+        self,
+        name: str,
+        symbol: Optional[str],
+        aliases: Iterable[str],
+        converter: Converter,
+        reference: Optional[UnitsContainer] = None,
+        is_base: bool = False,
+    ) -> None:
         self.reference = reference
         self.is_base = is_base
 
         super().__init__(name, symbol, aliases, converter)
 
     @classmethod
-    def from_string(cls, definition, non_int_type=float):
+    def from_string(
+        cls, definition: Union[str, PreprocessedDefinition], non_int_type: type = float
+    ) -> "UnitDefinition":
         if isinstance(definition, str):
             definition = PreprocessedDefinition.from_string(definition)
 
@@ -305,14 +328,24 @@ class DimensionDefinition(Definition):
         [density] = [mass] / [volume]
     """
 
-    def __init__(self, name, symbol, aliases, converter, reference=None, is_base=False):
+    def __init__(
+        self,
+        name: str,
+        symbol: Optional[str],
+        aliases: Iterable[str],
+        converter: Optional[Converter],
+        reference: Optional[UnitsContainer] = None,
+        is_base: bool = False,
+    ) -> None:
         self.reference = reference
         self.is_base = is_base
 
         super().__init__(name, symbol, aliases, converter=None)
 
     @classmethod
-    def from_string(cls, definition, non_int_type=float):
+    def from_string(
+        cls, definition: Union[str, PreprocessedDefinition], non_int_type: type = float
+    ) -> "DimensionDefinition":
         if isinstance(definition, str):
             definition = PreprocessedDefinition.from_string(definition)
 
@@ -350,11 +383,13 @@ class AliasDefinition(Definition):
         @alias meter = my_meter
     """
 
-    def __init__(self, name, aliases):
+    def __init__(self, name: str, aliases: Iterable[str]) -> None:
         super().__init__(name=name, symbol=None, aliases=aliases, converter=None)
 
     @classmethod
-    def from_string(cls, definition, non_int_type=float):
+    def from_string(
+        cls, definition: Union[str, PreprocessedDefinition], non_int_type: type = float
+    ) -> AliasDefinition:
 
         if isinstance(definition, str):
             definition = PreprocessedDefinition.from_string(definition)

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -9,6 +9,7 @@
 """
 
 import re
+from typing import Dict
 
 from .babel_names import _babel_lengths, _babel_units
 from .compat import babel_parse
@@ -71,7 +72,7 @@ def _pretty_fmt_exponent(num):
 
 #: _FORMATS maps format specifications to the corresponding argument set to
 #: formatter().
-_FORMATS = {
+_FORMATS: Dict[str, dict] = {
     "P": {  # Pretty format.
         "as_ratio": True,
         "single_denominator": False,

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -6,6 +6,8 @@
     :license: BSD, see LICENSE for more details.
 """
 
+from __future__ import annotations
+
 import bisect
 import contextlib
 import copy
@@ -17,9 +19,27 @@ import numbers
 import operator
 import re
 import warnings
-from typing import List
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
 
+from ._typing import S, Shape, UnitLike, _MagnitudeType
 from .compat import (
+    HAS_NUMPY,
     _to_magnitude,
     babel_parse,
     compute,
@@ -65,6 +85,14 @@ from .util import (
     logger,
     to_units_container,
 )
+
+if TYPE_CHECKING:
+    from . import Context, Unit
+    from .registry import BaseRegistry
+    from .unit import UnitsContainer as UnitsContainerT
+
+    if HAS_NUMPY:
+        import numpy as np  # noqa
 
 
 class _Exception(Exception):  # pragma: no cover
@@ -153,7 +181,11 @@ def printoptions(*args, **kwargs):
         np.set_printoptions(**opts)
 
 
-class Quantity(PrettyIPython, SharedRegistryObject):
+# Workaround to bypass dynamically generated Quantity with overload method
+Magnitude = TypeVar("Magnitude")
+
+
+class Quantity(PrettyIPython, SharedRegistryObject, Generic[_MagnitudeType]):
     """Implements a class to describe a physical quantity:
     the product of a numerical value and a unit of measurement.
 
@@ -170,21 +202,22 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     """
 
     #: Default formatting string.
-    default_format = ""
+    default_format: str = ""
+    _magnitude: _MagnitudeType
 
     @property
-    def force_ndarray(self):
+    def force_ndarray(self) -> bool:
         return self._REGISTRY.force_ndarray
 
     @property
-    def force_ndarray_like(self):
+    def force_ndarray_like(self) -> bool:
         return self._REGISTRY.force_ndarray_like
 
     @property
-    def UnitsContainer(self):
+    def UnitsContainer(self) -> Callable[..., UnitsContainerT]:
         return self._REGISTRY.UnitsContainer
 
-    def __reduce__(self):
+    def __reduce__(self) -> tuple:
         """Allow pickling quantities. Since UnitRegistries are not pickled, upon
         unpickling the new object is always attached to the application registry.
         """
@@ -193,6 +226,30 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         # Note: type(self) would be a mistake as subclasses built by
         # build_quantity_class can't be pickled
         return _unpickle_quantity, (Quantity, self.magnitude, self._units)
+
+    @overload
+    def __new__(
+        cls, value: str, units: Optional[UnitLike] = None
+    ) -> Quantity[Magnitude]:
+        ...
+
+    @overload
+    def __new__(  # type: ignore[misc]
+        cls, value: Sequence, units: Optional[UnitLike] = None
+    ) -> Quantity[np.ndarray]:
+        ...
+
+    @overload
+    def __new__(
+        cls, value: Quantity[Magnitude], units: Optional[UnitLike] = None
+    ) -> Quantity[Magnitude]:
+        ...
+
+    @overload
+    def __new__(
+        cls, value: Magnitude, units: Optional[UnitLike] = None
+    ) -> Quantity[Magnitude]:
+        ...
 
     def __new__(cls, value, units=None):
         if is_upcast_type(type(value)):
@@ -250,7 +307,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     def debug_used(self):
         return self.__used
 
-    def __iter__(self):
+    def __iter__(self: Quantity[Iterable[S]]) -> Iterator[S]:
         # Make sure that, if self.magnitude is not iterable, we raise TypeError as soon
         # as one calls iter(self) without waiting for the first element to be drawn from
         # the iterator
@@ -262,34 +319,34 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         return it_outer()
 
-    def __copy__(self):
+    def __copy__(self) -> Quantity[_MagnitudeType]:
         ret = self.__class__(copy.copy(self._magnitude), self._units)
         ret.__used = self.__used
         return ret
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo) -> Quantity[_MagnitudeType]:
         ret = self.__class__(
             copy.deepcopy(self._magnitude, memo), copy.deepcopy(self._units, memo)
         )
         ret.__used = self.__used
         return ret
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self._REGISTRY.fmt_locale is not None:
             return self.format_babel()
 
         return format(self)
 
-    def __bytes__(self):
+    def __bytes__(self) -> bytes:
         return str(self).encode(locale.getpreferredencoding())
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if isinstance(self._magnitude, float):
             return f"<Quantity({self._magnitude:.9}, '{self._units}')>"
         else:
             return f"<Quantity({self._magnitude}, '{self._units}')>"
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         self_base = self.to_base_units()
         if self_base.dimensionless:
             return hash(self_base.magnitude)
@@ -298,7 +355,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
     _exp_pattern = re.compile(r"([0-9]\.?[0-9]*)e(-?)\+?0*([0-9]+)")
 
-    def __format__(self, spec):
+    def __format__(self, spec: str) -> str:
         if self._REGISTRY.fmt_locale is not None:
             return self.format_babel(spec)
 
@@ -410,7 +467,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
             p.text(" ")
             p.pretty(self.units)
 
-    def format_babel(self, spec="", **kwspec):
+    def format_babel(self, spec: str = "", **kwspec: Any) -> str:
         spec = spec or self.default_format
 
         # standard cases
@@ -435,16 +492,16 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         ).replace("\n", "")
 
     @property
-    def magnitude(self):
+    def magnitude(self) -> _MagnitudeType:
         """Quantity's magnitude. Long form for `m`"""
         return self._magnitude
 
     @property
-    def m(self):
+    def m(self) -> _MagnitudeType:
         """Quantity's magnitude. Short form for `magnitude`"""
         return self._magnitude
 
-    def m_as(self, units):
+    def m_as(self, units) -> _MagnitudeType:
         """Quantity's magnitude expressed in particular units.
 
         Parameters
@@ -459,31 +516,31 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return self.to(units).magnitude
 
     @property
-    def units(self):
+    def units(self) -> "Unit":
         """Quantity's units. Long form for `u`"""
         return self._REGISTRY.Unit(self._units)
 
     @property
-    def u(self):
+    def u(self) -> "Unit":
         """Quantity's units. Short form for `units`"""
         return self._REGISTRY.Unit(self._units)
 
     @property
-    def unitless(self):
+    def unitless(self) -> bool:
         """ """
         return not bool(self.to_root_units()._units)
 
     @property
-    def dimensionless(self):
+    def dimensionless(self) -> bool:
         """ """
         tmp = self.to_root_units()
 
         return not bool(tmp.dimensionality)
 
-    _dimensionality = None
+    _dimensionality: Optional[UnitsContainerT] = None
 
     @property
-    def dimensionality(self):
+    def dimensionality(self) -> UnitsContainerT:
         """
         Returns
         -------
@@ -495,12 +552,12 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         return self._dimensionality
 
-    def check(self, dimension):
+    def check(self, dimension: UnitLike) -> bool:
         """Return true if the quantity's dimension matches passed dimension."""
         return self.dimensionality == self._REGISTRY.get_dimensionality(dimension)
 
     @classmethod
-    def from_list(cls, quant_list, units=None):
+    def from_list(cls, quant_list: List[Quantity], units=None) -> Quantity[np.ndarray]:
         """Transforms a list of Quantities into an numpy.array quantity.
         If no units are specified, the unit of the first element will be used.
         Same as from_sequence.
@@ -522,7 +579,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return cls.from_sequence(quant_list, units=units)
 
     @classmethod
-    def from_sequence(cls, seq, units=None):
+    def from_sequence(cls, seq: Sequence[Quantity], units=None) -> Quantity[np.ndarray]:
         """Transforms a sequence of Quantities into an numpy.array quantity.
         If no units are specified, the unit of the first element will be used.
 
@@ -560,7 +617,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     def from_tuple(cls, tup):
         return cls(tup[0], cls._REGISTRY.UnitsContainer(tup[1]))
 
-    def to_tuple(self):
+    def to_tuple(self) -> Tuple[_MagnitudeType, Tuple[Tuple[str]]]:
         return self.m, tuple(self._units.items())
 
     def compatible_units(self, *contexts):
@@ -570,7 +627,9 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         return self._REGISTRY.get_compatible_units(self._units)
 
-    def is_compatible_with(self, other, *contexts, **ctx_kwargs):
+    def is_compatible_with(
+        self, other: Any, *contexts: Union[str, Context], **ctx_kwargs: Any
+    ) -> bool:
         """check if the other object is compatible
 
         Parameters
@@ -623,7 +682,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
             inplace=is_duck_array_type(type(self._magnitude)),
         )
 
-    def ito(self, other=None, *contexts, **ctx_kwargs):
+    def ito(self, other=None, *contexts, **ctx_kwargs) -> None:
         """Inplace rescale to different units.
 
         Parameters
@@ -642,7 +701,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         return None
 
-    def to(self, other=None, *contexts, **ctx_kwargs):
+    def to(self, other=None, *contexts, **ctx_kwargs) -> Quantity[_MagnitudeType]:
         """Return Quantity rescaled to different units.
 
         Parameters
@@ -664,7 +723,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         return self.__class__(magnitude, other)
 
-    def ito_root_units(self):
+    def ito_root_units(self) -> None:
         """Return Quantity rescaled to root units."""
 
         _, other = self._REGISTRY._get_root_units(self._units)
@@ -674,7 +733,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         return None
 
-    def to_root_units(self):
+    def to_root_units(self) -> Quantity[_MagnitudeType]:
         """Return Quantity rescaled to root units."""
 
         _, other = self._REGISTRY._get_root_units(self._units)
@@ -683,7 +742,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         return self.__class__(magnitude, other)
 
-    def ito_base_units(self):
+    def ito_base_units(self) -> None:
         """Return Quantity rescaled to base units."""
 
         _, other = self._REGISTRY._get_base_units(self._units)
@@ -693,7 +752,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         return None
 
-    def to_base_units(self):
+    def to_base_units(self) -> Quantity[_MagnitudeType]:
         """Return Quantity rescaled to base units."""
 
         _, other = self._REGISTRY._get_base_units(self._units)
@@ -702,7 +761,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         return self.__class__(magnitude, other)
 
-    def ito_reduced_units(self):
+    def ito_reduced_units(self) -> None:
         """Return Quantity scaled in place to reduced units, i.e. one unit per
         dimension. This will not reduce compound units (e.g., 'J/kg' will not
         be reduced to m**2/s**2), nor can it make use of contexts at this time.
@@ -730,7 +789,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         return self.ito(newunits)
 
-    def to_reduced_units(self):
+    def to_reduced_units(self) -> Quantity[_MagnitudeType]:
         """Return Quantity scaled in place to reduced units, i.e. one unit per
         dimension. This will not reduce compound units (intentionally), nor
         can it make use of contexts at this time.
@@ -741,7 +800,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         newq.ito_reduced_units()
         return newq
 
-    def to_compact(self, unit=None):
+    def to_compact(self, unit=None) -> Quantity[_MagnitudeType]:
         """ "Return Quantity rescaled to compact, human-readable units.
 
         To get output in terms of a different unit, use the unit parameter.
@@ -775,7 +834,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         ):
             return self
 
-        SI_prefixes = {}
+        SI_prefixes: Dict[int, str] = {}
         for prefix in self._REGISTRY._prefixes.values():
             try:
                 scale = prefix.converter.scale
@@ -786,9 +845,9 @@ class Quantity(PrettyIPython, SharedRegistryObject):
             except Exception:
                 SI_prefixes[0] = ""
 
-        SI_prefixes = sorted(SI_prefixes.items())
-        SI_powers = [item[0] for item in SI_prefixes]
-        SI_bases = [item[1] for item in SI_prefixes]
+        SI_prefixes_list = sorted(SI_prefixes.items())
+        SI_powers = [item[0] for item in SI_prefixes_list]
+        SI_bases = [item[1] for item in SI_prefixes_list]
 
         if unit is None:
             unit = infer_base_unit(self)
@@ -817,25 +876,25 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         if index >= len(SI_bases):
             index = -1
 
-        prefix = SI_bases[index]
+        prefix_str = SI_bases[index]
 
-        new_unit_str = prefix + unit_str
+        new_unit_str = prefix_str + unit_str
         new_unit_container = q_base._units.rename(unit_str, new_unit_str)
 
         return self.to(new_unit_container)
 
     # Mathematical operations
-    def __int__(self):
+    def __int__(self) -> int:
         if self.dimensionless:
             return int(self._convert_magnitude_not_inplace(UnitsContainer()))
         raise DimensionalityError(self._units, "dimensionless")
 
-    def __float__(self):
+    def __float__(self) -> float:
         if self.dimensionless:
             return float(self._convert_magnitude_not_inplace(UnitsContainer()))
         raise DimensionalityError(self._units, "dimensionless")
 
-    def __complex__(self):
+    def __complex__(self) -> complex:
         if self.dimensionless:
             return complex(self._convert_magnitude_not_inplace(UnitsContainer()))
         raise DimensionalityError(self._units, "dimensionless")
@@ -1065,6 +1124,14 @@ class Quantity(PrettyIPython, SharedRegistryObject):
             raise OffsetUnitCalculusError(self._units, other._units)
 
         return self.__class__(magnitude, units)
+
+    @overload
+    def __iadd__(self, other: datetime.datetime) -> datetime.timedelta:  # type: ignore[misc]
+        ...
+
+    @overload
+    def __iadd__(self, other) -> Quantity[_MagnitudeType]:
+        ...
 
     def __iadd__(self, other):
         if isinstance(other, datetime.datetime):
@@ -1431,7 +1498,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
             return self
 
     @check_implemented
-    def __pow__(self, other):
+    def __pow__(self, other) -> Quantity[_MagnitudeType]:
         try:
             _to_magnitude(other, self.force_ndarray, self.force_ndarray_like)
         except PintTypeError:
@@ -1496,7 +1563,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
             return self.__class__(magnitude, units)
 
     @check_implemented
-    def __rpow__(self, other):
+    def __rpow__(self, other) -> Quantity[_MagnitudeType]:
         try:
             _to_magnitude(other, self.force_ndarray, self.force_ndarray_like)
         except PintTypeError:
@@ -1509,16 +1576,16 @@ class Quantity(PrettyIPython, SharedRegistryObject):
             new_self = self.to_root_units()
             return other ** new_self._magnitude
 
-    def __abs__(self):
+    def __abs__(self) -> Quantity[_MagnitudeType]:
         return self.__class__(abs(self._magnitude), self._units)
 
-    def __round__(self, ndigits=0):
+    def __round__(self, ndigits: Optional[int] = 0) -> Quantity[int]:
         return self.__class__(round(self._magnitude, ndigits=ndigits), self._units)
 
-    def __pos__(self):
+    def __pos__(self) -> Quantity[_MagnitudeType]:
         return self.__class__(operator.pos(self._magnitude), self._units)
 
-    def __neg__(self):
+    def __neg__(self) -> Quantity[_MagnitudeType]:
         return self.__class__(operator.neg(self._magnitude), self._units)
 
     @check_implemented
@@ -1627,7 +1694,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     __ge__ = lambda self, other: self.compare(other, op=operator.ge)
     __gt__ = lambda self, other: self.compare(other, op=operator.gt)
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         # Only cast when non-ambiguous (when multiplicative unit)
         if self._is_multiplicative:
             return bool(self._magnitude)
@@ -1695,7 +1762,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         else:
             return value
 
-    def __array__(self, t=None):
+    def __array__(self, t=None) -> np.ndarray:
         warnings.warn(
             "The unit of the quantity is stripped when downcasting to ndarray.",
             UnitStrippedWarning,
@@ -1722,11 +1789,11 @@ class Quantity(PrettyIPython, SharedRegistryObject):
                 raise DimensionalityError("dimensionless", self._units)
         return self.__class__(self.magnitude.clip(min, max, out, **kwargs), self._units)
 
-    def fill(self, value):
+    def fill(self: Quantity[np.ndarray], value) -> None:
         self._units = value._units
         return self.magnitude.fill(value.magnitude)
 
-    def put(self, indices, values, mode="raise"):
+    def put(self: Quantity[np.ndarray], indices, values, mode="raise") -> None:
         if isinstance(values, self.__class__):
             values = values.to(self).magnitude
         elif self.dimensionless:
@@ -1736,11 +1803,11 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         self.magnitude.put(indices, values, mode)
 
     @property
-    def real(self):
+    def real(self) -> Quantity[_MagnitudeType]:
         return self.__class__(self._magnitude.real, self._units)
 
     @property
-    def imag(self):
+    def imag(self) -> Quantity[_MagnitudeType]:
         return self.__class__(self._magnitude.imag, self._units)
 
     @property
@@ -1753,7 +1820,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
             yield self.__class__(v, self._units)
 
     @property
-    def shape(self):
+    def shape(self) -> Shape:
         return self._magnitude.shape
 
     @shape.setter
@@ -1791,10 +1858,10 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         self.ito(to_units)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._magnitude)
 
-    def __getattr__(self, item):
+    def __getattr__(self, item) -> Any:
         if item.startswith("__array_"):
             # Handle array protocol attributes other than `__array__`
             raise AttributeError(f"Array protocol attribute {item} not available.")
@@ -1944,7 +2011,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
             self._get_unit_definition(d).reference == offset_unit_dim for d in deltas
         )
 
-    def _ok_for_muldiv(self, no_offset_units=None):
+    def _ok_for_muldiv(self, no_offset_units=None) -> bool:
         """Checks if Quantity object can be multiplied or divided"""
 
         is_ok = True
@@ -1964,7 +2031,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
                 is_ok = False
         return is_ok
 
-    def to_timedelta(self):
+    def to_timedelta(self: Quantity[float]) -> datetime.timedelta:
         return datetime.timedelta(microseconds=self.to("microseconds").magnitude)
 
     # Dask.array.Array ducking
@@ -2058,7 +2125,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 _Quantity = Quantity
 
 
-def build_quantity_class(registry):
+def build_quantity_class(registry: BaseRegistry) -> Type[Quantity]:
     class Quantity(_Quantity):
         _REGISTRY = registry
 

--- a/pint/unit.py
+++ b/pint/unit.py
@@ -8,23 +8,30 @@
     :license: BSD, see LICENSE for more details.
 """
 
+from __future__ import annotations
+
 import copy
 import locale
 import operator
 from numbers import Number
+from typing import TYPE_CHECKING, Any, Type, Union
 
+from ._typing import UnitLike
 from .compat import NUMERIC_TYPES, babel_parse, is_upcast_type
 from .definitions import UnitDefinition
 from .errors import DimensionalityError
 from .formatting import siunitx_format_unit
 from .util import PrettyIPython, SharedRegistryObject, UnitsContainer
 
+if TYPE_CHECKING:
+    from .context import Context
+
 
 class Unit(PrettyIPython, SharedRegistryObject):
     """Implements a class to describe a unit supporting math operations."""
 
     #: Default formatting string.
-    default_format = ""
+    default_format: str = ""
 
     def __reduce__(self):
         # See notes in Quantity.__reduce__
@@ -32,7 +39,7 @@ class Unit(PrettyIPython, SharedRegistryObject):
 
         return _unpickle_unit, (Unit, self._units)
 
-    def __init__(self, units):
+    def __init__(self, units: UnitLike) -> None:
         super().__init__()
         if isinstance(units, (UnitsContainer, UnitDefinition)):
             self._units = units
@@ -50,29 +57,29 @@ class Unit(PrettyIPython, SharedRegistryObject):
         self.__handling = None
 
     @property
-    def debug_used(self):
+    def debug_used(self) -> Any:
         return self.__used
 
-    def __copy__(self):
+    def __copy__(self) -> Unit:
         ret = self.__class__(self._units)
         ret.__used = self.__used
         return ret
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo) -> Unit:
         ret = self.__class__(copy.deepcopy(self._units, memo))
         ret.__used = self.__used
         return ret
 
-    def __str__(self):
+    def __str__(self) -> str:
         return format(self)
 
-    def __bytes__(self):
+    def __bytes__(self) -> bytes:
         return str(self).encode(locale.getpreferredencoding())
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<Unit('{}')>".format(self._units)
 
-    def __format__(self, spec):
+    def __format__(self, spec) -> str:
         spec = spec or self.default_format
         # special cases
         if "Lx" in spec:  # the LaTeX siunitx code
@@ -93,7 +100,7 @@ class Unit(PrettyIPython, SharedRegistryObject):
 
         return format(units, spec)
 
-    def format_babel(self, spec="", locale=None, **kwspec):
+    def format_babel(self, spec="", locale=None, **kwspec: Any) -> str:
         spec = spec or self.default_format
 
         if "~" in spec:
@@ -119,12 +126,12 @@ class Unit(PrettyIPython, SharedRegistryObject):
         return units.format_babel(spec, **kwspec)
 
     @property
-    def dimensionless(self):
+    def dimensionless(self) -> bool:
         """Return True if the Unit is dimensionless; False otherwise."""
         return not bool(self.dimensionality)
 
     @property
-    def dimensionality(self):
+    def dimensionality(self) -> UnitsContainer:
         """
         Returns
         -------
@@ -146,7 +153,9 @@ class Unit(PrettyIPython, SharedRegistryObject):
 
         return self._REGISTRY.get_compatible_units(self)
 
-    def is_compatible_with(self, other, *contexts, **ctx_kwargs):
+    def is_compatible_with(
+        self, other: Any, *contexts: Union[str, Context], **ctx_kwargs: Any
+    ) -> bool:
         """check if the other object is compatible
 
         Parameters
@@ -218,7 +227,7 @@ class Unit(PrettyIPython, SharedRegistryObject):
     __div__ = __truediv__
     __rdiv__ = __rtruediv__
 
-    def __pow__(self, other):
+    def __pow__(self, other) -> "Unit":
         if isinstance(other, NUMERIC_TYPES):
             return self.__class__(self._units ** other)
 
@@ -226,10 +235,10 @@ class Unit(PrettyIPython, SharedRegistryObject):
             mess = "Cannot power Unit by {}".format(type(other))
             raise TypeError(mess)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return self._units.__hash__()
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         # We compare to the base class of Unit because each Unit class is
         # unique.
         if self._check(other):
@@ -244,10 +253,10 @@ class Unit(PrettyIPython, SharedRegistryObject):
         else:
             return self._units == other
 
-    def __ne__(self, other):
+    def __ne__(self, other) -> bool:
         return not (self == other)
 
-    def compare(self, other, op):
+    def compare(self, other, op) -> bool:
         self_q = self._REGISTRY.Quantity(1, self)
 
         if isinstance(other, NUMERIC_TYPES):
@@ -262,13 +271,13 @@ class Unit(PrettyIPython, SharedRegistryObject):
     __ge__ = lambda self, other: self.compare(other, op=operator.ge)
     __gt__ = lambda self, other: self.compare(other, op=operator.gt)
 
-    def __int__(self):
+    def __int__(self) -> int:
         return int(self._REGISTRY.Quantity(1, self._units))
 
-    def __float__(self):
+    def __float__(self) -> float:
         return float(self._REGISTRY.Quantity(1, self._units))
 
-    def __complex__(self):
+    def __complex__(self) -> complex:
         return complex(self._REGISTRY.Quantity(1, self._units))
 
     __array_priority__ = 17
@@ -361,7 +370,7 @@ class Unit(PrettyIPython, SharedRegistryObject):
 _Unit = Unit
 
 
-def build_unit_class(registry):
+def build_unit_class(registry) -> Type[Unit]:
     class Unit(_Unit):
         _REGISTRY = registry
 

--- a/pint/util.py
+++ b/pint/util.py
@@ -8,6 +8,8 @@
     :license: BSD, see LICENSE for more details.
 """
 
+from __future__ import annotations
+
 import logging
 import math
 import operator
@@ -18,11 +20,18 @@ from functools import lru_cache, partial
 from logging import NullHandler
 from numbers import Number
 from token import NAME, NUMBER
+from typing import TYPE_CHECKING, ClassVar, Optional, Union
 
 from .compat import NUMERIC_TYPES, tokenizer
 from .errors import DefinitionSyntaxError
 from .formatting import format_unit
 from .pint_eval import build_eval_tree
+
+if TYPE_CHECKING:
+    from ._typing import UnitLike
+    from .quantity import Quantity
+    from .registry import BaseRegistry
+
 
 logger = logging.getLogger(__name__)
 logger.addHandler(NullHandler())
@@ -321,7 +330,7 @@ class UnitsContainer(Mapping):
 
     __slots__ = ("_d", "_hash", "_one", "_non_int_type")
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         if args and isinstance(args[0], UnitsContainer):
             default_non_int_type = args[0]._non_int_type
         else:
@@ -398,7 +407,7 @@ class UnitsContainer(Mapping):
     def __iter__(self):
         return iter(self._d)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._d)
 
     def __getitem__(self, key):
@@ -419,7 +428,7 @@ class UnitsContainer(Mapping):
     def __setstate__(self, state):
         self._d, self._hash, self._one, self._non_int_type = state
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if isinstance(other, UnitsContainer):
             # UnitsContainer.__hash__(self) is not the same as hash(self); see
             # ParserHelper.__hash__ and __eq__.
@@ -440,19 +449,19 @@ class UnitsContainer(Mapping):
 
         return dict.__eq__(self._d, other)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__format__("")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         tmp = "{%s}" % ", ".join(
             ["'{}': {}".format(key, value) for key, value in sorted(self._d.items())]
         )
         return "<UnitsContainer({})>".format(tmp)
 
-    def __format__(self, spec):
+    def __format__(self, spec: str) -> str:
         return format_unit(self, spec)
 
-    def format_babel(self, spec, **kwspec):
+    def format_babel(self, spec: str, **kwspec) -> str:
         return format_unit(self, spec, **kwspec)
 
     def __copy__(self):
@@ -742,7 +751,7 @@ class ParserHelper(UnitsContainer):
 
 
 #: List of regex substitution pairs.
-_subs_re = [
+_subs_re_list = [
     ("\N{DEGREE SIGN}", " degree"),
     (r"([\w\.\-\+\*\\\^])\s+", r"\1 "),  # merge multiple spaces
     (r"({}) squared", r"\1**2"),  # Handle square and cube
@@ -758,12 +767,14 @@ _subs_re = [
 ]
 
 #: Compiles the regex and replace {} by a regex that matches an identifier.
-_subs_re = [(re.compile(a.format(r"[_a-zA-Z][_a-zA-Z0-9]*")), b) for a, b in _subs_re]
+_subs_re = [
+    (re.compile(a.format(r"[_a-zA-Z][_a-zA-Z0-9]*")), b) for a, b in _subs_re_list
+]
 _pretty_table = str.maketrans("⁰¹²³⁴⁵⁶⁷⁸⁹·⁻", "0123456789*-")
 _pretty_exp_re = re.compile(r"⁻?[⁰¹²³⁴⁵⁶⁷⁸⁹]+(?:\.[⁰¹²³⁴⁵⁶⁷⁸⁹]*)?")
 
 
-def string_preprocessor(input_string):
+def string_preprocessor(input_string: str) -> str:
     input_string = input_string.replace(",", "")
     input_string = input_string.replace(" per ", "/")
 
@@ -781,7 +792,7 @@ def string_preprocessor(input_string):
     return input_string
 
 
-def _is_dim(name):
+def _is_dim(name: str) -> bool:
     return name[0] == "[" and name[-1] == "]"
 
 
@@ -799,6 +810,9 @@ class SharedRegistryObject:
 
     """
 
+    _REGISTRY: ClassVar[BaseRegistry]
+    _units: UnitsContainer
+
     def __new__(cls, *args, **kwargs):
         inst = object.__new__(cls)
         if not hasattr(cls, "_REGISTRY"):
@@ -809,7 +823,7 @@ class SharedRegistryObject:
             inst._REGISTRY = _APP_REGISTRY
         return inst
 
-    def _check(self, other):
+    def _check(self, other) -> bool:
         """Check if the other object use a registry and if so that it is the
         same registry.
 
@@ -840,6 +854,8 @@ class SharedRegistryObject:
 class PrettyIPython:
     """Mixin to add pretty-printers for IPython"""
 
+    default_format: str
+
     def _repr_html_(self):
         if "~" in self.default_format:
             return "{:~H}".format(self)
@@ -859,7 +875,9 @@ class PrettyIPython:
             p.text("{:P}".format(self))
 
 
-def to_units_container(unit_like, registry=None):
+def to_units_container(
+    unit_like: Union[UnitLike, Quantity], registry: Optional[BaseRegistry] = None
+) -> UnitsContainer:
     """Convert a unit compatible type to a UnitsContainer.
 
     Parameters
@@ -1014,7 +1032,7 @@ class BlockIterator(SourceIterator):
     next = __next__
 
 
-def iterable(y):
+def iterable(y) -> bool:
     """Check whether or not an object can be iterated over.
 
     Vendored from numpy under the terms of the BSD 3-Clause License. (Copyright
@@ -1036,7 +1054,7 @@ def iterable(y):
     return True
 
 
-def sized(y):
+def sized(y) -> bool:
     """Check whether or not an object has a defined length.
 
     Parameters

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ test =
     pytest-subtests
 
 [options.package_data]
-pint = default_en.txt; constants_en.txt
+pint = default_en.txt; constants_en.txt; py.typed
 
 [check-manifest]
 ignore =


### PR DESCRIPTION
Following the discussion started here #1166

- [x] Executed ``pre-commit run --all-files`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

This PR introduces Type annotation support for Quantity.

Quantity is a Generic (https://docs.python.org/3/library/typing.html#user-defined-generic-types).

Magnitude type changes based on input type when constructing Quantity.
This will ease type checking for libraries & application using types and developers who wish to statically type check their code.

- Quantity as Generic Type
- Properly type annotate widely used functions from public API (Registry, Unit, Quantity)

If readability is becoming an issue we can export type annotations to stub files.

After the merge of this PR we should comply to [PEP561](https://www.python.org/dev/peps/pep-0561/).
We can also introduce [Annotated Quantity](https://github.com/hgrecco/pint/issues/1166#issuecomment-755754727) types with dimensionality & unit.


After running mypy, we will be able to track some bugs since we have a lot of type checking with `isinstance`, switches etc.