### PR TITLE
add dBW, decibel watts, which are common in RF at higher power than dBm

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Pint Changelog
 0.18 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Added dBW, decibel Watts, which is used in RF high power applications
 
 
 0.17 (2021-03-22)

--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -480,6 +480,7 @@ nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
  
 # Logaritmic Units of dimensionless quantity: [ https://en.wikipedia.org/wiki/Level_(logarithmic_quantity) ]
 
+decibelwatt = watt; logbase: 10; logfactor: 10 = dBW
 decibelmilliwatt = 1e-3 watt; logbase: 10; logfactor: 10 = dBm
 decibelmicrowatt = 1e-6 watt; logbase: 10; logfactor: 10 = dBu
 

--- a/pint/testsuite/test_log_units.py
+++ b/pint/testsuite/test_log_units.py
@@ -68,6 +68,10 @@ class TestLogarithmicQuantity(QuantityTestCase):
         helpers.assert_quantity_almost_equal(
             self.Q_(0.0, "dBm"), self.Q_(29.999999999999996, "dBu"), atol=1e-7
         )
+        # ## Test dB to dB units dBm - dBW
+        # 0 dBW = 1W = 1e3 mW = 30 dBm
+        helpers.assert_quantity_almost_equal(
+            self.Q_(0.0, "dBW"), self.Q_(29.999999999999996, "dBm"), atol=1e-7
 
     def test_mix_regular_log_units(self):
         # Test regular-logarithmic mixed definition, such as dB/km or dB/cm
@@ -87,6 +91,8 @@ class TestLogarithmicQuantity(QuantityTestCase):
 
 
 log_unit_names = [
+    "decibelwatt",
+    "dBW",
     "decibelmilliwatt",
     "dBm",
     "decibelmicrowatt",
@@ -138,6 +144,7 @@ def test_quantity_by_multiplication(auto_ureg, unit_name, mag):
 @pytest.mark.parametrize(
     "unit1,unit2",
     [
+        ("decibelwatt", "dBW"),
         ("decibelmilliwatt", "dBm"),
         ("decibelmicrowatt", "dBu"),
         ("decibel", "dB"),

--- a/pint/testsuite/test_log_units.py
+++ b/pint/testsuite/test_log_units.py
@@ -72,6 +72,7 @@ class TestLogarithmicQuantity(QuantityTestCase):
         # 0 dBW = 1W = 1e3 mW = 30 dBm
         helpers.assert_quantity_almost_equal(
             self.Q_(0.0, "dBW"), self.Q_(29.999999999999996, "dBm"), atol=1e-7
+        )
 
     def test_mix_regular_log_units(self):
         # Test regular-logarithmic mixed definition, such as dB/km or dB/cm


### PR DESCRIPTION
- [N/A] Closes # (insert issue number)
- [N] Executed ``pre-commit run --all-files`` with no errors
- [Y] The change is fully covered by automated unit tests
- [N/A] Documented in docs/ as appropriate
- [Y] Added an entry to the CHANGES file

Added dBW capability, used dBu code as a model.