### PR TITLE
Fix string formatting for numpy array scalars

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ Pint Changelog
   (Issue #1085)
 - Fix handling of positional max/min arguments in clip function.
   (Issue #1244)
+- Fix string formatting of numpy array scalars
 
 ### Breaking Changes
 

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -348,12 +348,18 @@ class Quantity(PrettyIPython, SharedRegistryObject):
                 if isinstance(self.magnitude, ndarray):
                     # Use custom ndarray text formatting with monospace font
                     formatter = "{{:{}}}".format(mspec)
-                    with printoptions(formatter={"float_kind": formatter.format}):
-                        mstr = (
-                            "<pre>"
-                            + format(obj.magnitude).replace("\n", "<br>")
-                            + "</pre>"
-                        )
+                    # Need to override for scalars, which are detected as iterable,
+                    # and don't respond to printoptions.
+                    if self.magnitude.ndim == 0:
+                        allf = plain_allf = "{} {}"
+                        mstr = formatter.format(obj.magnitude)
+                    else:
+                        with printoptions(formatter={"float_kind": formatter.format}):
+                            mstr = (
+                                "<pre>"
+                                + format(obj.magnitude).replace("\n", "<br>")
+                                + "</pre>"
+                            )
                 elif not iterable(obj.magnitude):
                     # Use plain text for scalars
                     mstr = format(obj.magnitude, mspec)
@@ -369,10 +375,14 @@ class Quantity(PrettyIPython, SharedRegistryObject):
                 # Use ndarray LaTeX special formatting
                 mstr = ndarray_to_latex(obj.magnitude, mspec)
             else:
-                # Use custom ndarray text formatting
+                # Use custom ndarray text formatting--need to handle scalars differently
+                # since they don't respond to printoptions
                 formatter = "{{:{}}}".format(mspec)
-                with printoptions(formatter={"float_kind": formatter.format}):
-                    mstr = format(obj.magnitude).replace("\n", "")
+                if obj.magnitude.ndim == 0:
+                    mstr = formatter.format(obj.magnitude)
+                else:
+                    with printoptions(formatter={"float_kind": formatter.format}):
+                        mstr = format(obj.magnitude).replace("\n", "")
         else:
             mstr = format(obj.magnitude, mspec).replace("\n", "")
 

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -210,6 +210,16 @@ class TestQuantity(QuantityTestCase):
             with subtests.test(spec):
                 assert spec.format(x) == result
 
+    @helpers.requires_numpy
+    def test_quantity_array_scalar_format(self, subtests):
+        x = self.Q_(np.array(4.12345678), "kg * m ** 2")
+        for spec, result in (
+            ("{:.2f}", "4.12 kilogram * meter ** 2"),
+            ("{:.2fH}", "4.12 kilogram meter<sup>2</sup>"),
+        ):
+            with subtests.test(spec):
+                assert spec.format(x) == result
+
     def test_format_compact(self):
         q1 = (200e-9 * self.ureg.s).to_compact()
         q1b = self.Q_(200.0, "nanosecond")


### PR DESCRIPTION
Unlike normal arrays, the scalars do not respond to `set_printoptions`, so instead normal formatting needs to be used. (See numpy/numpy#11048 for ongoing confusion about this.) Also, for HTML formatting, they are flagged as `iterable` even though they should be formatted like single values.

- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
