### PR TITLE
String NaN creation with correct non_int_type

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@ Pint Changelog
 - Fix a recursion error that would be raised when passing quantities to `cond` and `x`.
   (Issue #1510, #1530)
 - Update test_non_int tests for pytest.
+- Create NaN-value quantities of appropriate non-int-type (Issue #1570).
 
 0.19.2 (2022-04-23)
 -------------------

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -1226,9 +1226,9 @@ class PlainRegistry(metaclass=RegistryMeta):
             if token_text == "dimensionless":
                 return 1 * self.dimensionless
             elif token_text.lower() in ("inf", "infinity"):
-                return float("inf")
+                return self.non_int_type("inf")
             elif token_text.lower() == "nan":
-                return float("nan")
+                return self.non_int_type("nan")
             elif token_text in values:
                 return self.Quantity(values[token_text])
             else:

--- a/pint/testsuite/test_non_int.py
+++ b/pint/testsuite/test_non_int.py
@@ -77,6 +77,27 @@ class _TestBasic(NonIntTypeTestCase):
             == "Creating new PlainQuantity using a non unity PlainQuantity as units."
         )
 
+    def test_nan_creation(self):
+        if self.SUPPORTS_NAN:
+            value = self.kwargs["non_int_type"]("nan")
+
+            for args in (
+                (value, "meter"),
+                (value, UnitsContainer(meter=1)),
+                (value, self.ureg.meter),
+                ("NaN*meter",),
+                ("nan/meter**(-1)",),
+                (self.Q_(value, "meter"),),
+            ):
+                x = self.Q_(*args)
+                assert math.isnan(x.magnitude)
+                assert type(x.magnitude) == self.kwargs["non_int_type"]
+                assert x.units == self.ureg.UnitsContainer(meter=1)
+
+        else:
+            with pytest.raises(ValueError):
+                self.Q_("NaN meters")
+
     def test_quantity_comparison(self):
         x = self.QP_("4.2", "meter")
         y = self.QP_("4.2", "meter")
@@ -1137,6 +1158,7 @@ class _TestOffsetUnitMath(NonIntTypeTestCase):
 class TestNonIntTypeQuantityFloat(_TestBasic):
 
     kwargs = dict(non_int_type=float)
+    SUPPORTS_NAN = True
 
 
 class TestNonIntTypeQuantityBasicMathFloat(_TestQuantityBasicMath):
@@ -1152,6 +1174,7 @@ class TestNonIntTypeOffsetUnitMathFloat(_TestOffsetUnitMath):
 class TestNonIntTypeQuantityDecimal(_TestBasic):
 
     kwargs = dict(non_int_type=Decimal)
+    SUPPORTS_NAN = True
 
 
 class TestNonIntTypeQuantityBasicMathDecimal(_TestQuantityBasicMath):
@@ -1167,6 +1190,7 @@ class TestNonIntTypeOffsetUnitMathDecimal(_TestOffsetUnitMath):
 class TestNonIntTypeQuantityFraction(_TestBasic):
 
     kwargs = dict(non_int_type=Fraction)
+    SUPPORTS_NAN = False
 
 
 class TestNonIntTypeQuantityBasicMathFraction(_TestQuantityBasicMath):

--- a/pint/util.py
+++ b/pint/util.py
@@ -641,7 +641,7 @@ class ParserHelper(UnitsContainer):
         for k in list(ret):
             if k.lower() == "nan":
                 del ret._d[k]
-                ret.scale = math.nan
+                ret.scale = non_int_type(math.nan)
 
         return ret
 


### PR DESCRIPTION
Creating NaN-value quantities should take into account the non_int_type, and create a magnitude of the correct type.  Not all common non_int_type choices support NaN (eg, Fraction does not); in this case, we pass through the resulting ValueError, which should be clear enough to be understandable.

- [x] Closes #1570 
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [N/A] Documented in docs/ as appropriate (N/A)
- [x] Added an entry to the CHANGES file

~~Note that this change is *not* covered by the automated unit tests.  It includes tests, but they are not run owing to problems with test_non_int.py (see below).  Those tests will be fixed in another PR.~~  (Addressed by #1603)