### PR TITLE
Use already existing cache if found during build

### DIFF
--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -534,7 +534,9 @@ class PlainRegistry(metaclass=RegistryMeta):
             if cache is None:
                 self._build_cache()
                 diskcache.save(self._cache, loaded_files, "build_cache")
-            return
+            else:
+                self._cache = cache
+                return
 
         self._cache = RegistryCache()
 

--- a/pint/testsuite/test_diskcache.py
+++ b/pint/testsuite/test_diskcache.py
@@ -95,3 +95,13 @@ def test_change_file(tmp_path):
     assert ureg.x == 1235
     files = tuple(ureg._diskcache.cache_folder.glob("*.pickle"))
     assert len(files) == 4
+
+
+def test_dimensional_equivalent_are_cached(tmp_path):
+    ureg = pint.UnitRegistry(cache_folder=tmp_path)
+    t = ureg.get_compatible_units("L")
+    assert len(t) > 0
+
+    ureg = pint.UnitRegistry(cache_folder=tmp_path)
+    t = ureg.get_compatible_units("L")
+    assert len(t) > 0


### PR DESCRIPTION
- [x] Closes #1746
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

This pull request attempts to update the `PlainRegistry` to set `self._cache` to the data retrieve from the cached data. Tests are passing, so I believe this change resolves the issue linked, but I'm not confident if it is the correct resolution or not.
