### PR TITLE
autoupdate pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: 20.8b1
+-   repo: https://github.com/psf/black
+    rev: 21.5b1
     hooks:
     - id: black
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: 'v5.6.4'
+-   repo: https://github.com/pycqa/isort
+    rev: 5.8.0
     hooks:
-    -   id: isort
+    - id: isort
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.2
     hooks:
     - id: flake8
 

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -875,7 +875,7 @@ class BaseRegistry(metaclass=RegistryMeta):
                     self._get_root_units_recurse(reg.reference, exp2, accumulators)
 
     def get_compatible_units(self, input_units, group_or_system=None):
-        """"""
+        """ """
         input_units = to_units_container(input_units)
 
         equiv = self._get_compatible_units(input_units, group_or_system)
@@ -883,7 +883,7 @@ class BaseRegistry(metaclass=RegistryMeta):
         return frozenset(self.Unit(eq) for eq in equiv)
 
     def _get_compatible_units(self, input_units, group_or_system):
-        """"""
+        """ """
         if not input_units:
             return frozenset()
 
@@ -1299,7 +1299,7 @@ class NonMultiplicativeRegistry(BaseRegistry):
         self.autoconvert_offset_to_baseunit = autoconvert_offset_to_baseunit
 
     def _parse_units(self, input_string, as_delta=None, case_sensitive=None):
-        """"""
+        """ """
         if as_delta is None:
             as_delta = self.default_as_delta
 


### PR DESCRIPTION
`pre-commit` maintenance.

For a automated workflow, see [this file](https://github.com/xarray-contrib/pint-xarray/blob/84c59c4412c69c1b8e88ca7e7decacc6dfe1d928/.github/workflows/pre-commit-autoupdate.yml). Should we set up something like this, too?

- [x] Executed ``pre-commit run --all-files`` with no errors
