### PR TITLE
custom unit formats

### DIFF
--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -83,6 +83,81 @@ def register_unit_format(name):
     return wrapper
 
 
+@register_unit_format("P")
+def format_pretty(unit):
+    return formatter(
+        unit.items(),
+        as_ratio=True,
+        single_denominator=False,
+        product_fmt="·",
+        division_fmt="/",
+        power_fmt="{}{}",
+        parenthesis_fmt="({})",
+        exp_call=_pretty_fmt_exponent,
+    )
+
+
+@register_unit_format("L")
+def format_latex(unit):
+    return formatter(
+        unit.items(),
+        as_ratio=True,
+        single_denominator=True,
+        product_fmt=r" \cdot ",
+        division_fmt=r"\frac[{}][{}]",
+        power_fmt="{}^[{}]",
+        parentheses_fmt=r"\left({}\right)",
+    )
+
+
+@register_unit_format("Lx")
+def format_latex_siunitx(unit):
+    return formatter(
+        unit.items(),
+        siopts="",
+        pm_fmt=" +- ",
+    )
+
+
+@register_unit_format("H")
+def format_html(unit):
+    return formatter(
+        unit.items(),
+        as_ratio=True,
+        single_denominator=True,
+        product_fmt=r" ",
+        division_fmt=r"{}/{}",
+        power_fmt=r"{}<sup>{}</sup>",
+        parentheses_fmt=r"({})",
+    )
+
+
+@register_unit_format("D")
+def format_default(unit):
+    return formatter(
+        unit.items(),
+        as_ratio=True,
+        single_denominator=False,
+        product_fmt=" * ",
+        division_fmt=" / ",
+        power_fmt="{} ** {}",
+        parentheses_fmt=r"({})",
+    )
+
+
+@register_unit_format("C")
+def format_compact(unit):
+    return formatter(
+        unit.items(),
+        as_ratio=True,
+        single_denominator=False,
+        product_fmt="*",  # TODO: Should this just be ''?
+        division_fmt="/",
+        power_fmt="{}**{}",
+        parentheses_fmt=r"({})",
+    )
+
+
 def formatter(
     items,
     as_ratio=True,

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -70,52 +70,8 @@ def _pretty_fmt_exponent(num):
     return ret
 
 
-#: _FORMATS maps format specifications to the corresponding argument set to
-#: formatter().
-_FORMATS: Dict[str, dict] = {
-    "P": {  # Pretty format.
-        "as_ratio": True,
-        "single_denominator": False,
-        "product_fmt": "·",
-        "division_fmt": "/",
-        "power_fmt": "{}{}",
-        "parentheses_fmt": "({})",
-        "exp_call": _pretty_fmt_exponent,
-    },
-    "L": {  # Latex format.
-        "as_ratio": True,
-        "single_denominator": True,
-        "product_fmt": r" \cdot ",
-        "division_fmt": r"\frac[{}][{}]",
-        "power_fmt": "{}^[{}]",
-        "parentheses_fmt": r"\left({}\right)",
-    },
-    "Lx": {"siopts": "", "pm_fmt": " +- "},  # Latex format with SIunitx.
-    "H": {  # HTML format.
-        "as_ratio": True,
-        "single_denominator": True,
-        "product_fmt": r" ",
-        "division_fmt": r"{}/{}",
-        "power_fmt": r"{}<sup>{}</sup>",
-        "parentheses_fmt": r"({})",
-    },
-    "": {  # Default format.
-        "as_ratio": True,
-        "single_denominator": False,
-        "product_fmt": " * ",
-        "division_fmt": " / ",
-        "power_fmt": "{} ** {}",
-        "parentheses_fmt": r"({})",
-    },
-    "C": {  # Compact format.
-        "as_ratio": True,
-        "single_denominator": False,
-        "product_fmt": "*",  # TODO: Should this just be ''?
-        "division_fmt": "/",
-        "power_fmt": "{}**{}",
-        "parentheses_fmt": r"({})",
-    },
-}
+#: _FORMATS maps format names to callables doing the formatting
+_FORMATS: Dict[str, dict] = {}
 
 
 def formatter(

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -9,7 +9,7 @@
 """
 
 import re
-from typing import Dict
+from typing import Callable, Dict
 
 from .babel_names import _babel_lengths, _babel_units
 from .compat import babel_parse
@@ -71,7 +71,16 @@ def _pretty_fmt_exponent(num):
 
 
 #: _FORMATS maps format names to callables doing the formatting
-_FORMATS: Dict[str, dict] = {}
+_FORMATS: Dict[str, Callable] = {}
+
+
+def register_unit_format(name):
+    def wrapper(func):
+        if name in _FORMATS:
+            raise ValueError("format already exists")  # or warn instead
+        _FORMATS[name] = func
+
+    return wrapper
 
 
 def formatter(

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -99,8 +99,11 @@ def format_pretty(unit):
 
 @register_unit_format("L")
 def format_latex(unit):
-    return formatter(
-        unit.items(),
+    preprocessed = {
+        r"\mathrm{{{}}}".format(u.replace("_", r"\_")): p for u, p in unit.items()
+    }
+    formatted = formatter(
+        preprocessed.items(),
         as_ratio=True,
         single_denominator=True,
         product_fmt=r" \cdot ",
@@ -108,6 +111,7 @@ def format_latex(unit):
         power_fmt="{}^[{}]",
         parentheses_fmt=r"\left({}\right)",
     )
+    return formatted.replace("[", "{").replace("]", "}")
 
 
 @register_unit_format("Lx")


### PR DESCRIPTION
This adds a `register_unit_format` function and implements the currently available formats using that. I'd also like to switch the `siunitx` code (`"Lx"`) to use the new format, but because that is implemented in a function that expects a `Unit` object instead of a `UnitContainer` I still need to figure out a way to make it compatible.

I also renamed the `""` format to `"D"`.

- [x] Closes #1357 (possibly more)
- [x] Executed ``pre-commit run --all-files`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
