### PR TITLE
DOCS: Typo and case in tutorial.rst

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -91,7 +91,7 @@ a ``Quantity()`` object.
 ``Quantity()`` objects also work well with NumPy arrays, which you can
 read about in the section on :doc:`NumPy support <numpy>`.
 
-Converting to Different Units
+Converting to different units
 -----------------------------
 
 As the underlying ``UnitRegistry`` knows the relationships between
@@ -447,7 +447,7 @@ Then in ``yourmodule.py`` the code would be
    length = 10 * ureg.meter
    my_speed = Q_(20, 'm/s')
 
-If you are pickling and unplicking Quantities within your project, you should
+If you are pickling and unpickling Quantities within your project, you should
 also define the registry as the application registry
 
 .. code-block:: python


### PR DESCRIPTION
- Fixed typo "plicking" instead of "pickling".
- Changed case of "Converting to different units" subhead to match the others, which all use sentence case (except when naming Pint classes).

- [ NA ] Closes # (insert issue number)
- [ NA ] Executed ``pre-commit run --all-files`` with no errors
- [ NA ] The change is fully covered by automated unit tests
- [ NA ] Documented in docs/ as appropriate
- [ NA ] Added an entry to the CHANGES file
