### PR TITLE
Implement `Quantity.to_no_prefix` for stripping SI-prefix

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -883,6 +883,28 @@ class Quantity(PrettyIPython, SharedRegistryObject, Generic[_MagnitudeType]):
 
         return self.to(new_unit_container)
 
+    def to_no_prefix(self) -> Quantity[_MagnitudeType]:
+        """Return Quantity rescaled to no SI-prefix.
+
+        Example
+        -------
+
+        >>> import pint
+        >>> Q_ = pint.Quantity
+        >>> (Q_('8 um')).to_no_prefix()
+        <Quantity(8e-6, 'meter')>
+        """
+        unit = str(self.u)
+
+        prefix = None
+        for p in self._REGISTRY._prefixes.values():
+            p = str(p)
+            if len(p) > 0 and unit.find(p) == 0:
+                prefix = p
+
+        no_prefix = unit.replace(prefix, "") if prefix is not None else unit
+        return self.to(no_prefix)
+
     # Mathematical operations
     def __int__(self) -> int:
         if self.dimensionless:

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -240,6 +240,26 @@ class TestQuantity(QuantityTestCase):
         assert f"{q2:#.1f}" == f"{q2b}"
         assert f"{q3:#.1f}" == f"{q3b}"
 
+    def test_format_no_prefix(self):
+        q1 = 200e-9 * self.ureg.s
+        q1b = self.Q_(200.0, "nanosecond").to_no_prefix()
+        assert round(abs(q1.magnitude - q1b.magnitude), 7) == 0
+        assert q1.units == q1b.units
+
+        q2 = (1e-2 * self.ureg("kg m/s^2")).to("N")
+        q2b = self.Q_(10.0, "millinewton").to_no_prefix()
+        assert q2.magnitude == q2b.magnitude
+        assert q2.units == q2b.units
+
+        q3 = -1000.0 * self.ureg("meters")
+        q3b = self.Q_(-1000.0, "meter").to_no_prefix()
+        assert q3.magnitude == q3b.magnitude
+        assert q3.units == q3b.units
+
+        assert f"{q1b:.1e}" == f"{q1:.1e}"
+        assert f"{q2b:.1e}" == f"{q2:.1e}"
+        assert f"{q3b:.1e}" == f"{q3:.1e}"
+
     def test_default_formatting(self, subtests):
         ureg = UnitRegistry()
         x = ureg.Quantity(4.12345678, UnitsContainer(meter=2, kilogram=1, second=-1))


### PR DESCRIPTION
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

This PR adds a method for Quantity to return a copy with no SI-prefixes, e.g., nanometers to meters w/o specifying that meters are the desired unit.

```python
import pint
Q_ = pint.Quantity
(Q_('8 um')).to_no_prefix()
```
returns 
```console
<Quantity(8e-6, 'meter')>
```
