### PR TITLE
Fix typing issue on to_reduced_units

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -792,9 +792,9 @@ class Quantity(PrettyIPython, SharedRegistryObject, Generic[_MagnitudeType]):
 
         # shortcuts in case we're dimensionless or only a single unit
         if self.dimensionless:
-            return self.ito({})
+            return self.to({})
         if len(self._units) == 1:
-            return None
+            return self
 
         units = self._units.copy()
         new_units = self._get_reduced_units(units)


### PR DESCRIPTION
Small fix after #1417.
Don't know if it was there before.

Anyway, it now returns Quantity type if it is dimensionless or single units
