### PR TITLE
Define microns as 1e-6 m

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Pint Changelog
 - Upgrade min version of uncertainties to 3.1.4
 - Fix setting options of the application registry (Issue #1403).
 - Fix Quantity & Unit `is_compatible_with` with registry active contexts (Issue #1424).
+- Fix equivalence between `Unit("micron")` and `Unit("micrometer")`
 
 
 0.18 (2021-10-26)
@@ -70,7 +71,7 @@ Pint Changelog
 - Fix tolist function with scalar ndarray.
   (Issue #1195, thanks jules-ch)
 - Corrected typos and dacstrings
-- Implements a first benchmark suite in airspeed velocity (asv). 
+- Implements a first benchmark suite in airspeed velocity (asv).
 - Power for pseudo-dimensionless units.
   (Issue #1185, thanks Kevin Fuhr)
 

--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -144,7 +144,7 @@ byte = 8 * bit = B = octet
 
 # Length
 angstrom = 1e-10 * meter = Å = ångström = Å
-micron = micrometer = µ
+micron = 1e-6 * meter = micrometer = µ
 fermi = femtometer = fm
 light_year = speed_of_light * julian_year = ly = lightyear
 astronomical_unit = 149597870700 * meter = au  # since Aug 2012
@@ -475,9 +475,9 @@ bohr_magneton = e * hbar / (2 * m_e) = µ_B = mu_B
 nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
 
 # Logaritmic Unit Definition
-#  Unit = scale; logbase; logfactor 
+#  Unit = scale; logbase; logfactor
 #  x_dB = [logfactor] * log( x_lin / [scale] ) / log( [logbase] )
- 
+
 # Logaritmic Units of dimensionless quantity: [ https://en.wikipedia.org/wiki/Level_(logarithmic_quantity) ]
 
 decibelmilliwatt = 1e-3 watt; logbase: 10; logfactor: 10 = dBm

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -791,6 +791,10 @@ class TestIssues(QuantityTestCase):
         assert isinstance(foo1, foo2.__class__)
         assert isinstance(foo2, foo1.__class__)
 
+    def test_issue1433(self):
+        assert ureg.Quantity("1 micron") == ureg.Quantity("1 micrometer")
+        assert ureg.Unit("micron") == ureg.Unit("micrometer")
+
     @helpers.requires_numpy
     def test_issue1174(self):
         q = [1.0, -2.0, 3.0, -4.0] * self.ureg.meter


### PR DESCRIPTION
This resolves #1433, the non-equality with micrometers.
Also includes a test which previously failed and now passes.

- [x] Closes # (insert issue number)
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
