### PR TITLE
Add "cooling tower tons" to default units

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -279,6 +279,7 @@ boiler_horsepower = 33475 * Btu / hour                            # unclear whic
 metric_horsepower = 75 * force_kilogram * meter / second
 electrical_horsepower = 746 * watt
 refrigeration_ton = 12e3 * Btu / hour = _ = ton_of_refrigeration  # approximate, no exact definition
+cooling_tower_ton = 1.25 * refrigeration_ton # approximate, no exact definition
 standard_liter_per_minute = atmosphere * liter / minute = slpm = slm
 conventional_watt_90 = K_J90 ** 2 * R_K90 / (K_J ** 2 * R_K) * watt = W_90
 


### PR DESCRIPTION
Refrigeration tons are already included in the default units. In the HVAC industry a different unit, cooling tower tons, is used to measure the heat rejection capacity of heat rejection equipment like cooling towers. A cooling tower ton is defined as 25% higher than a refrigeration ton because chillers typically produce 25% waste heat which must also be rejected by the heat rejection equipment. Cooling tower tons should be included to better support developers using Pint to model entire chilled water plants and other systems including heat rejection equipment.

A few sources documenting cooling tower tons as a commonly used unit in the HVAC industry:
https://www.engineeringtoolbox.com/cooling-loads-d_665.html
https://www.baltimoreaircoil.com/what-is-a-cooling-tower (note that cooling 3 GPM (0.19 lps) of water from a 95ºF (35.0ºC) entering water temperature to an 85ºF (29.4ºC) requires 15,000 BTU/hour of heat rejection).
https://www.energytrust.org/wp-content/uploads/2017/03/BESF_Presentation_8.15.12_Part_1.pdf (slide 9)

Thank you for considering this pull request!

- [ ] Closes # (insert issue number)
- [ ] Executed ``pre-commit run --all-files`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
