### PR TITLE
Allow string parsing of offset units

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -35,6 +35,9 @@ Pint Changelog
 - Improved the application registry.
   (Issue #1366, thanks keewis)
 - Improved testing isolation using pytest fixtures.
+- Fix string formatting of numpy array scalars
+- Allow string parsing of offset units
+  (Issue #386)
 
 ### Breaking Changes
 

--- a/CHANGES
+++ b/CHANGES
@@ -47,6 +47,7 @@ Pint Changelog
 0.17 (2021-03-22)
 -----------------
 
+- Do not build "universal" wheel as Python 2 is not supported.
 - Add the Wh unit for battery capacity measurements
   (PR #1260, thanks Maciej Grela)
 - Fix issue with reducable dimensionless units when using power (Quantity**ndarray)

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -85,7 +85,7 @@ from .errors import (
     RedefinitionError,
     UndefinedUnitError,
 )
-from .pint_eval import build_eval_tree
+from .pint_eval import _BINARY_OPERATOR_MAP, build_eval_tree
 from .systems import Group, System
 from .util import (
     ParserHelper,
@@ -1232,6 +1232,11 @@ class BaseRegistry(metaclass=RegistryMeta):
         else:
             raise Exception("unknown token type")
 
+    def _eval_implicit_mul(self, left, right):
+        if isinstance(left, self.Quantity):
+            return left * right
+        return self.Quantity(left, right)
+
     def parse_pattern(
         self,
         input_string: str,
@@ -1337,8 +1342,13 @@ class BaseRegistry(metaclass=RegistryMeta):
         input_string = string_preprocessor(input_string)
         gen = tokenizer(input_string)
 
+        # replace implicit multiplication with self._eval_implicit_mul
+        bin_op = dict(_BINARY_OPERATOR_MAP)
+        bin_op[""] = self._eval_implicit_mul
+
         return build_eval_tree(gen).evaluate(
-            lambda x: self._eval_token(x, case_sensitive=case_sensitive, **values)
+            lambda x: self._eval_token(x, case_sensitive=case_sensitive, **values),
+            bin_op=bin_op,
         )
 
     __call__ = parse_expression

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -440,8 +440,13 @@ class TestIssues(QuantityTestCase):
         assert "{:~}".format(1 * self.ureg("MiB")) == "1 MiB"
 
     def test_issue_386(self):
-        x = ureg.Quantity(7, "degC")
-        y = ureg.Quantity("7 degC")
+        x = ureg.Quantity(42, "degC")
+        y = ureg.Quantity("42 degC")
+        assert x == y
+
+        # make sure normal combined units still work
+        x = ureg.Quantity(42, ureg.mm * ureg.s)
+        y = ureg.Quantity("42 mm s")
         assert x == y
 
     def test_issue468(self):

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -439,6 +439,11 @@ class TestIssues(QuantityTestCase):
         assert "{:~}".format(1 * self.ureg.count) == "1 count"
         assert "{:~}".format(1 * self.ureg("MiB")) == "1 MiB"
 
+    def test_issue_386(self):
+        x = ureg.Quantity(7, "degC")
+        y = ureg.Quantity("7 degC")
+        assert x == y
+
     def test_issue468(self):
         @ureg.wraps("kg", "meter")
         def f(x):

--- a/pint/testsuite/test_util.py
+++ b/pint/testsuite/test_util.py
@@ -229,7 +229,7 @@ class TestStringProcessor:
         self._test("sq bcd", "bcd**2")
         self._test("square bcd", "bcd**2")
         self._test("cubic bcd", "bcd**3")
-        self._test("bcd efg", "bcd*efg")
+        self._test("bcd efg", "bcd efg")
 
     def test_per(self):
         self._test("miles per hour", "miles/hour")
@@ -244,25 +244,25 @@ class TestStringProcessor:
         self._test("1E24", "1E24")
 
     def test_space_multiplication(self):
-        self._test("bcd efg", "bcd*efg")
-        self._test("bcd  efg", "bcd*efg")
-        self._test("1 hour", "1*hour")
-        self._test("1. hour", "1.*hour")
-        self._test("1.1 hour", "1.1*hour")
-        self._test("1E24 hour", "1E24*hour")
-        self._test("1E-24 hour", "1E-24*hour")
-        self._test("1E+24 hour", "1E+24*hour")
-        self._test("1.2E24 hour", "1.2E24*hour")
-        self._test("1.2E-24 hour", "1.2E-24*hour")
-        self._test("1.2E+24 hour", "1.2E+24*hour")
+        self._test("bcd efg", "bcd efg")
+        self._test("bcd  efg", "bcd efg")
+        self._test("1 hour", "1 hour")
+        self._test("1. hour", "1. hour")
+        self._test("1.1 hour", "1.1 hour")
+        self._test("1E24 hour", "1E24 hour")
+        self._test("1E-24 hour", "1E-24 hour")
+        self._test("1E+24 hour", "1E+24 hour")
+        self._test("1.2E24 hour", "1.2E24 hour")
+        self._test("1.2E-24 hour", "1.2E-24 hour")
+        self._test("1.2E+24 hour", "1.2E+24 hour")
 
     def test_joined_multiplication(self):
-        self._test("1hour", "1*hour")
-        self._test("1.hour", "1.*hour")
-        self._test("1.1hour", "1.1*hour")
-        self._test("1h", "1*h")
-        self._test("1.h", "1.*h")
-        self._test("1.1h", "1.1*h")
+        self._test("1hour", "1 hour")
+        self._test("1.hour", "1. hour")
+        self._test("1.1hour", "1.1 hour")
+        self._test("1h", "1 h")
+        self._test("1.h", "1. h")
+        self._test("1.1h", "1.1 h")
 
     def test_names(self):
         self._test("g_0", "g_0")

--- a/pint/util.py
+++ b/pint/util.py
@@ -761,9 +761,8 @@ _subs_re_list = [
     (r"sq ({})", r"\1**2"),
     (
         r"\b([0-9]+\.?[0-9]*)(?=[e|E][a-zA-Z]|[a-df-zA-DF-Z])",
-        r"\1*",
+        r"\1 ",
     ),  # Handle numberLetter for multiplication
-    (r"([\w\.\-])\s+(?=\w)", r"\1*"),  # Handle space for multiplication
 ]
 
 #: Compiles the regex and replace {} by a regex that matches an identifier.

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,10 @@ test =
 [options.package_data]
 pint = default_en.txt; constants_en.txt; py.typed
 
+[check-manifest]
+ignore =
+    .travis.yml
+
 [build-system]
 requires = ["setuptools", "setuptools_scm", "wheel"]
 


### PR DESCRIPTION
- [x] Closes #386
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

The fix implements special handling for implicit multiplications in the string parser when the left operand is not a quantity:
Then, it creates a quantity directly, instead of multiplying the two operands.
For this to work, the `string_preprocessor` had to be modified not to replace implicit multiplications with explicit multiplications.