### PR TITLE
Update contributing.rst

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -57,7 +57,7 @@ environment on Linux or OSX with the following commands::
     $ cd pint
     $ python -m virtualenv venv
     $ source venv/bin/activate
-    $ pip install -e .
+    $ pip install -e '.[test]'
     $ pip install -r requirements_docs.txt
     $ pip install pre-commit # This step and the next are optional but recommended.
     $ pre-commit install


### PR DESCRIPTION
It seems that the [`test`](https://github.com/hgrecco/pint/blob/master/setup.cfg#L36-L40) extra requirements section is needed to run test locally, when willing to contributing.

(I still have 3 tests failing even and 13 xfailed but that's probably another pb)

- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
