### PR TITLE
Fix typo in `square_meter` definition

### DIFF
--- a/pint/xtranslated.txt
+++ b/pint/xtranslated.txt
@@ -3,7 +3,7 @@
 
 dietary_calorie = 1000 * calorie = Cal = Calorie
 metric_cup = liter / 4
-square_meter = kilometer ** 2 = sq_m
+square_meter = meter ** 2 = sq_m
 square_kilometer = kilometer ** 2 = sq_km
 mile_scandinavian = 10000 * meter
 cubic_mile = 1 * mile ** 3 = cu_mile = cubic_miles


### PR DESCRIPTION
- [x] Closes #1247
- [x] Executed ``pre-commit run --all-files`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
