### PR TITLE
fix LaTeX siunitx exponent formatting (closes #1515)

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -435,7 +435,7 @@ class Quantity(PrettyIPython, SharedRegistryObject, Generic[_MagnitudeType]):
         else:
             mstr = format(obj.magnitude, mspec).replace("\n", "")
 
-        if "L" in uspec:
+        if "L" in uspec and "Lx" not in uspec:
             mstr = self._exp_pattern.sub(r"\1\\times 10^{\2\3}", mstr)
         elif "H" in uspec or "P" in uspec:
             m = self._exp_pattern.match(mstr)

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -294,11 +294,13 @@ class TestQuantity(QuantityTestCase):
         x = ureg.Quantity(1e20, "meter")
         assert f"{x:~H}" == r"1×10<sup>20</sup> m"
         assert f"{x:~L}" == r"1\times 10^{20}\ \mathrm{m}"
+        assert f"{x:~Lx}" == r"\SI[]{1e+20}{\meter}"
         assert f"{x:~P}" == r"1×10²⁰ m"
 
         x /= 1e40
         assert f"{x:~H}" == r"1×10<sup>-20</sup> m"
         assert f"{x:~L}" == r"1\times 10^{-20}\ \mathrm{m}"
+        assert f"{x:~Lx}" == r"\SI[]{1e-20}{\meter}"
         assert f"{x:~P}" == r"1×10⁻²⁰ m"
 
     def test_ipython(self):


### PR DESCRIPTION
I have not done a deep-dive to figure out when and how the exponent formatting for 'Lx' changed, but this commit adds two unit tests for the siunitx formatter that would fail on the current code and provides a fix for them.


With siunitx, you can format a quantity in scientfic notation by
specifying the quantity's magnitude in 'e' notation.

\SI{1e2}{\meter}

Here, the '1e2' will expand to '1 \times 10^{2}'.

So, when Pint formats exponents for LaTeX, it should *not* expand '1e2'
to '1 \times 10^{2}' *if* siunitx is used.

This commit adds a check to disable expaning exponents for quantity
magnitude formatting if siunitx is used.

- [ ] Closes # (insert issue number)
- [ ] Executed ``pre-commit run --all-files`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
