### PR TITLE
WIP: add support for vulgar fractions

### DIFF
--- a/pint/pint_eval.py
+++ b/pint/pint_eval.py
@@ -152,6 +152,8 @@ def build_eval_tree(tokens, op_priority=_OP_PRIORITY, index=0, depth=0, prev_op=
         token_text = current_token[1]
 
         if token_type == tokenlib.OP:
+            if token_text.isnumeric():
+                pass
             if token_text == ")":
                 if prev_op is None:
                     raise DefinitionSyntaxError(
@@ -202,7 +204,11 @@ def build_eval_tree(tokens, op_priority=_OP_PRIORITY, index=0, depth=0, prev_op=
                         tokens, op_priority, index + 1, depth + 1, "unary"
                     )
                     result = EvalTreeNode(left=right, operator=current_token)
-        elif token_type == tokenlib.NUMBER or token_type == tokenlib.NAME:
+        if (
+            token_type == tokenlib.NUMBER
+            or token_type == tokenlib.NAME
+            or token_text.isnumeric()
+        ):
             if result:
                 # tokens with an implicit operation i.e. "1 kg"
                 if op_priority[""] <= op_priority.get(prev_op, -1):

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -1231,7 +1231,7 @@ class BaseRegistry(metaclass=RegistryMeta):
                         {self.get_name(token_text, case_sensitive=case_sensitive): 1}
                     ),
                 )
-        elif token_type == NUMBER:
+        elif token_type == NUMBER or token_text.isnumeric():
             return ParserHelper.eval_token(token, non_int_type=self.non_int_type)
         else:
             raise Exception("unknown token type")


### PR DESCRIPTION
See https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=[:Decomposition_Type=Fraction:]
The allowed list: `vulgars = ['¼', '½', '¾', '⅐', '⅑', '⅒', '⅓', '⅔', '⅕', '⅖', '⅗', '⅘', '⅙', '⅚', '⅛', '⅜', '⅝', '⅞', '⅟', '↉']`

- [x] Closes #1430 (insert issue number)
- [x] Executed ``pre-commit run --all-files`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

```py
>>> ureg('⅐ m kg')
<Quantity(0.142857143, 'kilogram * meter')>
>>> uregF('⅚')
Fraction(5, 6)
>>> uregD('⅝')
Decimal('0.625')
```

It doesn't quite resolve "mixed number" cases and we might want to look into that (assumes implicit multiplication between tokens):
```py
>>> uregF('4⅑ m')
<Quantity(4/9, 'meter')>
```

It doesn't allow for the other numeric or fractional unicode chars to be used, but the error message is not the most elegant:
```py
>>> '൵'.isnumeric()
True
>>> ureg('൵')
"""
Traceback (most recent call last):
  File "pint\pint\util.py", line 587, in eval_token
    if decomposition(token_text).split()[0] == "<fraction>":
IndexError: list index out of range
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "pint\pint\registry.py", line 1344, in parse_expression
    return build_eval_tree(gen).evaluate(
  File "pint\pint\pint_eval.py", line 118, in evaluate
    return define_op(self.left)
  File "pint\pint\registry.py", line 1345, in <lambda>
    lambda x: self._eval_token(x, case_sensitive=case_sensitive, **values)
  File "pint\pint\registry.py", line 1235, in _eval_token
    return ParserHelper.eval_token(token, non_int_type=self.non_int_type)
  File "pint\pint\util.py", line 592, in eval_token
    raise Exception("unknown token type")
Exception: unknown token type
"""
```

And not sure if the following is the error message we should expect:
```py
>>> 'Ⅺ'.isnumeric()
True
>>> from unicodedata import decomposition, numeric
>>> numeric('Ⅺ')
11.0
>>> decomposition('Ⅺ')
'<compat> 0058 0049'
>>> ureg('Ⅺ')
"""
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "pint\pint\registry.py", line 1344, in parse_expression
    return build_eval_tree(gen).evaluate(
  File "pint\pint\pint_eval.py", line 118, in evaluate
    return define_op(self.left)
  File "pint\pint\registry.py", line 1345, in <lambda>
    lambda x: self._eval_token(x, case_sensitive=case_sensitive, **values)
  File "pint\pint\registry.py", line 1231, in _eval_token
    {self.get_name(token_text, case_sensitive=case_sensitive): 1}
  File "pint\pint\registry.py", line 683, in get_name
    raise UndefinedUnitError(name_or_alias)
pint.errors.UndefinedUnitError: 'Ⅺ' is not defined in the unit registry
"""
```