### PR TITLE
Fix changing number of significant places when converting units with Decimal magnitudes (See #1527)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Pint Changelog
 - Reorganized code into facets.
   Each facet encapsulate a Pint functionality.
   (See #1466, #1479)
+- Fix changing number of significant places when converting units with Decimal magnitudes (See #1527)
 
 
 0.19.2 (2022-04-23)

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -1047,6 +1047,10 @@ class PlainRegistry(metaclass=RegistryMeta):
         # must first convert to Decimal before we can '*' the values
         if isinstance(value, Decimal):
             factor = Decimal(str(factor))
+
+            # we need to remove trailing zeros that would affect the number
+            # of significant places returned
+            factor = factor.normalize()
         elif isinstance(value, Fraction):
             factor = Fraction(str(factor))
 


### PR DESCRIPTION
I am definitely not very familiar with pint, and haven't contributed much to open-source projects before, so please excuse any clumsiness in execution here! In #1527 @hgrecco suggested that `decimal.Decimal.Normalize` would work to ensure that additional significant places aren't introduced when converting quantities. 

This worked to fix the issue that I was having, so I thought I'd make it into a pull request, but I suspect that I might have missed something, as he also said "But I cannot think of a way of putting this in pint in simple way". Sorry if this is the case, and I'm creating more work then I'm helping with...

- [X] Closes #1527
- [X] Executed ``pre-commit run --all-files`` with no errors
- [ ] The change is fully covered by automated unit tests (Not very experienced with this, and I suspect that I have put them in the wrong place, sorry! But I tried.
- [X] Documented in docs/ as appropriate (Don't think that this needs an addition in the docs?)
- [X ] Added an entry to the CHANGES file (Again, don't think that I did this correctly but figured I'd do something instead of nothing)
