### PR TITLE
Support preprocessing in to_units_container for string inputs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Pint Changelog
 0.19 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Support registry preprocessors in `to_units_container` (#1402)
 
 
 0.18 (2021-10-26)

--- a/pint/testsuite/test_util.py
+++ b/pint/testsuite/test_util.py
@@ -133,6 +133,18 @@ class TestToUnitsContainer:
     def test_str_conversion(self):
         assert to_units_container("m") == UnitsContainer(m=1)
 
+    def test_str_conversion_with_preprocessing(self):
+        from pint.registry import UnitRegistry
+
+        ureg = UnitRegistry(
+            preprocessors=[
+                lambda s: s.replace("%", " percent "),
+            ]
+        )
+        ureg.define("percent = 0.01 = %")
+
+        assert to_units_container("%", registry=ureg) == UnitsContainer(percent=1)
+
     def test_uc_conversion(self):
         a = UnitsContainer(m=1)
         assert to_units_container(a) is a

--- a/pint/util.py
+++ b/pint/util.py
@@ -896,7 +896,7 @@ def to_units_container(
         return unit_like._units
     elif str in mro:
         if registry:
-            return registry._parse_units(unit_like)
+            return registry.parse_units(unit_like)._units
         else:
             return ParserHelper.from_string(unit_like)
     elif dict in mro:


### PR DESCRIPTION
Implement support for registry preprocessing against string inputs to the `to_units_container` util.

This allows string inputs to use the given registry preprocessors if available, e.g.:

```python
from pint import UnitRegistry
from pint.utils import to_units_container

ureg = UnitRegistry(preprocessors=[lambda s: s.replace('%', ' percent ')])
ureg.define('percent = 0.01 = %')

# Used directly, specifying the registry with defined preprocessors.
to_units_container('%', registry=ureg)
# <UnitsContainer({'percent': 1})>

# Used via .to('%')
quantity = ureg.Quantity(1)
quantity.to('%')
# 100.0 <Unit('percent')>
```

- [x] Closes #1004 and #1274
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
