### PR TITLE
explicitly install `packaging` for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt install -y graphviz
-          pip install pytest pytest-cov pytest-subtests
+          pip install pytest pytest-cov pytest-subtests packaging
           pip install .
 
       - name: Install pytest-mpl
@@ -139,7 +139,7 @@ jobs:
       - name: Install dependencies
         run: |
           # sudo apt install -y graphviz
-          pip install pytest pytest-cov pytest-subtests
+          pip install pytest pytest-cov pytest-subtests packaging
           pip install .
 
       # - name: Install pytest-mpl
@@ -191,7 +191,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install pytest pytest-cov pytest-subtests
+          pip install pytest pytest-cov pytest-subtests packaging
           pip install .
 
       - name: Run Tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ test =
     pytest-mpl
     pytest-cov
     pytest-subtests
+    packaging
 
 [options.package_data]
 pint = default_en.txt; constants_en.txt; py.typed


### PR DESCRIPTION
Not really necessary since some of the dependencies pull it in, anyways, but it's good to explicitly install it to avoid breaking CI in case that changes.

- [x] follow-up to #1670
- [x] Executed ``pre-commit run --all-files`` with no errors