### PR TITLE
Handling of max/min in clip function

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,5 +52,6 @@ Other contributors, listed alphabetically, are:
 * Tom Ritchford <tom@swirly.com>
 * Virgil Dupras <virgil.dupras@savoirfairelinux.com>
 * Zebedee Nicholls <zebedee.nicholls@climate-energy-college.org>
+* Robert Booth <rob@ishigoya.com>
 
 (If you think that your name belongs here, please let the maintainer know)

--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Other contributors, listed alphabetically, are:
 * Nate Bogdanowicz <natezb@gmail.com>
 * Peter Grayson <jpgrayson@gmail.com>
 * Richard Barnes <rbarnes@umn.edu>
+* Robert Booth <rob@ishigoya.com>
 * Ryan Dwyer <ryanpdwyer@gmail.com>
 * Ryan Kingsbury <RyanSKingsbury@alumni.unc.edu>
 * Ryan May
@@ -52,6 +53,5 @@ Other contributors, listed alphabetically, are:
 * Tom Ritchford <tom@swirly.com>
 * Virgil Dupras <virgil.dupras@savoirfairelinux.com>
 * Zebedee Nicholls <zebedee.nicholls@climate-energy-college.org>
-* Robert Booth <rob@ishigoya.com>
 
 (If you think that your name belongs here, please let the maintainer know)

--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,8 @@ Pint Changelog
   (Issue #1308)
 - Fix babel format for `Unit`.
   (Issue #1085)
+- Fix handling of positional max/min arguments in clip function.
+  (Issue #1244)
 
 ### Breaking Changes
 

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1693,32 +1693,24 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         )
         return _to_magnitude(self._magnitude, force_ndarray=True)
 
-    def clip(self, first=None, second=None, out=None, **kwargs):
-        minimum = kwargs.get("min", first)
-        maximum = kwargs.get("max", second)
+    def clip(self, min=None, max=None, out=None, **kwargs):
 
-        if minimum is None and maximum is None:
-            raise TypeError("clip() takes at least 3 arguments (2 given)")
-
-        kwargs = {"out": out}
-
-        if minimum is not None:
-            if isinstance(minimum, self.__class__):
-                kwargs["min"] = minimum.to(self).magnitude
+        if min is not None:
+            if isinstance(min, self.__class__):
+                min = min.to(self).magnitude
             elif self.dimensionless:
-                kwargs["min"] = minimum
+                pass
             else:
                 raise DimensionalityError("dimensionless", self._units)
 
-        if maximum is not None:
-            if isinstance(maximum, self.__class__):
-                kwargs["max"] = maximum.to(self).magnitude
+        if max is not None:
+            if isinstance(max, self.__class__):
+                max = max.to(self).magnitude
             elif self.dimensionless:
-                kwargs["max"] = maximum
+                pass
             else:
                 raise DimensionalityError("dimensionless", self._units)
-
-        return self.__class__(self.magnitude.clip(**kwargs), self._units)
+        return self.__class__(self.magnitude.clip(min, max, out, **kwargs), self._units)
 
     def fill(self, value):
         self._units = value._units

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1700,9 +1700,6 @@ class Quantity(PrettyIPython, SharedRegistryObject):
         if minimum is None and maximum is None:
             raise TypeError("clip() takes at least 3 arguments (2 given)")
 
-        if maximum is None and "min" not in kwargs:
-            minimum, maximum = maximum, minimum
-
         kwargs = {"out": out}
 
         if minimum is not None:

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -751,6 +751,12 @@ class TestNumpyUnclassified(TestNumpyMethods):
             self.q.clip(min=2 * self.ureg.m, max=3 * self.ureg.m),
             [[2, 2], [3, 3]] * self.ureg.m,
         )
+        helpers.assert_quantity_equal(
+            self.q.clip(3 * self.ureg.m, None), [[3, 3], [3, 4]] * self.ureg.m
+        )
+        helpers.assert_quantity_equal(
+            self.q.clip(3 * self.ureg.m), [[3, 3], [3, 4]] * self.ureg.m
+        )
         with pytest.raises(DimensionalityError):
             self.q.clip(self.ureg.J)
         with pytest.raises(DimensionalityError):


### PR DESCRIPTION
- define the first positional argument as min in the
  absence of kwarg "min"
- added tests to cover behaviour as in numpy

- [x] Closes #1244
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file