### PR TITLE
don't fail all CI jobs of a matrix if one job fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on: [push, pull_request]
 jobs:
   test-linux:
     strategy:
+      fail-fast: false
       matrix:
-        fail-fast: false
         python-version: [3.7, 3.8, 3.9]
         numpy: [null, "numpy>=1.17,<2.0.0"]
         uncertainties: [null, "uncertainties==3.0.1", "uncertainties>=3.0.1,<4.0.0"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   test-linux:
     strategy:
       matrix:
+        fail-fast: false
         python-version: [3.7, 3.8, 3.9]
         numpy: [null, "numpy>=1.17,<2.0.0"]
         uncertainties: [null, "uncertainties==3.0.1", "uncertainties>=3.0.1,<4.0.0"]


### PR DESCRIPTION
Currently, all jobs of a matrix will be cancelled / skipped if a single one fails. This is problematic if e.g. there's a failure for both the `uncertainties`- and the `numpy`-only CI, but the `uncertainties`-only CI finishes first: in that case, all other CI is cancelled, including the `numpy`-only CI. This in turn will severely reduce the usefulness of the CI.

The `fail-fast: false` setting disables that, with the disadvantage that now all jobs will complete (or time out).

- [x] Executed ``pre-commit run --all-files`` with no errors
