### PR TITLE
improve the application registry

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ Pint Changelog
 - Fix string formatting of numpy array scalars
 - Fix default format for Measurement class (Issue #1300)
 - Fix parsing of pretty units with same exponents but different sign. (Issue #1360)
+- Convert the application registry to a wrapper object (Issue #1365)
 
 ### Breaking Changes
 

--- a/pint/__init__.py
+++ b/pint/__init__.py
@@ -48,7 +48,6 @@ _DEFAULT_REGISTRY = LazyRegistry()
 
 #: Registry used for unpickling operations.
 application_registry = ApplicationRegistry(_DEFAULT_REGISTRY)
-_APP_REGISTRY = application_registry
 
 
 def _unpickle(cls, *args):
@@ -73,24 +72,24 @@ def _unpickle(cls, *args):
         # We need to make sure that this happens before using.
         if isinstance(arg, UnitsContainer):
             for name in arg:
-                _APP_REGISTRY.parse_units(name)
+                application_registry.parse_units(name)
 
     return cls(*args)
 
 
 def _unpickle_quantity(cls, *args):
     """Rebuild quantity upon unpickling using the application registry."""
-    return _unpickle(_APP_REGISTRY.Quantity, *args)
+    return _unpickle(application_registry.Quantity, *args)
 
 
 def _unpickle_unit(cls, *args):
     """Rebuild unit upon unpickling using the application registry."""
-    return _unpickle(_APP_REGISTRY.Unit, *args)
+    return _unpickle(application_registry.Unit, *args)
 
 
 def _unpickle_measurement(cls, *args):
     """Rebuild measurement upon unpickling using the application registry."""
-    return _unpickle(_APP_REGISTRY.Measurement, *args)
+    return _unpickle(application_registry.Measurement, *args)
 
 
 def set_application_registry(registry):

--- a/pint/__init__.py
+++ b/pint/__init__.py
@@ -27,7 +27,7 @@ from .measurement import Measurement
 from .quantity import Quantity
 from .registry import ApplicationRegistry, LazyRegistry, UnitRegistry
 from .unit import Unit
-from .util import logger, pi_theorem
+from .util import logger, pi_theorem  # noqa: F401
 
 try:
     from importlib.metadata import version
@@ -101,11 +101,7 @@ def set_application_registry(registry):
     ----------
     registry : pint.UnitRegistry
     """
-    if not isinstance(registry, (LazyRegistry, UnitRegistry)):
-        raise TypeError("Expected UnitRegistry; got %s" % type(registry))
-    global _APP_REGISTRY
-    logger.debug("Changing app registry from %r to %r.", _APP_REGISTRY, registry)
-    _APP_REGISTRY = registry
+    application_registry.set(registry)
 
 
 def get_application_registry():
@@ -117,7 +113,7 @@ def get_application_registry():
     -------
     pint.UnitRegistry
     """
-    return _APP_REGISTRY
+    return application_registry
 
 
 def test():

--- a/pint/__init__.py
+++ b/pint/__init__.py
@@ -25,7 +25,7 @@ from .errors import (  # noqa: F401
 from .formatting import formatter
 from .measurement import Measurement
 from .quantity import Quantity
-from .registry import LazyRegistry, UnitRegistry
+from .registry import ApplicationRegistry, LazyRegistry, UnitRegistry
 from .unit import Unit
 from .util import logger, pi_theorem
 
@@ -48,6 +48,7 @@ _DEFAULT_REGISTRY = LazyRegistry()
 
 #: Registry used for unpickling operations.
 _APP_REGISTRY = _DEFAULT_REGISTRY
+application_registry = ApplicationRegistry(_DEFAULT_REGISTRY)
 
 
 def _unpickle(cls, *args):

--- a/pint/__init__.py
+++ b/pint/__init__.py
@@ -47,8 +47,8 @@ except Exception:  # pragma: no cover
 _DEFAULT_REGISTRY = LazyRegistry()
 
 #: Registry used for unpickling operations.
-_APP_REGISTRY = _DEFAULT_REGISTRY
 application_registry = ApplicationRegistry(_DEFAULT_REGISTRY)
+_APP_REGISTRY = application_registry
 
 
 def _unpickle(cls, *args):

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -2330,6 +2330,9 @@ class ApplicationRegistry:
         self._registry = registry
 
     def set(self, new_registry):
+        if isinstance(new_registry, type(self)):
+            new_registry = new_registry._registry
+
         if not isinstance(new_registry, (LazyRegistry, UnitRegistry)):
             raise TypeError("Expected UnitRegistry; got %s" % type(new_registry))
         logger.debug(

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -2323,3 +2323,17 @@ class LazyRegistry:
     def __call__(self, *args, **kwargs):
         self.__init()
         return self(*args, **kwargs)
+
+
+class ApplicationRegistry:
+    def __init__(self, registry):
+        self._registry = registry
+
+    def set(self, new_registry):
+        self._registry = new_registry
+
+    def __getattr__(self, name):
+        return getattr(self._registry, name)
+
+    def __dir__(self):
+        return dir(self._registry)

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -2326,13 +2326,27 @@ class LazyRegistry:
 
 
 class ApplicationRegistry:
+    """A wrapper class used to distribute changes to the application registry."""
+
     def __init__(self, registry):
         self._registry = registry
 
     def get(self):
+        """Get the wrapped registry"""
         return self._registry
 
     def set(self, new_registry):
+        """Set the new registry
+
+        Parameters
+        ----------
+        new_registry : ApplicationRegistry or LazyRegistry or UnitRegistry
+            The new registry.
+
+        See Also
+        --------
+        set_application_registry
+        """
         if isinstance(new_registry, type(self)):
             new_registry = new_registry.get()
 

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -2337,3 +2337,15 @@ class ApplicationRegistry:
 
     def __dir__(self):
         return dir(self._registry)
+
+    def __getitem__(self, item):
+        return self._registry[item]
+
+    def __call__(self, *args, **kwargs):
+        return self._registry(*args, **kwargs)
+
+    def __contains__(self, item):
+        return self._registry.__contains__(item)
+
+    def __iter__(self):
+        return iter(self._registry)

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -2330,6 +2330,11 @@ class ApplicationRegistry:
         self._registry = registry
 
     def set(self, new_registry):
+        if not isinstance(new_registry, (LazyRegistry, UnitRegistry)):
+            raise TypeError("Expected UnitRegistry; got %s" % type(new_registry))
+        logger.debug(
+            "Changing app registry from %r to %r.", self._registry, new_registry
+        )
         self._registry = new_registry
 
     def __getattr__(self, name):

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -2329,6 +2329,9 @@ class ApplicationRegistry:
     def __init__(self, registry):
         self._registry = registry
 
+    def get(self):
+        return self._registry
+
     def set(self, new_registry):
         if isinstance(new_registry, type(self)):
             new_registry = new_registry._registry

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -2334,7 +2334,7 @@ class ApplicationRegistry:
 
     def set(self, new_registry):
         if isinstance(new_registry, type(self)):
-            new_registry = new_registry._registry
+            new_registry = new_registry.get()
 
         if not isinstance(new_registry, (LazyRegistry, UnitRegistry)):
             raise TypeError("Expected UnitRegistry; got %s" % type(new_registry))

--- a/pint/testsuite/test_application_registry.py
+++ b/pint/testsuite/test_application_registry.py
@@ -102,7 +102,7 @@ class TestCustomApplicationRegistry:
         cls.ureg.define("foo = []")
         cls.ureg.define("bar = foo / 2")
         set_application_registry(cls.ureg)
-        assert get_application_registry() is cls.ureg
+        # assert get_application_registry() is cls.ureg
 
     @classmethod
     def teardown_class(cls):

--- a/pint/testsuite/test_application_registry.py
+++ b/pint/testsuite/test_application_registry.py
@@ -258,3 +258,15 @@ class TestSwapApplicationRegistry:
         assert m1.to("bar").error.magnitude == 2
         assert m2.to("bar").error.magnitude == 3
         assert m3.to("bar").error.magnitude == 3
+
+
+@pytest.mark.usefixtures("isolate_application_registry")
+def test_update_saved_registries():
+    ureg1 = get_application_registry()
+    ureg2 = get_application_registry()
+
+    new = UnitRegistry()
+    new.define("foo = []")
+    set_application_registry(new)
+
+    assert ureg1.Unit("foo") == ureg2.Unit("foo")

--- a/pint/testsuite/test_application_registry.py
+++ b/pint/testsuite/test_application_registry.py
@@ -5,6 +5,7 @@ import pickle
 import pytest
 
 from pint import (
+    ApplicationRegistry,
     Measurement,
     Quantity,
     UndefinedUnitError,
@@ -14,6 +15,14 @@ from pint import (
     set_application_registry,
 )
 from pint.testsuite import helpers
+
+
+@pytest.fixture
+def isolate_application_registry(monkeypatch):
+    import pint
+
+    new = ApplicationRegistry(UnitRegistry())
+    monkeypatch.setattr(pint, "application_registry", new)
 
 
 class TestDefaultApplicationRegistry:
@@ -94,20 +103,16 @@ class TestDefaultApplicationRegistry:
             pickle.loads(b)
 
 
+@pytest.fixture
+def custom_registry(isolate_application_registry):
+    ureg = UnitRegistry(None)
+    ureg.define("foo = []")
+    ureg.define("bar = foo / 2")
+    set_application_registry(ureg)
+
+
+@pytest.mark.usefixtures("custom_registry")
 class TestCustomApplicationRegistry:
-    @classmethod
-    def setup_class(cls):
-        cls.ureg_bak = get_application_registry()
-        cls.ureg = UnitRegistry(None)
-        cls.ureg.define("foo = []")
-        cls.ureg.define("bar = foo / 2")
-        set_application_registry(cls.ureg)
-        # assert get_application_registry() is cls.ureg
-
-    @classmethod
-    def teardown_class(cls):
-        set_application_registry(cls.ureg_bak)
-
     @helpers.allprotos
     def test_unit(self, protocol):
         u = Unit("foo")
@@ -158,6 +163,7 @@ class TestCustomApplicationRegistry:
         assert str(m.units) == "foo"
 
 
+@pytest.mark.usefixtures("isolate_application_registry")
 class TestSwapApplicationRegistry:
     """Test that the constructors of Quantity, Unit, and Measurement capture
     the registry that is set as the application registry at creation time
@@ -170,19 +176,12 @@ class TestSwapApplicationRegistry:
 
     """
 
-    @classmethod
-    def setup_class(cls):
-        cls.ureg_bak = get_application_registry()
-        cls.ureg1 = UnitRegistry(None)
-        cls.ureg1.define("foo = [dim1]")
-        cls.ureg1.define("bar = foo / 2")
-        cls.ureg2 = UnitRegistry(None)
-        cls.ureg2.define("foo = [dim2]")
-        cls.ureg2.define("bar = foo / 3")
-
-    @classmethod
-    def teardown_class(cls):
-        set_application_registry(cls.ureg_bak)
+    ureg1 = UnitRegistry(None)
+    ureg1.define("foo = [dim1]")
+    ureg1.define("bar = foo / 2")
+    ureg2 = UnitRegistry(None)
+    ureg2.define("foo = [dim2]")
+    ureg2.define("bar = foo / 3")
 
     @helpers.allprotos
     def test_quantity_1arg(self, protocol):

--- a/pint/util.py
+++ b/pint/util.py
@@ -820,7 +820,7 @@ class SharedRegistryObject:
             # UnitRegistry._init_dynamic_classes
             from . import _APP_REGISTRY
 
-            inst._REGISTRY = _APP_REGISTRY
+            inst._REGISTRY = _APP_REGISTRY.get()
         return inst
 
     def _check(self, other) -> bool:

--- a/pint/util.py
+++ b/pint/util.py
@@ -818,9 +818,9 @@ class SharedRegistryObject:
         if not hasattr(cls, "_REGISTRY"):
             # Base class, not subclasses dynamically by
             # UnitRegistry._init_dynamic_classes
-            from . import _APP_REGISTRY
+            from . import application_registry
 
-            inst._REGISTRY = _APP_REGISTRY.get()
+            inst._REGISTRY = application_registry.get()
         return inst
 
     def _check(self, other) -> bool:


### PR DESCRIPTION
This adds the application registry wrapper object proposed in #1365 to make the application registry easier to use between packages. `get_application_registry` and `set_application_registry` were changed to use the new wrapper class.

No docstrings, docs or extra tests, yet, and the testsuite still fails.

cc @jthielen

- [x] Closes #1365, closes xarray-contrib/pint-xarray#129
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
