### PR TITLE
Fix #1300

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@ Pint Changelog
 - Fix handling of positional max/min arguments in clip function.
   (Issue #1244)
 - Fix string formatting of numpy array scalars
+- Fix default format for Measurement class (Issue #1300)
 
 ### Breaking Changes
 

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -344,6 +344,7 @@ class BaseRegistry(metaclass=RegistryMeta):
     def default_format(self, value):
         self.Unit.default_format = value
         self.Quantity.default_format = value
+        self.Measurement.default_format = value
 
     def define(self, definition):
         """Add unit to the registry.

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -817,6 +817,13 @@ class TestIssues(QuantityTestCase):
             np.array((0.04, 0.09)),
         )
 
+    @helpers.requires_uncertainties()
+    def test_issue_1300(self):
+        ureg = UnitRegistry()
+        ureg.default_format = "~P"
+        m = ureg.Measurement(1, 0.1, "meter")
+        assert m.default_format == "~P"
+
 
 if np is not None:
 


### PR DESCRIPTION
Propagate default_format to Measurement class

- [x] Closes #1300
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Added an entry to the CHANGES file
