### PR TITLE
Handle definitions @import from relative paths on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,77 @@ jobs:
           pip install coveralls
           coveralls
 
+  test-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.8, 3.9, "3.10"]
+        numpy: [ "numpy>=1.19,<2.0.0" ]
+        # uncertainties: [null, "uncertainties==3.1.6", "uncertainties>=3.1.6,<4.0.0"]
+        # extras: [null]
+        # include:
+        #   - python-version: 3.8 # Minimal versions
+        #     numpy: numpy==1.19.5
+        #     extras: matplotlib==2.2.5
+        #   - python-version: 3.8
+        #     numpy: "numpy"
+        #     uncertainties: "uncertainties"
+        #     extras: "sparse xarray netCDF4 dask[complete] graphviz babel==2.8"
+    runs-on: windows-latest
+
+    env:
+      TEST_OPTS: "-rfsxEX -s -k issue1498b"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 100
+
+      - name: Get tags
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Setup caching
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: pip-windows-${{ matrix.python-version }}
+          restore-keys: |
+            pip-windows-${{ matrix.python-version }}
+
+      - name: Install numpy
+        if: ${{ matrix.numpy != null }}
+        run: pip install "${{matrix.numpy}}"
+
+      # - name: Install uncertainties
+      #   if: ${{ matrix.uncertainties != null }}
+      #   run: pip install "${{matrix.uncertainties}}"
+      #
+      # - name: Install extras
+      #   if: ${{ matrix.extras != null }}
+      #   run: pip install ${{matrix.extras}}
+
+      - name: Install dependencies
+        run: |
+          # sudo apt install -y graphviz
+          pip install pytest pytest-cov pytest-subtests
+          pip install .
+
+      # - name: Install pytest-mpl
+      #   if: contains(matrix.extras, 'matplotlib')
+      #   run: pip install pytest-mpl
+
+      - name: Run tests
+        run: pytest ${env:TEST_OPTS}
+
   coveralls:
     needs: test-linux
     runs-on: ubuntu-latest

--- a/pint/parser.py
+++ b/pint/parser.py
@@ -80,7 +80,7 @@ class DefinitionFiles(tuple):
                         f"No more files while trying to import {definition.path}."
                     )
 
-                if not str(pending_files[0].filename).endswith(definition.path):
+                if not pending_files[0].filename.as_posix().endswith(definition.path):
                     raise ValueError(
                         "The order of the files do not match. "
                         f"(expected: {definition.path}, "

--- a/pint/parser.py
+++ b/pint/parser.py
@@ -80,7 +80,7 @@ class DefinitionFiles(tuple):
                         f"No more files while trying to import {definition.path}."
                     )
 
-                if not pending_files[0].filename.as_posix().endswith(definition.path):
+                if not str(pending_files[0].filename).endswith(str(definition.path)):
                     raise ValueError(
                         "The order of the files do not match. "
                         f"(expected: {definition.path}, "
@@ -135,13 +135,13 @@ def build_disk_cache_class(non_int_type: type):
 class ImportDefinition:
     """Definition for the @import directive"""
 
-    path: str
+    path: pathlib.Path
 
     @classmethod
     def from_string(
         cls, definition: str, non_int_type: type = float
     ) -> ImportDefinition:
-        return ImportDefinition(definition[7:].strip())
+        return ImportDefinition(pathlib.Path(definition[7:].strip()))
 
 
 class Parser:


### PR DESCRIPTION
Initially as suggested at https://github.com/hgrecco/pint/issues/1498#issuecomment-1090432579, since this continues to affect downstream packages and their CI on Windows.

The actual fix ended up being using pathlib.Path for ImportDefinition.path; this way its str() representation can be compared with those of other Path objects, and they will be consistent on any given OS.

I realized that the pint test suite does not run on Windows; this is one reason the particular manifestation of the bug mentioned at https://github.com/hgrecco/pint/issues/1498#issuecomment-1090345520 was not noticed in #1499. So, I added (probably in the wrong place/form, sorry) a slimmed-down copy of the `test-linux` jobs, named `test-windows`, to confirm.

Happy to make any desired adjustments.

- [x] Closes #1498
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- ~Documented in docs/ as appropriate~ N/A as in #1499
- [ ] Added an entry to the CHANGES file
