### PR TITLE
Fix cryptic error when re-registering a formatter

### DIFF
--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -157,7 +157,7 @@ def register_unit_format(name):
 
     def wrapper(func):
         if name in _FORMATTERS:
-            raise ValueError(f"format {name:!r} already exists")  # or warn instead
+            raise ValueError(f"format {name!r} already exists")  # or warn instead
         _FORMATTERS[name] = func
 
     return wrapper

--- a/pint/testsuite/test_formatting.py
+++ b/pint/testsuite/test_formatting.py
@@ -65,5 +65,5 @@ def test_register_unit_format(func_registry):
     with pytest.raises(ValueError, match="format 'custom' already exists"):
 
         @fmt.register_unit_format("custom")
-        def format_custom(unit, registry, **options):
+        def format_custom_redefined(unit, registry, **options):
             return "<overwritten>"

--- a/pint/testsuite/test_formatting.py
+++ b/pint/testsuite/test_formatting.py
@@ -52,3 +52,18 @@ def test_split_format(format, default, flag, expected):
     result = fmt.split_format(format, default, flag)
 
     assert result == expected
+
+
+def test_register_unit_format(func_registry):
+    @fmt.register_unit_format("custom")
+    def format_custom(unit, registry, **options):
+        return "<formatted unit>"
+
+    quantity = 1.0 * func_registry.meter
+    assert f"{quantity:custom}" == "1.0 <formatted unit>"
+
+    with pytest.raises(ValueError, match="format 'custom' already exists"):
+
+        @fmt.register_unit_format("custom")
+        def format_custom(unit, registry, **options):
+            return "<overwritten>"


### PR DESCRIPTION
Hiya! I've been getting a very cryptic error with the [following code](https://github.com/openforcefield/openff-toolkit/pull/1442#issuecomment-1290535524):

```python
@pint.register_unit_format("simple")
def format_unit_simple(unit, registry, **options):
    return " * ".join(f"{u} ** {p}" for u, p in unit.items())
```

The error is:

```
openff/toolkit/utils/utils.py:118: in <module>
    def format_unit_simple(unit, registry, **options):
../../../micromamba-root/envs/test/lib/python3.8/site-packages/pint/formatting.py:158: in wrapper
    raise ValueError(f"format {name:!r} already exists")  # or warn instead
E   ValueError: Invalid format specifier
```

I believe this is because the colon shouldn't be there. `f"{1:!r}"` fails on Python 3.8, 3.9, and 3.10, whereas `f"{1!r}"` succeeds.

So here is the smallest ever PR!

- [ ] Closes # (insert issue number)
- [ ] Executed ``pre-commit run --all-files`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
