### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,13 @@ jobs:
   test-linux:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
-        numpy: [null, "numpy>=1.14,<2.0.0"]
+        python-version: [3.7, 3.8]
+        numpy: [null, "numpy>=1.17,<2.0.0"]
         uncertainties: [null, "uncertainties==3.0.1", "uncertainties>=3.0.1,<4.0.0"]
         extras: [null]
         include:
-          - python-version: 3.6
-            numpy: numpy==1.14.6
+          - python-version: 3.7
+            numpy: numpy==1.17.5
             extras: matplotlib==2.2.5
           - python-version: 3.8
             numpy: "numpy"

--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,11 @@ Pint Changelog
 - Implement use of Quantity in the Quantity constructor (convert to specified units).
   (Issue #1231)
 
+### Breaking Changes
+
+- pint no longer supports Python 3.6
+- Minimum Numpy version supported is 1.17+
+
 
 0.17 (2021-03-22)
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -44,8 +44,8 @@ and constants. Due to its modular design, you can extend (or even rewrite!)
 the complete list without changing the source code. It supports a lot of
 numpy mathematical operations **without monkey patching or wrapping numpy**.
 
-It has a complete test coverage. It runs in Python 3.6+ with no other dependency.
-If you need Python 2.7 or 3.4/3.5 compatibility, use Pint 0.9.
+It has a complete test coverage. It runs in Python 3.7+ with no other dependency.
+If you need Python 3.6 compatibility, use Pint 0.17.
 It is licensed under BSD.
 
 It is extremely easy and natural to use:

--- a/docs/getting.rst
+++ b/docs/getting.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-Pint has no dependencies except Python_ itself. In runs on Python 3.6+.
+Pint has no dependencies except Python_ itself. In runs on Python 3.7+.
 
 You can install it (or upgrade to the latest version) using pip_::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ Due to its modular design, you can extend (or even rewrite!) the complete list
 without changing the source code. It supports a lot of numpy mathematical
 operations **without monkey patching or wrapping numpy**.
 
-It has a complete test coverage. It runs in Python 3.6+ with no other
+It has a complete test coverage. It runs in Python 3.7+ with no other
 dependencies. It is licensed under a `BSD 3-clause style license`_.
 
 It is extremely easy and natural to use:

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -19,11 +19,7 @@ import re
 import warnings
 from typing import List
 
-from packaging import version
-
 from .compat import (
-    HAS_NUMPY_ARRAY_FUNCTION,
-    NUMPY_VER,
     _to_magnitude,
     babel_parse,
     compute,
@@ -1248,11 +1244,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
     __rmul__ = __mul__
 
     def __matmul__(self, other):
-        # Use NumPy ufunc (existing since 1.16) for matrix multiplication
-        if version.parse(NUMPY_VER) >= version.parse("1.16"):
-            return np.matmul(self, other)
-        else:
-            return NotImplemented
+        return np.matmul(self, other)
 
     __rmatmul__ = __matmul__
 
@@ -1792,15 +1784,6 @@ class Quantity(PrettyIPython, SharedRegistryObject):
 
         Wraps np.prod().
         """
-        # TODO: remove after support for 1.16 has been dropped
-        if not HAS_NUMPY_ARRAY_FUNCTION:
-            raise NotImplementedError(
-                "prod is only defined for"
-                " numpy == 1.16 with NUMPY_ARRAY_FUNCTION_PROTOCOL enabled"
-                f" or for numpy >= 1.17 ({np.__version__} is installed)."
-                " Please try setting the NUMPY_ARRAY_FUNCTION_PROTOCOL environment variable"
-                " or updating your numpy version."
-            )
         return np.prod(self, *args, **kwargs)
 
     def __ito_if_needed(self, to_units):

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -35,6 +35,7 @@ The module actually defines 5 registries with different capabilities:
 
 import copy
 import functools
+import importlib.resources
 import itertools
 import locale
 import os
@@ -78,13 +79,6 @@ from .util import (
     string_preprocessor,
     to_units_container,
 )
-
-try:
-    import importlib.resources as importlib_resources
-except ImportError:
-    # Backport for Python < 3.7
-    import importlib_resources
-
 
 _BLOCK_RE = re.compile(r"[ (]")
 
@@ -534,7 +528,7 @@ class BaseRegistry(metaclass=RegistryMeta):
         if isinstance(file, str):
             try:
                 if is_resource:
-                    rbytes = importlib_resources.read_binary(__package__, file)
+                    rbytes = importlib.resources.read_binary(__package__, file)
                     return self.load_definitions(
                         StringIO(rbytes.decode("utf-8")), is_resource
                     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,25 +18,24 @@ classifiers =
     Programming Language :: Python
     Topic :: Scientific/Engineering
     Topic :: Software Development :: Libraries
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 packages = pint
 zip_safe = True
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     packaging
     importlib-metadata; python_version < '3.8'
-    importlib-resources; python_version < '3.7'
 setup_requires = setuptools; setuptools_scm
 test_suite = pint.testsuite.testsuite
 scripts = pint/pint-convert
 
 [options.extras_require]
-numpy = numpy >= 1.14
+numpy = numpy >= 1.17
 uncertainties = uncertainties >= 3.0
 test =
     pytest


### PR DESCRIPTION
- [x] Related #1325 
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

Update documentation & function supporting Python 3.6
- remove importlib_resources backport
- Update minimal version numpy to 1.17
- Drop python 3.6 in ci.yml
- remove condition on numpy version for __matmul__
- Numpy `__array_function__` is enabled by default in numpy>1.17