### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,8 @@ Pint Changelog
 
 - Implement use of Quantity in the Quantity constructor (convert to specified units).
   (Issue #1231)
+- Fix a few small typos.
+  (Issue #1308)
 
 
 0.17 (2021-03-22)

--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ ufuncs are supported including automatic conversion of units. For example
 quantity will be radian.
 
 
-Pint is maintained by a community of scientists, programmers and entusiasts around the world.
+Pint is maintained by a community of scientists, programmers and enthusiasts around the world.
 See AUTHORS_ for a complete list.
 
 To review an ordered list of notable changes for each version of a project,

--- a/pint/measurement.py
+++ b/pint/measurement.py
@@ -88,7 +88,7 @@ class Measurement(Quantity):
             # the uncertainties module supports formatting
             # numbers in value(unc) notation (i.e. 1.23(45) instead of 1.23 +/- 0.45),
             # using type code 'S', which siunitx actually accepts as input.
-            # However, the implimentation is incompatible with siunitx.
+            # However, the implementation is incompatible with siunitx.
             # Uncertainties will do 9.1(1.1), which is invalid, should be 9.1(11).
             # TODO: add support for extracting options
             #

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -1847,7 +1847,7 @@ class ContextRegistry(BaseRegistry):
 class SystemRegistry(BaseRegistry):
     """Handle of Systems and Groups.
 
-    Conversion between units with different dimenstions according
+    Conversion between units with different dimensions according
     to previously established relations (contexts).
     (e.g. in the spectroscopy, conversion between frequency and energy is possible)
 

--- a/pint/registry_helpers.py
+++ b/pint/registry_helpers.py
@@ -2,7 +2,7 @@
     pint.registry_helpers
     ~~~~~~~~~~~~~~~~~~~~~
 
-    Miscellaneous methods of the registry writen as separate functions.
+    Miscellaneous methods of the registry written as separate functions.
 
     :copyright: 2016 by Pint Authors, see AUTHORS for more details..
     :license: BSD, see LICENSE for more details.

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -1518,7 +1518,7 @@ class TestOffsetUnitMath(QuantityTestCase):
                 assert op.truediv(in1, in2).units == expected.units
                 helpers.assert_quantity_almost_equal(op.truediv(in1, in2), expected)
 
-    exponentiation = [  # resuls without / with autoconvert
+    exponentiation = [  # results without / with autoconvert
         (((10, "degC"), 1), [(10, "degC"), (10, "degC")]),
         (((10, "degC"), 0.5), ["error", (283.15 ** 0.5, "kelvin**0.5")]),
         (((10, "degC"), 0), [(1.0, ""), (1.0, "")]),

--- a/pint/unit.py
+++ b/pint/unit.py
@@ -310,7 +310,7 @@ class Unit(PrettyIPython, SharedRegistryObject):
         value :
             a Quantity (or numerical value if strict=False) to convert
         strict :
-            boolean to indicate that only quanities are accepted (Default value = True)
+            boolean to indicate that only quantities are accepted (Default value = True)
         name :
             descriptive name to use if an exception occurs (Default value = "value")
 
@@ -338,7 +338,7 @@ class Unit(PrettyIPython, SharedRegistryObject):
         value :
             a Quantity (or numerical value if strict=False) to convert
         strict :
-            boolean to indicate that only quanities are accepted (Default value = True)
+            boolean to indicate that only quantities are accepted (Default value = True)
         name :
             descriptive name to use if an exception occurs (Default value = "value")
 


### PR DESCRIPTION
There are small typos in:
- README.rst
- pint/measurement.py
- pint/registry.py
- pint/registry_helpers.py
- pint/testsuite/test_quantity.py
- pint/unit.py

Fixes:
- Should read `quantities` rather than `quanities`.
- Should read `written` rather than `writen`.
- Should read `results` rather than `resuls`.
- Should read `implementation` rather than `implimentation`.
- Should read `enthusiasts` rather than `entusiasts`.
- Should read `dimensions` rather than `dimenstions`.

- [x] Closes #1308 
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
