### PR TITLE
creation functions according to NEP 35 and updated `*_like` behavior

### DIFF
--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -950,9 +950,11 @@ def implement_nep35_func(func_str):
 nep35_function_names = {
     "array",
     "asarray",
+    "asanyarray",
     "arange",
     "linspace",
     "identity",
+    "eye",
 }
 for func_str in nep35_function_names:
     implement_nep35_func(func_str)

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -934,6 +934,30 @@ for func_str in ["var", "nanvar"]:
     implement_func("function", func_str, input_units=None, output_unit="variance")
 
 
+def implement_nep35_func(func_str):
+    # If NumPy is not available, do not attempt implement that which does not exist
+    if np is None:
+        return
+
+    func = getattr(np, func_str)
+
+    @implements(func_str, "function")
+    def implementation(*args, like, **kwargs):
+        result = func(*args, **kwargs)
+        return like._REGISTRY.Quantity(result, like.units)
+
+
+nep35_function_names = {
+    "array",
+    "asarray",
+    "arange",
+    "linspace",
+    "identity",
+}
+for func_str in nep35_function_names:
+    implement_nep35_func(func_str)
+
+
 def numpy_wrap(func_type, func, args, kwargs, types):
     """Return the result from a NumPy function/ufunc as wrapped by Pint."""
 

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -530,18 +530,19 @@ def _full_like(a, fill_value, dtype=None, order="K", subok=True, shape=None):
     # Make full_like by multiplying with array from ones_like in a
     # non-multiplicative-unit-safe way
     if hasattr(fill_value, "_REGISTRY"):
-        return fill_value._REGISTRY.Quantity(
-            (
-                np.ones_like(a, dtype=dtype, order=order, subok=subok, shape=shape)
-                * fill_value.m
-            ),
-            fill_value.units,
-        )
+        units = fill_value.units
+        fill_value_ = fill_value.m
     else:
-        return (
-            np.ones_like(a, dtype=dtype, order=order, subok=subok, shape=shape)
-            * fill_value
-        )
+        units = None
+        fill_value_ = fill_value
+
+    magnitude = np.full_like(
+        a.m, dtype=dtype, order=order, subok=subok, shape=shape, fill_value=fill_value_
+    )
+    if units is not None:
+        return fill_value._REGISTRY.Quantity(magnitude, units)
+    else:
+        return magnitude
 
 
 @implements("interp", "function")

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -964,6 +964,27 @@ for func_str in nep35_function_names:
     implement_nep35_func(func_str)
 
 
+@implements("full", "function")
+def _full(shape, fill_value, dtype=None, order="C", *, like):
+    # Make full_like by multiplying with array from ones_like in a
+    # non-multiplicative-unit-safe way
+    if hasattr(fill_value, "_REGISTRY"):
+        units = fill_value.units
+        fill_value_ = fill_value.m
+    else:
+        units = None
+        fill_value_ = fill_value
+
+    magnitude = np.full(shape=shape, fill_value=fill_value_, dtype=dtype, order=order)
+    if units is not None:
+        return fill_value._REGISTRY.Quantity(magnitude, units)
+    else:
+        return like._REGISTRY.Quantity(magnitude, units)
+
+
+nep35_function_names.add("full")
+
+
 def numpy_wrap(func_type, func, args, kwargs, types):
     """Return the result from a NumPy function/ufunc as wrapped by Pint."""
 

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -903,9 +903,6 @@ for func_str in [
     "isreal",
     "iscomplex",
     "shape",
-    "ones_like",
-    "zeros_like",
-    "empty_like",
     "argsort",
     "argmin",
     "argmax",
@@ -932,6 +929,10 @@ for func_str in ["linalg.solve"]:
     implement_func("function", func_str, input_units=None, output_unit="invdiv")
 for func_str in ["var", "nanvar"]:
     implement_func("function", func_str, input_units=None, output_unit="variance")
+
+
+for func_str in ["ones_like", "zeros_like", "empty_like"]:
+    implement_func("function", func_str, input_units=None, output_unit="match_input")
 
 
 def implement_nep35_func(func_str):

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -945,7 +945,7 @@ def implement_nep35_func(func_str):
 
     @implements(func_str, "function")
     def implementation(*args, like, **kwargs):
-        result = func(*args, **kwargs)
+        result = func(*args, like=like.magnitude, **kwargs)
         return like._REGISTRY.Quantity(result, like.units)
 
 
@@ -975,7 +975,13 @@ def _full(shape, fill_value, dtype=None, order="C", *, like):
         units = None
         fill_value_ = fill_value
 
-    magnitude = np.full(shape=shape, fill_value=fill_value_, dtype=dtype, order=order)
+    magnitude = np.full(
+        shape=shape,
+        fill_value=fill_value_,
+        dtype=dtype,
+        order=order,
+        like=like.magnitude,
+    )
     if units is not None:
         return fill_value._REGISTRY.Quantity(magnitude, units)
     else:

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -954,6 +954,9 @@ nep35_function_names = {
     "asarray",
     "asanyarray",
     "arange",
+    "ones",
+    "zeros",
+    "empty",
     "identity",
     "eye",
 }

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -954,7 +954,6 @@ nep35_function_names = {
     "asarray",
     "asanyarray",
     "arange",
-    "linspace",
     "identity",
     "eye",
 }

--- a/pint/facets/numpy/quantity.py
+++ b/pint/facets/numpy/quantity.py
@@ -22,6 +22,7 @@ from .numpy_func import (
     get_op_output_unit,
     matching_input_copy_units_output_ufuncs,
     matching_input_set_units_output_ufuncs,
+    nep35_function_names,
     numpy_wrap,
     op_units_output_ufuncs,
     set_units_ufuncs,
@@ -61,6 +62,10 @@ class NumpyQuantity:
         return numpy_wrap("ufunc", ufunc, inputs, kwargs, types)
 
     def __array_function__(self, func, types, args, kwargs):
+        nep35_functions = {getattr(np, name) for name in nep35_function_names}
+        if func in nep35_functions:
+            kwargs["like"] = self
+
         return numpy_wrap("function", func, args, kwargs, types)
 
     _wrapped_numpy_methods = ["flatten", "astype", "item"]

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -82,6 +82,47 @@ class TestNumpyArrayCreation(TestNumpyMethods):
         )
         self.assertNDArrayEqual(np.full_like(self.q, 2), np.array([[2, 2], [2, 2]]))
 
+    def test_array(self):
+        x = [0, 1, 2, 3]
+        actual = np.array(x, like=self.q)
+        expected = self.Q_(x, self.q.units)
+
+        helpers.assert_quantity_equal(actual, expected)
+
+    def test_asarray(self):
+        x = [0, 1, 2, 3]
+        actual = np.asarray(x, like=self.q)
+        expected = self.Q_(x, self.q.units)
+
+        helpers.assert_quantity_equal(actual, expected)
+
+    def test_asanyarray(self):
+        x = [0, 1, 2, 3]
+        actual = np.asanyarray(x, like=self.q)
+        expected = self.Q_(x, self.q.units)
+
+        helpers.assert_quantity_equal(actual, expected)
+
+    def test_arange(self):
+        actual = np.arange(10, like=self.q)
+        expected = self.Q_(np.arange(10), self.q.units)
+
+        helpers.assert_quantity_equal(actual, expected)
+
+    @helpers.requires_numpy_at_least("1.23.0")
+    def test_identity(self):
+        actual = np.identity(10, like=self.q)
+        expected = self.Q_(np.identity(10), self.q.units)
+
+        helpers.assert_quantity_equal(actual, expected)
+
+    @helpers.requires_numpy_at_least("1.23.0")
+    def test_eye(self):
+        actual = np.eye(10, like=self.q)
+        expected = self.Q_(np.eye(10), self.q.units)
+
+        helpers.assert_quantity_equal(actual, expected)
+
 
 class TestNumpyArrayManipulation(TestNumpyMethods):
     # TODO

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -109,6 +109,7 @@ class TestNumpyArrayCreation(TestNumpyMethods):
 
         helpers.assert_quantity_equal(actual, expected)
 
+    # before 1.23.0, ones seems to be a pure python function with changing address
     @helpers.requires_numpy_at_least("1.23.0")
     def test_ones(self):
         shape = (2, 3)
@@ -131,6 +132,7 @@ class TestNumpyArrayCreation(TestNumpyMethods):
 
         helpers.assert_quantity_equal(actual, expected)
 
+    # before 1.23.0, identity seems to be a pure python function with changing address
     @helpers.requires_numpy_at_least("1.23.0")
     def test_identity(self):
         actual = np.identity(10, like=self.q)
@@ -138,6 +140,7 @@ class TestNumpyArrayCreation(TestNumpyMethods):
 
         helpers.assert_quantity_equal(actual, expected)
 
+    # before 1.23.0, eye seems to be a pure python function with changing address
     @helpers.requires_numpy_at_least("1.23.0")
     def test_eye(self):
         actual = np.eye(10, like=self.q)

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -132,6 +132,19 @@ class TestNumpyArrayCreation(TestNumpyMethods):
 
         helpers.assert_quantity_equal(actual, expected)
 
+    def test_full(self):
+        shape = (2, 2)
+
+        actual = np.full(
+            shape=shape, fill_value=self.Q_(0, self.ureg.degC), like=self.q
+        )
+        expected = self.Q_([[0, 0], [0, 0]], self.ureg.degC)
+        helpers.assert_quantity_equal(actual, expected)
+
+        actual = np.full(shape=shape, fill_value=2, like=self.q)
+        expected = self.Q_([[2, 2], [2, 2]], "dimensionless")
+        helpers.assert_quantity_equal(actual, expected)
+
     # before 1.23.0, identity seems to be a pure python function with changing address
     @helpers.requires_numpy_at_least("1.23.0")
     def test_identity(self):

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -110,6 +110,28 @@ class TestNumpyArrayCreation(TestNumpyMethods):
         helpers.assert_quantity_equal(actual, expected)
 
     @helpers.requires_numpy_at_least("1.23.0")
+    def test_ones(self):
+        shape = (2, 3)
+        actual = np.ones(shape=shape, like=self.q)
+        expected = self.Q_(np.ones(shape=shape), self.q.units)
+
+        helpers.assert_quantity_equal(actual, expected)
+
+    def test_zeros(self):
+        shape = (2, 3)
+        actual = np.zeros(shape=shape, like=self.q)
+        expected = self.Q_(np.zeros(shape=shape), self.q.units)
+
+        helpers.assert_quantity_equal(actual, expected)
+
+    def test_empty(self):
+        shape = (2, 3)
+        actual = np.empty(shape=shape, like=self.q)
+        expected = self.Q_(np.empty(shape=shape), self.q.units)
+
+        helpers.assert_quantity_equal(actual, expected)
+
+    @helpers.requires_numpy_at_least("1.23.0")
     def test_identity(self):
         actual = np.identity(10, like=self.q)
         expected = self.Q_(np.identity(10), self.q.units)

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -57,17 +57,22 @@ class TestNumpyArrayCreation(TestNumpyMethods):
 
     @helpers.requires_array_function_protocol()
     def test_ones_like(self):
-        self.assertNDArrayEqual(np.ones_like(self.q), np.array([[1, 1], [1, 1]]))
+        helpers.assert_quantity_equal(
+            np.ones_like(self.q), self.Q_([[1, 1], [1, 1]], self.q.units)
+        )
 
     @helpers.requires_array_function_protocol()
     def test_zeros_like(self):
-        self.assertNDArrayEqual(np.zeros_like(self.q), np.array([[0, 0], [0, 0]]))
+        helpers.assert_quantity_equal(
+            np.zeros_like(self.q), self.Q_([[0, 0], [0, 0]], self.q.units)
+        )
 
     @helpers.requires_array_function_protocol()
     def test_empty_like(self):
         ret = np.empty_like(self.q)
-        assert ret.shape == (2, 2)
-        assert isinstance(ret, np.ndarray)
+        expected = self.Q_(np.empty_like(self.q.magnitude), self.q.units)
+
+        helpers.assert_quantity_equal(ret, expected)
 
     @helpers.requires_array_function_protocol()
     def test_full_like(self):


### PR DESCRIPTION
- [x] Closes #1406, closes #1037, closes #882
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

For a more consistent experience with the `*_like` functions and the functions from NEP 35 (introduced in `numpy=1.20`, minimum version is `1.19.5` but could be `1.20` according to NEP 29), this changes the semantics to:
- have `full_like` return the units of `fill_value` (a non-quantity `fill_value` results an array of the type of the magnitude):
```python
full_like(arr, fill_value=q) == Quantity(full_like(arr, fill_value=q.magnitude), q.units)
```
- have `empty_like` use the units of the argument:
```python
empty_like(q) == Quantity(empty_like(q.magnitude), q.units)
```
- have `ones_like` and `zero_like` a quantity with the units of the argument:
```python
ones_like(q) == full_like(q, fill_value=Quantity(1, q.units))
zeros_like(q) == full_like(q, fill_value=Quantity(0, q.units))
```
- support the NEP 35 keyword `like` for creation functions:
```python
np.array(arr, like=q) == Quantity(np.array(arr), q.units)
np.arange(10, like=q) == Quantity(np.arange(10, like=q.magnitude), q.units)
...
```

I'm not sure I got all of the functions that were changed by NEP 35, I couldn't find a comprehensive list. The ones I found are:
- `array`
- `asarray`
- `asanyarray`
- `arange`
- `ones`
- `zeros`
- `empty`
- `full`
- `identity`
- `eye`

but I'm almost certain I missed some. The definition of all of them except `full` is pretty simple: just use the units of the `like` argument. For `full`, I choose to go with the unit of the `fill_value` or `dimensionless` if the fill value happens not to be a quantity (because by passing `like` we expect a quantity). I'm not really sure about that, though.

cc @jthielen