### PR TITLE
Fix Quantity & Unit `is_compatible_with` with registry active contexts

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Pint Changelog
 
 - Upgrade min version of uncertainties to 3.1.4
 - Fix setting options of the application registry (Issue #1403).
+- Fix Quantity & Unit `is_compatible_with` with registry active contexts (Issue #1424).
 
 
 0.18 (2021-10-26)

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -648,7 +648,7 @@ class Quantity(PrettyIPython, SharedRegistryObject, Generic[_MagnitudeType]):
         -------
         bool
         """
-        if contexts:
+        if contexts or self._REGISTRY._active_ctx:
             try:
                 self.to(other, *contexts, **ctx_kwargs)
                 return True

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -596,6 +596,27 @@ class TestQuantity(QuantityTestCase):
             self.Q_(FakeWrapper(42), "m")
         assert FakeWrapper(self.Q_(42, "m")).q == self.Q_(42, "m")
 
+    def test_is_compatible_with(self):
+        a = self.Q_(1, "kg")
+        b = self.Q_(20, "g")
+        c = self.Q_(550)
+
+        assert a.is_compatible_with(b)
+        assert a.is_compatible_with("lb")
+        assert a.is_compatible_with(self.U_("lb"))
+        assert not a.is_compatible_with("km")
+        assert not a.is_compatible_with("")
+        assert not a.is_compatible_with(12)
+
+        assert c.is_compatible_with(12)
+
+    def test_is_compatible_with_with_context(self):
+        a = self.Q_(532.0, "nm")
+        b = self.Q_(563.5, "terahertz")
+        assert a.is_compatible_with(b, "sp")
+        with self.ureg.context("sp"):
+            assert a.is_compatible_with(b)
+
 
 class TestQuantityToCompact(QuantityTestCase):
     def assertQuantityAlmostIdentical(self, q1, q2):

--- a/pint/unit.py
+++ b/pint/unit.py
@@ -168,7 +168,7 @@ class Unit(PrettyIPython, SharedRegistryObject):
         -------
         bool
         """
-        if contexts:
+        if contexts or self._REGISTRY._active_ctx:
             try:
                 (1 * self).to(other, *contexts, **ctx_kwargs)
                 return True


### PR DESCRIPTION
- [x] Closes #1424
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
