### PR TITLE
Fix mutating the application registry

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Pint Changelog
 0.19 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fix setting options of the application registry (Issue #1403).
 
 
 0.18 (2021-10-26)

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -2328,6 +2328,8 @@ class LazyRegistry:
 class ApplicationRegistry:
     """A wrapper class used to distribute changes to the application registry."""
 
+    __slots__ = ["_registry"]
+
     def __init__(self, registry):
         self._registry = registry
 
@@ -2359,6 +2361,12 @@ class ApplicationRegistry:
 
     def __getattr__(self, name):
         return getattr(self._registry, name)
+
+    def __setattr__(self, name, value):
+        if name in self.__slots__:
+            super().__setattr__(name, value)
+        else:
+            setattr(self._registry, name, value)
 
     def __dir__(self):
         return dir(self._registry)

--- a/pint/testsuite/test_application_registry.py
+++ b/pint/testsuite/test_application_registry.py
@@ -270,3 +270,12 @@ def test_update_saved_registries():
     set_application_registry(new)
 
     assert ureg1.Unit("foo") == ureg2.Unit("foo")
+
+
+@pytest.mark.usefixtures("isolate_application_registry")
+def test_modify_application_registry():
+    ar = get_application_registry()
+    u = ar.get()
+    ar.force_ndarray_like = True
+
+    assert ar.force_ndarray_like == u.force_ndarray_like

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx>4
 ipython
 matplotlib
 nbsphinx


### PR DESCRIPTION
When adding the `ApplicationRegistry` class I apparently forgot to forward `__setattr__`. This means that trying to mutate the application registry does not change the wrapped registry, but rather adds a new attribute to `ApplicationRegistry`:
```python
from pint import application_registry as ureg

ureg.force_ndarray_like = True
assert ureg.force_ndarray_like is True
assert ureg._registry.force_ndarray_like is True  # AssertionError
```

Since this is included in `v0.18`, we might need a new release soon. What do you think, @hgrecco, @jules-ch

- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Added an entry to the CHANGES file
