### PR TITLE
Fix babel format for Unit

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,8 @@ Pint Changelog
   (Issue #1231)
 - Fix a few small typos.
   (Issue #1308)
+- Fix babel format for `Unit`.
+  (Issue #1085)
 
 ### Breaking Changes
 

--- a/pint/testsuite/test_babel.py
+++ b/pint/testsuite/test_babel.py
@@ -52,6 +52,13 @@ def test_registry_locale():
 
 
 @helpers.requires_babel()
+def test_unit_format_babel():
+    ureg = UnitRegistry(fmt_locale="fr_FR")
+    volume = ureg.Unit("ml")
+    assert volume.format_babel() == "millilitre"
+
+
+@helpers.requires_babel()
 def test_no_registry_locale(sess_registry):
     ureg = sess_registry
     distance = 24.0 * ureg.meter

--- a/pint/unit.py
+++ b/pint/unit.py
@@ -13,7 +13,7 @@ import locale
 import operator
 from numbers import Number
 
-from .compat import NUMERIC_TYPES, is_upcast_type
+from .compat import NUMERIC_TYPES, babel_parse, is_upcast_type
 from .definitions import UnitDefinition
 from .errors import DimensionalityError
 from .formatting import siunitx_format_unit
@@ -93,7 +93,7 @@ class Unit(PrettyIPython, SharedRegistryObject):
 
         return format(units, spec)
 
-    def format_babel(self, spec="", **kwspec):
+    def format_babel(self, spec="", locale=None, **kwspec):
         spec = spec or self.default_format
 
         if "~" in spec:
@@ -109,7 +109,14 @@ class Unit(PrettyIPython, SharedRegistryObject):
         else:
             units = self._units
 
-        return "%s" % (units.format_babel(spec, **kwspec))
+        locale = self._REGISTRY.fmt_locale if locale is None else locale
+
+        if locale is None:
+            raise ValueError("Provide a `locale` value to localize translation.")
+        else:
+            kwspec["locale"] = babel_parse(locale)
+
+        return units.format_babel(spec, **kwspec)
 
     @property
     def dimensionless(self):


### PR DESCRIPTION
- [x] Closes #1085
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

Fix format_babel function to take Registry locale by default