### PR TITLE
use `packaging.version` instead of the deprecated `distutils.version`

### DIFF
--- a/pint/testsuite/helpers.py
+++ b/pint/testsuite/helpers.py
@@ -1,9 +1,9 @@
 import doctest
 import pickle
 import re
-from distutils.version import LooseVersion
 
 import pytest
+from packaging.version import parse as version_parse
 
 from pint.testing import assert_allclose as assert_quantity_almost_equal  # noqa: F401
 from pint.testing import assert_equal as assert_quantity_equal  # noqa: F401
@@ -113,7 +113,7 @@ def requires_numpy_previous_than(version):
     if not HAS_NUMPY:
         return pytest.mark.skip("Requires NumPy")
     return pytest.mark.skipif(
-        not LooseVersion(NUMPY_VER) < LooseVersion(version),
+        not version_parse(NUMPY_VER) < version_parse(version),
         reason="Requires NumPy < %s" % version,
     )
 
@@ -122,7 +122,7 @@ def requires_numpy_at_least(version):
     if not HAS_NUMPY:
         return pytest.mark.skip("Requires NumPy")
     return pytest.mark.skipif(
-        not LooseVersion(NUMPY_VER) >= LooseVersion(version),
+        not version_parse(NUMPY_VER) >= version_parse(version),
         reason="Requires NumPy >= %s" % version,
     )
 


### PR DESCRIPTION
- [x] Executed ``pre-commit run --all-files`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file