### PR TITLE
fix dask.base.tokenize on quantities not containing dask arrays

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1996,7 +1996,9 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return self._magnitude.__dask_keys__()
 
     def __dask_tokenize__(self):
-        return (Quantity, self._magnitude.name, self.units)
+        from dask.base import tokenize
+
+        return (Quantity, tokenize(self._magnitude), self.units)
 
     @property
     def __dask_optimize__(self):

--- a/pint/testsuite/test_dask.py
+++ b/pint/testsuite/test_dask.py
@@ -59,13 +59,24 @@ def test_dask_scheduler(dask_array):
     assert scheduler_name == true_name
 
 
-def test_dask_tokenize(dask_array):
-    """Test that a pint.Quantity wrapped Dask array has a unique token."""
-    dask_token = dask.base.tokenize(dask_array)
-    q = ureg.Quantity(dask_array, units_)
+@pytest.mark.parametrize(
+    "item",
+    (
+        pytest.param(1, id="int"),
+        pytest.param(1.3, id="float"),
+        pytest.param(np.array([1, 2]), id="numpy"),
+        pytest.param(
+            dask.array.arange(0, 25, chunks=5, dtype=float).reshape((5, 5)), id="dask"
+        ),
+    ),
+)
+def test_dask_tokenize(item):
+    """Test that a scalar pint.Quantity wrapping something has a unique token."""
+    dask_token = dask.base.tokenize(item)
+    q = ureg.Quantity(item, units_)
 
-    assert dask.base.tokenize(dask_array) != dask.base.tokenize(q)
-    assert dask.base.tokenize(dask_array) == dask_token
+    assert dask.base.tokenize(item) != dask.base.tokenize(q)
+    assert dask.base.tokenize(item) == dask_token
 
 
 def test_dask_optimize(dask_array):

--- a/pint/testsuite/test_dask.py
+++ b/pint/testsuite/test_dask.py
@@ -71,7 +71,7 @@ def test_dask_scheduler(dask_array):
     ),
 )
 def test_dask_tokenize(item):
-    """Test that a scalar pint.Quantity wrapping something has a unique token."""
+    """Test that a pint.Quantity wrapping something has a unique token."""
     dask_token = dask.base.tokenize(item)
     q = ureg.Quantity(item, units_)
 


### PR DESCRIPTION
As discussed in #1313, this changes the implementation of `__dask_tokenize__` to delegate to the magnitude instead of trying to find our own unique identifier.

cc @jthielen, @mnlevy1981

- [x] Closes #1313
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] ~Documented in docs/ as appropriate~
- [ ] Added an entry to the CHANGES file
