### PR TITLE
fix conversion involving negative exponents with `force_ndarray=True`

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1486,7 +1486,7 @@ class Quantity(PrettyIPython, SharedRegistryObject):
                     raise DimensionalityError(other._units, "dimensionless")
                 else:
                     exponent = _to_magnitude(
-                        other, self.force_ndarray, self.force_ndarray_like
+                        other, force_ndarray=False, force_ndarray_like=False
                     )
                     units = new_self._units ** exponent
 

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -1563,6 +1563,18 @@ class TestOffsetUnitMath(QuantityTestCase):
                 helpers.assert_quantity_almost_equal(op.pow(in1, in2), expected)
 
     @helpers.requires_numpy
+    def test_exponentiation_force_ndarray(self):
+        self.ureg.force_ndarray_like = True
+        q = self.Q_(1, "1 / hours")
+
+        q1 = q ** 2
+        assert all(isinstance(v, int) for v in q1._units.values())
+
+        q2 = q.copy()
+        q2 **= 2
+        assert all(isinstance(v, int) for v in q2._units.values())
+
+    @helpers.requires_numpy
     @pytest.mark.parametrize(("input_tuple", "expected"), exponentiation)
     def test_inplace_exponentiation(self, input_tuple, expected):
         self.ureg.default_as_delta = False

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -1564,8 +1564,8 @@ class TestOffsetUnitMath(QuantityTestCase):
 
     @helpers.requires_numpy
     def test_exponentiation_force_ndarray(self):
-        self.ureg.force_ndarray_like = True
-        q = self.Q_(1, "1 / hours")
+        ureg = UnitRegistry(force_ndarray_like=True)
+        q = ureg.Quantity(1, "1 / hours")
 
         q1 = q ** 2
         assert all(isinstance(v, int) for v in q1._units.values())


### PR DESCRIPTION
again, I'm not sure if I'm breaking something, but the test suite doesn't fail locally and it fixes my issue.

- [x] Closes #1327
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Added an entry to the CHANGES file
