### PR TITLE
Do not install numpy in CI when not instructed to

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,12 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt install -y graphviz
-          pip install .[test]
+          pip install pytest pytest-cov pytest-subtests
+          pip install .
+
+      - name: Install pytest-mpl
+        if: contains(matrix.extras, 'matplotlib')
+        run: pip install pytest-mpl
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
Fixing CI

When installing with `pip install .[test]`, this installs pytest-mpl which depends on matplotlib which depends on numpy.
We are then testing with numpy installed even though we have some tests that requires numpy not to be installed.

I added an extra step with pytest-mpl if matplotlib is in the `extras` dependencies