### PR TITLE
PR: Avoid looping on large numpy arrays

### DIFF
--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -50,8 +50,7 @@ def _is_sequence_with_quantity_elements(obj):
     -------
     True if obj is a sequence and at least one element is a Quantity; False otherwise
     """
-    if (np is not None and isinstance(obj, np.ndarray)
-            and not obj.dtype.hasobject):
+    if np is not None and isinstance(obj, np.ndarray) and not obj.dtype.hasobject:
         # If obj is a numpy array, avoid looping on all elements
         # if dtype does not have objects
         return False

--- a/pint/numpy_func.py
+++ b/pint/numpy_func.py
@@ -50,6 +50,11 @@ def _is_sequence_with_quantity_elements(obj):
     -------
     True if obj is a sequence and at least one element is a Quantity; False otherwise
     """
+    if (np is not None and isinstance(obj, np.ndarray)
+            and not obj.dtype.hasobject):
+        # If obj is a numpy array, avoid looping on all elements
+        # if dtype does not have objects
+        return False
     return (
         iterable(obj)
         and sized(obj)


### PR DESCRIPTION
Some numpy arrays have a dtype (such as int32) that excludes any objects. In that case, looping the array looking for a quantity is not helpful, and can waste a lot of time if the array is large.

- [ ] Closes # (insert issue number)
- [ ] Executed ``pre-commit run --all-files`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
