### PR TITLE
Add new SI prefixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     rev: 5.10.1
     hooks:
     - id: isort
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     - id: flake8

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,8 @@ Pint Changelog
 0.21 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Add new SI prefixes: ronna-, ronto-, quetta-, quecto-.
+  (PR #1652)
 
 
 0.20.1 (2022-10-27)

--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -62,6 +62,8 @@
 #### PREFIXES ####
 
 # decimal prefixes
+quecto- = 1e-30 = q-
+ronto- = 1e-27 = r-
 yocto- = 1e-24 = y-
 zepto- = 1e-21 = z-
 atto- =  1e-18 = a-
@@ -84,6 +86,8 @@ peta- =  1e15  = P-
 exa- =   1e18  = E-
 zetta- = 1e21  = Z-
 yotta- = 1e24  = Y-
+ronna- = 1e27 = R-
+quetta- = 1e30 = Q-
 
 # binary_prefixes
 kibi- = 2**10 = Ki-


### PR DESCRIPTION
Based on Resolution 3 of the 27th meeting of
the General Conference on Weights and Measures (CGPM).

https://www.bipm.org/documents/20126/64811223/Resolutions-2022.pdf

- [ ] Closes # (insert issue number)
- [ ] Executed ``pre-commit run --all-files`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
