### PR TITLE
Update quantity.py

### DIFF
--- a/pint/quantity.py
+++ b/pint/quantity.py
@@ -1049,7 +1049,7 @@ class Quantity(PrettyIPython, SharedRegistryObject, Generic[_MagnitudeType]):
                     _to_magnitude(other, self.force_ndarray, self.force_ndarray_like),
                 )
             else:
-                raise DimensionalityError(self._units, "dimensionless")
+                return NotImplemented
             return self.__class__(magnitude, units)
 
         if not self.dimensionality == other.dimensionality:


### PR DESCRIPTION
`return NotImplemented` to defer to other object`s `__radd__` method.

See [this issue](https://github.com/hgrecco/pint/issues/1521)

- [x] Closes # (1521)
- [ ] Executed ``pre-commit run --all-files`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
