### PR TITLE
Fix parsing units with same exponents but different sign

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Pint Changelog
   (Issue #1244)
 - Fix string formatting of numpy array scalars
 - Fix default format for Measurement class (Issue #1300)
+- Fix parsing of pretty units with same exponents but different sign. (Issue #1360)
 
 ### Breaking Changes
 

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -313,6 +313,9 @@ class TestRegistry(QuantityTestCase):
         assert self.ureg.parse_expression("meter² · second") == self.Q_(
             1, UnitsContainer(meter=2.0, second=1)
         )
+        assert self.ureg.parse_expression("m²·s⁻²") == self.Q_(
+            1, UnitsContainer(meter=2, second=-2)
+        )
         assert self.ureg.parse_expression("meter⁰.⁵·second") == self.Q_(
             1, UnitsContainer(meter=0.5, second=1)
         )

--- a/pint/util.py
+++ b/pint/util.py
@@ -771,7 +771,7 @@ _subs_re = [
     (re.compile(a.format(r"[_a-zA-Z][_a-zA-Z0-9]*")), b) for a, b in _subs_re_list
 ]
 _pretty_table = str.maketrans("⁰¹²³⁴⁵⁶⁷⁸⁹·⁻", "0123456789*-")
-_pretty_exp_re = re.compile(r"⁻?[⁰¹²³⁴⁵⁶⁷⁸⁹]+(?:\.[⁰¹²³⁴⁵⁶⁷⁸⁹]*)?")
+_pretty_exp_re = re.compile(r"(⁻?[⁰¹²³⁴⁵⁶⁷⁸⁹]+(?:\.[⁰¹²³⁴⁵⁶⁷⁸⁹]*)?)")
 
 
 def string_preprocessor(input_string: str) -> str:
@@ -781,10 +781,8 @@ def string_preprocessor(input_string: str) -> str:
     for a, b in _subs_re:
         input_string = a.sub(b, input_string)
 
+    input_string = _pretty_exp_re.sub(r"**(\1)", input_string)
     # Replace pretty format characters
-    for pretty_exp in _pretty_exp_re.findall(input_string):
-        exp = "**" + pretty_exp.translate(_pretty_table)
-        input_string = input_string.replace(pretty_exp, exp)
     input_string = input_string.translate(_pretty_table)
 
     # Handle caret exponentiation


### PR DESCRIPTION
- [x] Closes #1360
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
