### PR TITLE
Add Quantity conversion from timedelta

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -547,6 +547,11 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         return cls(a, units)
 
     @classmethod
+    def from_timedelta(cls, value):
+        total_microseconds = value / datetime.timedelta(microseconds=1)
+        return cls(total_microseconds, "microseconds")
+
+    @classmethod
     def from_tuple(cls, tup):
         return cls(tup[0], cls._REGISTRY.UnitsContainer(tup[1]))
 

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -1664,6 +1664,14 @@ class TestDimensionReduction:
 
 
 class TestTimedelta(QuantityTestCase):
+    def test_from_timedelta(self):
+        td = datetime.timedelta(seconds=3)
+        assert 3 * self.ureg.seconds == self.ureg.Quantity.from_timedelta(td)
+
+    def test_to_timedelta(self):
+        q = self.ureg.Quantity(3, "seconds")
+        assert datetime.timedelta(seconds=3) == q.to_timedelta()
+
     def test_add_sub(self):
         d = datetime.datetime(year=1968, month=1, day=10, hour=3, minute=42, second=24)
         after = d + 3 * self.ureg.second


### PR DESCRIPTION
- [ ] Closes # (insert issue number)
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

Balance to_timedelta() interface of Quantity with from_timedelta.
Maybe such a conversion should be allowed directly in Quantity.__new__ to happen automatically?