### PR TITLE
use `**kwargs` to pass along additional arguments to `ones_like`

### DIFF
--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -527,22 +527,16 @@ def _meshgrid(*xi, **kwargs):
 
 
 @implements("full_like", "function")
-def _full_like(a, fill_value, dtype=None, order="K", subok=True, shape=None):
+def _full_like(a, fill_value, **kwargs):
     # Make full_like by multiplying with array from ones_like in a
     # non-multiplicative-unit-safe way
     if hasattr(fill_value, "_REGISTRY"):
         return fill_value._REGISTRY.Quantity(
-            (
-                np.ones_like(a, dtype=dtype, order=order, subok=subok, shape=shape)
-                * fill_value.m
-            ),
+            np.ones_like(a, **kwargs) * fill_value.m,
             fill_value.units,
         )
     else:
-        return (
-            np.ones_like(a, dtype=dtype, order=order, subok=subok, shape=shape)
-            * fill_value
-        )
+        return np.ones_like(a, **kwargs) * fill_value
 
 
 @implements("interp", "function")


### PR DESCRIPTION
This is a fix to be included in a release before merging #1669, as the changes there would break `xarray` with no possible work-around. Not sure if we need tests, as those would probably be tricky to write and maintain.

@hgrecco, @jules-ch, I'd like to have a bugfix release some time soon, and include #1669 in the next release. Would that be possible? (Also, I'd be happy to help make that happen)

- [x] Executed ``pre-commit run --all-files`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file