### PR TITLE
Fix __dask_postcompute__() to better preserve type

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,8 @@ Pint Changelog
   (PR #1663)
 - Changed frequency to angular frequency in the docs.
   (PR #1668)
+- Fixed Quantity type returned from `__dask_postcompute__`.
+  (PR #1722)
 
 ### Breaking Changes
 

--- a/pint/facets/dask/__init__.py
+++ b/pint/facets/dask/__init__.py
@@ -46,10 +46,7 @@ class DaskQuantity:
     def __dask_tokenize__(self):
         from dask.base import tokenize
 
-        from pint import UnitRegistry
-
-        # TODO: Check if this is the right class as first argument
-        return (UnitRegistry.Quantity, tokenize(self._magnitude), self.units)
+        return (type(self), tokenize(self._magnitude), self.units)
 
     @property
     def __dask_optimize__(self):
@@ -67,14 +64,9 @@ class DaskQuantity:
         func, args = self._magnitude.__dask_postpersist__()
         return self._dask_finalize, (func, args, self.units)
 
-    @staticmethod
-    def _dask_finalize(results, func, args, units):
+    def _dask_finalize(self, results, func, args, units):
         values = func(results, *args)
-
-        from pint import Quantity
-
-        # TODO: Check if this is the right class as first argument
-        return Quantity(values, units)
+        return type(self)(values, units)
 
     @check_dask_array
     def compute(self, **kwargs):

--- a/pint/testsuite/test_dask.py
+++ b/pint/testsuite/test_dask.py
@@ -149,6 +149,8 @@ def test_compute_persist_equivalent(local_registry, dask_array, numpy_array):
 
     assert np.all(res_compute == res_persist)
     assert res_compute.units == res_persist.units == units_
+    assert type(res_compute) == local_registry.Quantity
+    assert type(res_persist) == local_registry.Quantity
 
 
 @pytest.mark.parametrize("method", ["compute", "persist", "visualize"])


### PR DESCRIPTION
In Unidata/MetPy#2945, a call to dask's .compute() was causing the resulting type to be a different Quantity() variant (from pint.util rather than the parent registry), which resulted in isinstance() failing. This changes things to use the appropriate type from `self` rather than hard-coded class names.

- [ ] Closes # (insert issue number)
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
