### PR TITLE
Provide a method to iter the definitions in the order they appear

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,8 @@ Pint Changelog
 0.20 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Provide a method to iter the definitions in the order they appear,
+  recursing the imported files. (Issue #1498)
 
 
 0.19 (2022-04-04)

--- a/pint/parser.py
+++ b/pint/parser.py
@@ -61,8 +61,19 @@ class DefinitionFile:
 class DefinitionFiles(tuple):
     """Wrapper class that allows handling a tuple containing DefinitionFile."""
 
-    def _iter_definitions(self, next_file, *pending_files):
-        for lineno, definition in next_file.parsed_lines:
+    @staticmethod
+    def _iter_definitions(
+        pending_files: list[DefinitionFile],
+    ) -> Generator[Tuple[int, Definition]]:
+        """Internal method to iterate definitions.
+
+        pending_files is a mutable list of definitions files
+        and elements are being removed as they are yielded.
+        """
+        if not pending_files:
+            return
+        current_file = pending_files.pop(0)
+        for lineno, definition in current_file.parsed_lines:
             if isinstance(definition, ImportDefinition):
                 if not pending_files:
                     raise ValueError(
@@ -73,10 +84,10 @@ class DefinitionFiles(tuple):
                     raise ValueError(
                         "The order of the files do not match. "
                         f"(expected: {definition.path}, "
-                        f"found {pending_files[0].path})"
+                        f"found {pending_files[0].filename})"
                     )
 
-                yield from self._iter_definitions(*pending_files)
+                yield from DefinitionFiles._iter_definitions(pending_files)
             else:
                 yield lineno, definition
 
@@ -87,7 +98,7 @@ class DefinitionFiles(tuple):
         Important: This assumes that the order of the imported files
         is the one that they will appear in the definitions.
         """
-        yield from self._iter_definitions(*self)
+        yield from self._iter_definitions(list(self))
 
 
 def build_disk_cache_class(non_int_type: type):

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -637,17 +637,16 @@ class BaseRegistry(metaclass=RegistryMeta):
         else:
             parsed_files = parser.DefinitionFiles([p.parse_lines(file)])
 
-        for definition_file in parsed_files[::-1]:
-            for lineno, definition in definition_file.parsed_lines:
-                if definition.__class__ in p.handled_classes:
-                    continue
-                loaderfunc = loaders.get(definition.__class__, None)
-                if not loaderfunc:
-                    raise ValueError(
-                        f"No loader function defined "
-                        f"for {definition.__class__.__name__}"
-                    )
-                loaderfunc(definition)
+        for lineno, definition in parsed_files.iter_definitions():
+            if definition.__class__ in p.handled_classes:
+                continue
+            loaderfunc = loaders.get(definition.__class__, None)
+            if not loaderfunc:
+                raise ValueError(
+                    f"No loader function defined "
+                    f"for {definition.__class__.__name__}"
+                )
+            loaderfunc(definition)
 
         return parsed_files
 

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -941,3 +941,63 @@ if np is not None:
         ureg1.load_definitions(def1)  # ← FAILS
 
         assert 12.0 == ureg1("1.2 foo").to("kg", "BAR").magnitude
+
+    def test_issue1498b(tmp_path):
+        def0 = tmp_path / "def0.txt"
+        def1 = tmp_path / "def1.txt"
+        def1_1 = tmp_path / "def1_1.txt"
+        def1_2 = tmp_path / "def1_2.txt"
+        def2 = tmp_path / "def2.txt"
+
+        # A file that defines a new base unit and uses it in a context
+        def0.write_text(
+            """
+        foo = [FOO]
+
+        @context BAR
+            [FOO] -> [mass]: value / foo * 10.0 kg
+        @end
+
+        @import def1.txt
+        @import def2.txt
+        """
+        )
+
+        # A file that defines a new base unit, then imports another file…
+        def1.write_text(
+            """
+        @import def1_1.txt
+        @import def1_2.txt
+        """
+        )
+
+        def1_1.write_text(
+            """
+        @context BAR1_1
+            [FOO] -> [mass]: value / foo * 10.0 kg
+        @end
+        """
+        )
+
+        def1_2.write_text(
+            """
+        @context BAR1_2
+            [FOO] -> [mass]: value / foo * 10.0 kg
+        @end
+        """
+        )
+
+        # …that, in turn, uses it in a context
+        def2.write_text(
+            """
+        @context BAR2
+            [FOO] -> [mass]: value / foo * 10.0 kg
+        @end
+        """
+        )
+
+        # Succeeds with pint 0.18; fails with pint 0.19
+        ureg1 = UnitRegistry()
+        ureg1.load_definitions(def0)  # ← FAILS
+
+        assert 12.0 == ureg1("1.2 foo").to("kg", "BAR").magnitude


### PR DESCRIPTION
- [x] Closes #1498
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
