### PR TITLE
Fix to_compact, infer_base_unit for non-float non_int_type (#1461)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ Pint Changelog
 - Use default numpy `np.printoptions` available since numpy 1.15.
 - Implement `numpy.nanprod` (Issue #1369)
 - Fix default_format ignored for measurement (Issue #1456)
+- Fix `to_compact` and `infer_base_unit` for non-float non_int_type.
 
 ### Breaking Changes
 

--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -867,18 +867,10 @@ class Quantity(PrettyIPython, SharedRegistryObject, Generic[_MagnitudeType]):
         else:
             unit_str, unit_power = units[0]
 
-        if self._REGISTRY.non_int_type is float:
-            log10_abs_m = math.log10(abs(magnitude))
-        else:
-            # We don't necessarily know how to compute log10 for an
-            # arbitrary non-integer type.  We'll assume the type has
-            # a log10 method, as decimal.Decimal does.
-            log10_abs_m = abs(magnitude).log10()
-
         if unit_power > 0:
-            power = math.floor(log10_abs_m / unit_power / 3) * 3
+            power = math.floor(math.log10(abs(magnitude)) / float(unit_power) / 3) * 3
         else:
-            power = math.ceil(log10_abs_m / unit_power / 3) * 3
+            power = math.ceil(math.log10(abs(magnitude)) / float(unit_power) / 3) * 3
 
         index = bisect.bisect_left(SI_powers, power)
 

--- a/pint/testsuite/test_infer_base_unit.py
+++ b/pint/testsuite/test_infer_base_unit.py
@@ -1,4 +1,7 @@
+from decimal import Decimal
+
 from pint import Quantity as Q
+from pint import UnitRegistry
 from pint.testsuite import helpers
 from pint.util import infer_base_unit
 
@@ -8,6 +11,17 @@ class TestInferBaseUnit:
         from pint.util import infer_base_unit
 
         assert infer_base_unit(Q(1, "millimeter * nanometer")) == Q(1, "meter**2").units
+
+    def test_infer_base_unit_decimal(self):
+        from pint.util import infer_base_unit
+
+        ureg = UnitRegistry(non_int_type=Decimal)
+        Q = ureg.Quantity
+
+        assert (
+            infer_base_unit(Q(Decimal("1"), "millimeter * nanometer"))
+            == Q(Decimal("1"), "meter**2").units
+        )
 
     def test_units_adding_to_zero(self):
         assert infer_base_unit(Q(1, "m * mm / m / um * s")) == Q(1, "s").units
@@ -20,6 +34,24 @@ class TestInferBaseUnit:
 
         r = (Q(1, "m") * Q(1, "mm") / Q(1, "m") / Q(2, "um") * Q(2, "s")).to_compact()
         helpers.assert_quantity_almost_equal(r, Q(1000, "s"))
+
+    def test_to_compact_decimal(self):
+        ureg = UnitRegistry(non_int_type=Decimal)
+        Q = ureg.Quantity
+        r = (
+            Q(Decimal("1000000000.0"), "m")
+            * Q(Decimal("1"), "mm")
+            / Q(Decimal("1"), "s")
+            / Q(Decimal("1"), "ms")
+        )
+        compact_r = r.to_compact()
+        expected = Q(Decimal("1000.0"), "kilometer**2 / second**2")
+        assert compact_r == expected
+
+        r = (
+            Q(Decimal(1), "m") * Q(1, "mm") / Q(1, "m") / Q(2, "um") * Q(2, "s")
+        ).to_compact()
+        assert r == Q(1000, "s")
 
     def test_volts(self):
         from pint.util import infer_base_unit

--- a/pint/util.py
+++ b/pint/util.py
@@ -906,29 +906,40 @@ def to_units_container(
             return UnitsContainer(unit_like)
 
 
-def infer_base_unit(q):
+def infer_base_unit(
+    unit_like: Union[UnitLike, Quantity], registry: Optional[BaseRegistry] = None
+) -> UnitsContainer:
     """
+    Given a Quantity or UnitLike, give the UnitsContainer for it's base units.
 
     Parameters
     ----------
-    q :
+    unit_like : Union[UnitLike, Quantity]
+        Quantity or Unit to infer the base units from.
+
+    registry: Optional[BaseRegistry]
+        If provided, uses the registry's UnitsContainer rather than the base UnitsContainer.  If None,
+        uses the registry attached to unit_like.
 
 
     Returns
     -------
-    type
-
+    UnitsContainer
 
     """
     d = udict()
-    for unit_name, power in q._units.items():
-        candidates = q._REGISTRY.parse_unit_name(unit_name)
+    for unit_name, power in unit_like._units.items():
+        candidates = unit_like._REGISTRY.parse_unit_name(unit_name)
         assert len(candidates) == 1
         _, base_unit, _ = candidates[0]
         d[base_unit] += power
 
     # remove values that resulted in a power of 0
-    return UnitsContainer({k: v for k, v in d.items() if v != 0})
+    nonzero_dict = {k: v for k, v in d.items() if v != 0}
+    if registry is not None:
+        return registry.UnitsContainer(nonzero_dict)
+    else:
+        return unit_like._REGISTRY.UnitsContainer(nonzero_dict)
 
 
 def getattr_maybe_raise(self, item):


### PR DESCRIPTION
to_compact used math.log10, which converted non-float types to floats;
this caused exceptions when using a non-integer type, like Decimal,
that does not implement multiplication/division with floats, and
generally changed non-integer types to floats.  This addresses the
problem by checking non_int_type.  If non_int_type != float, it
assumes that the type implements a log10 method, as Decimal does.

infer_base_unit created a generic UnitsContainer, not a UnitsContainer
specific to a registry; this allows specification of a registry, or
uses the registry of the passed-in Quantity/UnitLike.

- [x] Closes #1461
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] ~~Documented in docs/ as appropriate~~ (probably N/A)
- [x] Added an entry to the CHANGES file
