### PR TITLE
custom formatters: pass the unit modifiers to the formatter

### DIFF
--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -453,6 +453,15 @@ def siunitx_format_unit(units, registry):
     return "".join(lpos) + "".join(lneg)
 
 
+def split_unit_format(uspec):
+    modifiers_re = re.compile(rf"[{''.join(_UNIT_MODIFIERS)}]")
+    modifiers = modifiers_re.findall(uspec)
+
+    uspec = modifiers_re.sub("", uspec)
+
+    return modifiers, uspec
+
+
 def extract_custom_flags(spec):
     flag_re = re.compile(
         "(" + "|".join(list(_FORMATTERS.keys()) + list(_UNIT_MODIFIERS)) + ")"

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -463,10 +463,10 @@ def extract_custom_flags(spec):
 
 
 def remove_custom_flags(spec):
-    for flag in list(_FORMATTERS.keys()) + ["~"]:
-        if flag:
-            spec = spec.replace(flag, "")
-    return spec
+    flag_re = re.compile(
+        "(" + "|".join(list(_FORMATTERS.keys()) + list(_UNIT_MODIFIERS)) + ")"
+    )
+    return flag_re.sub("", spec)
 
 
 def vector_to_latex(vec, fmtfun=lambda x: format(x, ".2f")):

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -371,6 +371,7 @@ def formatter(
 # http://docs.python.org/2/library/string.html#format-specification-mini-language
 # We also add uS for uncertainties.
 _BASIC_TYPES = frozenset("bcdeEfFgGnosxX%uS")
+_UNIT_MODIFIERS = frozenset("~")
 
 
 def _parse_spec(spec):
@@ -378,7 +379,7 @@ def _parse_spec(spec):
     for ch in reversed(spec):
         if ch == "~" or ch in _BASIC_TYPES:
             continue
-        elif ch in list(_FORMATTERS.keys()) + ["~"]:
+        elif ch in list(_FORMATTERS.keys()) + list(_UNIT_MODIFIERS):
             if result:
                 raise ValueError("expected ':' after format specifier")
             else:
@@ -453,9 +454,9 @@ def siunitx_format_unit(units, registry):
 
 
 def extract_custom_flags(spec):
-    import re
-
-    flag_re = re.compile("(" + "|".join(list(_FORMATTERS.keys()) + ["~"]) + ")")
+    flag_re = re.compile(
+        "(" + "|".join(list(_FORMATTERS.keys()) + list(_UNIT_MODIFIERS)) + ")"
+    )
     custom_flags = flag_re.findall(spec)
 
     return "".join(custom_flags)

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -110,6 +110,21 @@ class TestUnit(QuantityTestCase):
 
         assert "{:new}".format(ureg.m) == "new format"
 
+    def test_unit_formatting_custom_modifiers(self, monkeypatch):
+        from pint import formatting, register_unit_format
+
+        monkeypatch.setattr(formatting, "_FORMATTERS", formatting._FORMATTERS.copy())
+
+        @register_unit_format("new")
+        def format_new(unit, *, modifiers, **options):
+            return f"new format for {unit:~P} with '{modifiers}'"
+
+        ureg = UnitRegistry()
+        u = ureg.m
+
+        assert f"{u:new}" == "new format for m with ''"
+        assert f"{u:~new}" == "new format for m with '~'"
+
     def test_ipython(self):
         alltext = []
 

--- a/pint/unit.py
+++ b/pint/unit.py
@@ -81,36 +81,11 @@ class Unit(PrettyIPython, SharedRegistryObject):
 
     def __format__(self, spec) -> str:
         spec = spec or extract_custom_flags(self.default_format)
-        if "~" in spec:
-            if not self._units:
-                return ""
-            units = UnitsContainer(
-                dict(
-                    (self._REGISTRY._get_symbol(key), value)
-                    for key, value in self._units.items()
-                )
-            )
-            spec = spec.replace("~", "")
-        else:
-            units = self._units
 
-        return format_unit(units, spec, registry=self._REGISTRY)
+        return format_unit(self, spec, registry=self._REGISTRY)
 
     def format_babel(self, spec="", locale=None, **kwspec: Any) -> str:
         spec = spec or extract_custom_flags(self.default_format)
-
-        if "~" in spec:
-            if self.dimensionless:
-                return ""
-            units = UnitsContainer(
-                dict(
-                    (self._REGISTRY._get_symbol(key), value)
-                    for key, value in self._units.items()
-                )
-            )
-            spec = spec.replace("~", "")
-        else:
-            units = self._units
 
         locale = self._REGISTRY.fmt_locale if locale is None else locale
 
@@ -119,7 +94,7 @@ class Unit(PrettyIPython, SharedRegistryObject):
         else:
             kwspec["locale"] = babel_parse(locale)
 
-        return units.format_babel(spec, registry=self._REGISTRY, **kwspec)
+        return self._units.format_babel(spec, registry=self._REGISTRY, **kwspec)
 
     @property
     def dimensionless(self) -> bool:


### PR DESCRIPTION
As noted in xarray-contrib/cf-xarray#278, it is important to pass the modifiers to the custom formatters in order to support both short and long formats with the same name if the distinction is not as simple as using the symbol instead of the long name.

This PR shifts the modifier support to the formatters. For the builtin formatters, this is implemented using a helper function which we should probably expose as public API to help with custom formatters that don't need that sort of control.

cc @dcherian

- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
