### PR TITLE
Extend upcast_type_names with fully qualified names

### DIFF
--- a/pint/compat.py
+++ b/pint/compat.py
@@ -215,12 +215,12 @@ except ImportError:
 
 #: List upcast type names
 upcast_type_names = (
-    "pint_pandas.PintArray",
-    "pandas.Series",
+    "pint_pandas.pint_array.PintArray",
     "xarray.core.dataarray.DataArray",
     "xarray.core.dataset.Dataset",
     "xarray.core.variable.Variable",
     "pandas.core.series.Series",
+    "pandas.core.frame.DataFrame",
     "xarray.core.dataarray.DataArray",
 )
 


### PR DESCRIPTION
To fix the recent `pint-pandas` regressions discussed in https://github.com/hgrecco/pint-pandas/pull/171 , it seems to help to have `DataFrame`s in the list and to ensure that the full module name is used for `PintArray` (for it to be found).

Feel free to comment and adapt as necessary!