### PR TITLE
add NEP18 overrides for `max`, `min`, and `round`

### DIFF
--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -816,6 +816,8 @@ for func_str, unit_arguments, wrap_output in [
     ("broadcast_to", ["array"], True),
     ("amax", ["a", "initial"], True),
     ("amin", ["a", "initial"], True),
+    ("max", ["a", "initial"], True),
+    ("min", ["a", "initial"], True),
     ("searchsorted", ["a", "v"], False),
     ("isclose", ["a", "b"], False),
     ("nan_to_num", ["x", "nan", "posinf", "neginf"], True),

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -796,6 +796,7 @@ for func_str, unit_arguments, wrap_output in [
     ("ptp", "a", True),
     ("ravel", "a", True),
     ("round_", "a", True),
+    ("round", "a", True),
     ("sort", "a", True),
     ("median", "a", True),
     ("nanmedian", "a", True),

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -806,7 +806,7 @@ class TestNumpyUnclassified(TestNumpyMethods):
             np.around(1.0275 * self.ureg.m, decimals=2), 1.03 * self.ureg.m
         )
         helpers.assert_quantity_equal(
-            np.round_(1.0275 * self.ureg.m, decimals=2), 1.03 * self.ureg.m
+            np.round(1.0275 * self.ureg.m, decimals=2), 1.03 * self.ureg.m
         )
 
     def test_trace(self):


### PR DESCRIPTION
`numpy` recently changed the names of `amin` and `amax` to `min` and `max`, with the old names being kept around as aliases. However, that means that we need to override *both* until `numpy<1.25` drops out of support (which will be a while, considering that `numpy=1.25` has not been released yet).

Additionally, `round_` has been deprecated in favor of `round`.

The test coverage has already been sufficient (we didn't get errors in CI because we don't test `numpy` dev), but I changed the `round` tests to not use the deprecated name.

- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] ~The change is fully covered by automated unit tests~
- [x] ~Documented in docs/ as appropriate~