### PR TITLE
add a CI to automatically update the `pre-commit` hook versions

### DIFF
--- a/.github/workflows/lint-autoupdate.yml
+++ b/.github/workflows/lint-autoupdate.yml
@@ -1,4 +1,4 @@
-name: "pre-commit autoupdate"
+name: pre-commit
 
 on:
   schedule:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   autoupdate:
-    name: 'pre-commit autoupdate'
+    name: autoupdate
     runs-on: ubuntu-latest
     if: github.repository == 'hgrecco/pint'
     steps:

--- a/.github/workflows/lint-autoupdate.yml
+++ b/.github/workflows/lint-autoupdate.yml
@@ -1,0 +1,46 @@
+name: "pre-commit autoupdate"
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"  # every Sunday at 00:00 UTC
+  workflow_dispatch:
+
+
+jobs:
+  autoupdate:
+    name: 'pre-commit autoupdate'
+    runs-on: ubuntu-latest
+    if: github.repository == 'hgrecco/pint'
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Cache pip and pre-commit
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/pre-commit
+            ~/.cache/pip
+          key: ${{ runner.os }}-pre-commit-autoupdate
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - name: upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: install dependencies
+        run: python -m pip install --upgrade pre-commit
+      - name: version info
+        run: python -m pip list
+      - name: autoupdate
+        uses: technote-space/create-pr-action@bfd4392c80dbeb54e0bacbcf4750540aecae6ed4
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXECUTE_COMMANDS: |
+            python -m pre_commit autoupdate
+            python -m pre_commit run --all-files
+          COMMIT_MESSAGE: 'pre-commit: autoupdate hook versions'
+          COMMIT_NAME: 'github-actions[bot]'
+          COMMIT_EMAIL: 'github-actions[bot]@users.noreply.github.com'
+          PR_TITLE: 'pre-commit: autoupdate hook versions'
+          PR_BRANCH_PREFIX: 'pre-commit/'
+          PR_BRANCH_NAME: 'autoupdate-${PR_ID}'


### PR DESCRIPTION
As mentioned in #1302 there's a way to automatically get PRs to autoupdate the `pre-commit` hooks (once a week or on explicit request).

- [x] Executed ``pre-commit run --all-files`` with no errors