### PR TITLE
WIP: Fix Offset conversion with prefix & conversions using offset units

### DIFF
--- a/pint/registry.py
+++ b/pint/registry.py
@@ -1461,11 +1461,10 @@ class NonMultiplicativeRegistry(BaseRegistry):
     def _is_multiplicative(self, u) -> bool:
         if u in self._units:
             # TODO
-            multiplicative_reference_units = not self._units[u].is_base and all(
+            multiplicative_reference_units = all(
                 [
-                    self._units[u].is_multiplicative
-                    for u in self._units[u].reference
-                    if not self._units[u].is_base
+                    converter.is_multiplicative
+                    for converter in converter_iterator(self, self._units[u])
                 ]
             )
             return self._units[u].is_multiplicative and multiplicative_reference_units

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -78,7 +78,7 @@ from .definitions import (
     DimensionDefinition,
     PrefixDefinition,
     UnitDefinition,
-    converter_iterator
+    converter_iterator,
 )
 from .errors import (
     DefinitionSyntaxError,
@@ -1460,8 +1460,14 @@ class NonMultiplicativeRegistry(BaseRegistry):
 
     def _is_multiplicative(self, u) -> bool:
         if u in self._units:
-            #TODO
-            multiplicative_reference_units = not self._units[u].is_base and all([self._units[u].is_multiplicative for u in self._units[u].reference if not self._units[u].is_base])
+            # TODO
+            multiplicative_reference_units = not self._units[u].is_base and all(
+                [
+                    self._units[u].is_multiplicative
+                    for u in self._units[u].reference
+                    if not self._units[u].is_base
+                ]
+            )
             return self._units[u].is_multiplicative and multiplicative_reference_units
 
         # If the unit is not in the registry might be because it is not
@@ -1573,7 +1579,7 @@ class NonMultiplicativeRegistry(BaseRegistry):
         if src_offset_unit:
             src = src.remove([src_offset_unit])
             for converter in converter_iterator(self, self._units[src_offset_unit]):
-                 value = converter.to_reference(value, inplace)
+                value = converter.to_reference(value, inplace)
             # Add reference unit for multiplicative section
             src = self._add_ref_of_log_or_offset_unit(src_offset_unit, src)
 
@@ -1588,8 +1594,10 @@ class NonMultiplicativeRegistry(BaseRegistry):
 
         # Finally convert to offset units specified in destination
         if dst_offset_unit:
-            for converter in reversed(list(converter_iterator(self, self._units[dst_offset_unit]))):
-                 value = converter.from_reference(value, inplace)
+            for converter in reversed(
+                list(converter_iterator(self, self._units[dst_offset_unit]))
+            ):
+                value = converter.from_reference(value, inplace)
 
         return value
 

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -859,6 +859,12 @@ class TestIssues(QuantityTestCase):
         m = module_registry.Measurement(1, 0.1, "meter")
         assert m.default_format == "~P"
 
+    def test_issue_1504(self, func_registry):
+
+        ureg = func_registry
+        assert ureg.Quantity(0, "kilodegC").to("degK").m == 273.15
+        assert ureg.Quantity(1, "kilodegC").to("degK").m == 1273.15
+
 
 if np is not None:
 


### PR DESCRIPTION
- [x] Closes #1504
- [ ] Executed ``pre-commit run --all-files`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file


Well it works but the implementation is so ugly.

It basically using an iterator to get converter from unit to base unit & making conversion from src to base & then from base to dst.

prefixed_src -> src_referenced -> ... -> base

base -> ... -> dst_reference -> prefixed_dst

It is similar to what happens with multiplicative, but this time I'm using an iterator instead of the recursive function used in get_roots_units with the accumulator.

I had to use some trickery for to identify the prefixed unit as non multiplicative.
I think we need to work on this, since if a converter is non multiplicative in this tree going back to base unit, well conversion will be non multiplicative.

If you guys have insights, I feel like this is clearly not OK in terms of clarity.