### PR TITLE
Control autoconvert in test mul w/ scalar

### DIFF
--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -1585,6 +1585,7 @@ class TestOffsetUnitMath(QuantityTestCase):
     @pytest.mark.parametrize(("input_tuple", "expected"), multiplications_with_scalar)
     def test_multiplication_with_scalar(self, input_tuple, expected):
         self.ureg.default_as_delta = False
+        self.ureg.autoconvert_offset_to_baseunit = False
         in1, in2 = input_tuple
         if type(in1) is tuple:
             in1, in2 = self.Q_(*in1), in2


### PR DESCRIPTION
test_multiplication_with_scalar has been dependent on the prior state of self.ureg.autoconvert_offset_to_baseunit making the `(10, "deC")` case pass/fail intermittently. Set `self.ureg.autoconvert_offset_to_baseunit = False` at the start of the test. Note that this case will reliably fail now.

- [ ] Closes # (insert issue number)
- [ ] Executed ``pre-commit run --all-files`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
