### PR TITLE
fix the RTD builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,3 +10,4 @@ python:
      - requirements: requirements_docs.txt
      - method: pip
        path: .
+   system_packages: false

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ sphinx:
   configuration: docs/conf.py
   fail_on_warning: false
 python:
-   version: 3.7
+   version: 3.8
    install:
      - requirements: requirements_docs.txt
      - method: pip


### PR DESCRIPTION
as described in https://github.com/hgrecco/pint/pull/1376#pullrequestreview-736375619, the RTD builds are currently failing because the environment includes a old version of `numpy` (via the system packages). To fix that, we can set `system_packages` to `false`.

- [x] Executed ``pre-commit run --all-files`` with no errors