### PR TITLE
run `black` on notebooks as well

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     rev: 22.10.0
     hooks:
     - id: black
+    - id: black-jupyter
 -   repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,6 @@ repos:
 -   repo: https://github.com/psf/black
     rev: 22.10.0
     hooks:
-    - id: black
     - id: black-jupyter
 -   repo: https://github.com/pycqa/isort
     rev: 5.10.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,8 @@ repos:
     rev: 6.0.0
     hooks:
     - id: flake8
+-   repo: https://github.com/kynan/nbstripout
+    rev: 0.6.1
+    hooks:
+      - id: nbstripout
+        args: [--extra-keys=metadata.kernelspec metadata.language_info.version]

--- a/docs/user/numpy.ipynb
+++ b/docs/user/numpy.ipynb
@@ -37,11 +37,13 @@
     "\n",
     "# Import Pint\n",
     "import pint\n",
+    "\n",
     "ureg = pint.UnitRegistry()\n",
     "Q_ = ureg.Quantity\n",
     "\n",
     "# Silence NEP 18 warning\n",
     "import warnings\n",
+    "\n",
     "with warnings.catch_warnings():\n",
     "    warnings.simplefilter(\"ignore\")\n",
     "    Q_([])"
@@ -68,7 +70,7 @@
    },
    "outputs": [],
    "source": [
-    "legs1 = Q_(np.asarray([3., 4.]), 'meter')\n",
+    "legs1 = Q_(np.asarray([3.0, 4.0]), \"meter\")\n",
     "print(legs1)"
    ]
   },
@@ -82,7 +84,7 @@
    },
    "outputs": [],
    "source": [
-    "legs1 = [3., 4.] * ureg.meter\n",
+    "legs1 = [3.0, 4.0] * ureg.meter\n",
     "print(legs1)"
    ]
   },
@@ -107,7 +109,7 @@
    },
    "outputs": [],
    "source": [
-    "print(legs1.to('kilometer'))"
+    "print(legs1.to(\"kilometer\"))"
    ]
   },
   {
@@ -134,7 +136,7 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    legs1.to('joule')\n",
+    "    legs1.to(\"joule\")\n",
     "except pint.DimensionalityError as exc:\n",
     "    print(exc)"
    ]
@@ -160,7 +162,7 @@
    },
    "outputs": [],
    "source": [
-    "legs2 = [400., 300.] * ureg.centimeter\n",
+    "legs2 = [400.0, 300.0] * ureg.centimeter\n",
     "print(legs2)"
    ]
   },
@@ -214,7 +216,7 @@
    },
    "outputs": [],
    "source": [
-    "angles = np.arccos(legs2/hyps)\n",
+    "angles = np.arccos(legs2 / hyps)\n",
     "print(angles)"
    ]
   },
@@ -239,7 +241,7 @@
    },
    "outputs": [],
    "source": [
-    "print(angles.to('degree'))"
+    "print(angles.to(\"degree\"))"
    ]
   },
   {
@@ -302,6 +304,7 @@
    "outputs": [],
    "source": [
     "from pint.facets.numpy.numpy_func import HANDLED_FUNCTIONS\n",
+    "\n",
     "print(sorted(list(HANDLED_FUNCTIONS)))"
    ]
   },
@@ -374,27 +377,27 @@
    "source": [
     "from graphviz import Digraph\n",
     "\n",
-    "g = Digraph(graph_attr={'size': '8,5'}, node_attr={'fontname': 'courier'})\n",
-    "g.edge('Dask array', 'NumPy ndarray')\n",
-    "g.edge('Dask array', 'CuPy ndarray')\n",
-    "g.edge('Dask array', 'Sparse COO')\n",
-    "g.edge('Dask array', 'NumPy masked array', style='dashed')\n",
-    "g.edge('CuPy ndarray', 'NumPy ndarray')\n",
-    "g.edge('Sparse COO', 'NumPy ndarray')\n",
-    "g.edge('NumPy masked array', 'NumPy ndarray')\n",
-    "g.edge('Jax array', 'NumPy ndarray')\n",
-    "g.edge('Pint Quantity', 'Dask array', style='dashed')\n",
-    "g.edge('Pint Quantity', 'NumPy ndarray')\n",
-    "g.edge('Pint Quantity', 'CuPy ndarray', style='dashed')\n",
-    "g.edge('Pint Quantity', 'Sparse COO')\n",
-    "g.edge('Pint Quantity', 'NumPy masked array', style='dashed')\n",
-    "g.edge('xarray Dataset/DataArray/Variable', 'Dask array')\n",
-    "g.edge('xarray Dataset/DataArray/Variable', 'CuPy ndarray', style='dashed')\n",
-    "g.edge('xarray Dataset/DataArray/Variable', 'Sparse COO')\n",
-    "g.edge('xarray Dataset/DataArray/Variable', 'NumPy ndarray')\n",
-    "g.edge('xarray Dataset/DataArray/Variable', 'NumPy masked array', style='dashed')\n",
-    "g.edge('xarray Dataset/DataArray/Variable', 'Pint Quantity')\n",
-    "g.edge('xarray Dataset/DataArray/Variable', 'Jax array', style='dashed')\n",
+    "g = Digraph(graph_attr={\"size\": \"8,5\"}, node_attr={\"fontname\": \"courier\"})\n",
+    "g.edge(\"Dask array\", \"NumPy ndarray\")\n",
+    "g.edge(\"Dask array\", \"CuPy ndarray\")\n",
+    "g.edge(\"Dask array\", \"Sparse COO\")\n",
+    "g.edge(\"Dask array\", \"NumPy masked array\", style=\"dashed\")\n",
+    "g.edge(\"CuPy ndarray\", \"NumPy ndarray\")\n",
+    "g.edge(\"Sparse COO\", \"NumPy ndarray\")\n",
+    "g.edge(\"NumPy masked array\", \"NumPy ndarray\")\n",
+    "g.edge(\"Jax array\", \"NumPy ndarray\")\n",
+    "g.edge(\"Pint Quantity\", \"Dask array\", style=\"dashed\")\n",
+    "g.edge(\"Pint Quantity\", \"NumPy ndarray\")\n",
+    "g.edge(\"Pint Quantity\", \"CuPy ndarray\", style=\"dashed\")\n",
+    "g.edge(\"Pint Quantity\", \"Sparse COO\")\n",
+    "g.edge(\"Pint Quantity\", \"NumPy masked array\", style=\"dashed\")\n",
+    "g.edge(\"xarray Dataset/DataArray/Variable\", \"Dask array\")\n",
+    "g.edge(\"xarray Dataset/DataArray/Variable\", \"CuPy ndarray\", style=\"dashed\")\n",
+    "g.edge(\"xarray Dataset/DataArray/Variable\", \"Sparse COO\")\n",
+    "g.edge(\"xarray Dataset/DataArray/Variable\", \"NumPy ndarray\")\n",
+    "g.edge(\"xarray Dataset/DataArray/Variable\", \"NumPy masked array\", style=\"dashed\")\n",
+    "g.edge(\"xarray Dataset/DataArray/Variable\", \"Pint Quantity\")\n",
+    "g.edge(\"xarray Dataset/DataArray/Variable\", \"Jax array\", style=\"dashed\")\n",
     "g"
    ]
   },
@@ -424,10 +427,10 @@
     "import xarray as xr\n",
     "\n",
     "# Load tutorial data\n",
-    "air = xr.tutorial.load_dataset('air_temperature')['air'][0]\n",
+    "air = xr.tutorial.load_dataset(\"air_temperature\")[\"air\"][0]\n",
     "\n",
     "# Convert to Quantity\n",
-    "air.data = Q_(air.data, air.attrs.pop('units', ''))\n",
+    "air.data = Q_(air.data, air.attrs.pop(\"units\", \"\"))\n",
     "\n",
     "print(air)\n",
     "print()\n",
@@ -494,7 +497,7 @@
     "m = np.ma.masked_array([2, 3, 5, 7], mask=[False, True, False, True])\n",
     "\n",
     "# Must create using Quantity class\n",
-    "print(repr(ureg.Quantity(m, 'm')))\n",
+    "print(repr(ureg.Quantity(m, \"m\")))\n",
     "print()\n",
     "\n",
     "# DO NOT create using multiplication until\n",
@@ -568,14 +571,14 @@
     "x[x < 0.95] = 0\n",
     "\n",
     "data = xr.DataArray(\n",
-    "    Q_(x.map_blocks(COO), 'm'),\n",
-    "    dims=('z', 'y', 'x'),\n",
+    "    Q_(x.map_blocks(COO), \"m\"),\n",
+    "    dims=(\"z\", \"y\", \"x\"),\n",
     "    coords={\n",
-    "        'z': np.arange(100),\n",
-    "        'y': np.arange(100) - 50,\n",
-    "        'x': np.arange(100) * 1.5 - 20\n",
+    "        \"z\": np.arange(100),\n",
+    "        \"y\": np.arange(100) - 50,\n",
+    "        \"x\": np.arange(100) * 1.5 - 20,\n",
     "    },\n",
-    "    name='test'\n",
+    "    name=\"test\",\n",
     ")\n",
     "\n",
     "print(data)\n",

--- a/docs/user/numpy.ipynb
+++ b/docs/user/numpy.ipynb
@@ -630,11 +630,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -644,8 +639,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
A while ago, `black` introduced the `black-jupyter` hook, which blackens code in notebook cells.

Being consistent within a project is important, so in a new PR we should try to blacken the code in the narrative documentation / doctests as well.

- [x] Executed ``pre-commit run --all-files`` with no errors