### PR TITLE
Remove __array__ interface

### DIFF
--- a/pint/facets/numpy/quantity.py
+++ b/pint/facets/numpy/quantity.py
@@ -129,10 +129,10 @@ class NumpyQuantity(Generic[MagnitudeT], PlainQuantity[MagnitudeT]):
         if isinstance(values, self.__class__):
             values = values.to(self).magnitude
         elif self.dimensionless:
-            values = self.__class__(values, "").to(self)
+            values = self.__class__(values, "").to(self).magnitude
         else:
             raise DimensionalityError("dimensionless", self._units)
-        self.magnitude.put(indices, values, mode)
+        self._magnitude.put(indices, values, mode)
 
     @property
     def real(self) -> NumpyQuantity:

--- a/pint/facets/numpy/quantity.py
+++ b/pint/facets/numpy/quantity.py
@@ -10,14 +10,13 @@ from __future__ import annotations
 
 import functools
 import math
-import warnings
 from typing import Any, Generic
 
 from ..plain import PlainQuantity, MagnitudeT
 
 from ..._typing import Shape
 from ...compat import _to_magnitude, np
-from ...errors import DimensionalityError, PintTypeError, UnitStrippedWarning
+from ...errors import DimensionalityError, PintTypeError
 from .numpy_func import (
     HANDLED_UFUNCS,
     copy_units_output_ufuncs,
@@ -103,14 +102,6 @@ class NumpyQuantity(Generic[MagnitudeT], PlainQuantity[MagnitudeT]):
             return self.__class__(value, output_unit)
 
         return value
-
-    def __array__(self, t=None) -> np.ndarray:
-        warnings.warn(
-            "The unit of the quantity is stripped when downcasting to ndarray.",
-            UnitStrippedWarning,
-            stacklevel=2,
-        )
-        return _to_magnitude(self._magnitude, force_ndarray=True)
 
     def clip(self, min=None, max=None, out=None, **kwargs):
         if min is not None:

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -5,7 +5,7 @@ import warnings
 
 import pytest
 
-from pint import DimensionalityError, OffsetUnitCalculusError, UnitStrippedWarning
+from pint import DimensionalityError, OffsetUnitCalculusError
 from pint.compat import np
 from pint.testsuite import helpers
 from pint.testsuite.test_umath import TestUFuncs

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1255,17 +1255,8 @@ class TestNumpyUnclassified(TestNumpyMethods):
             np.array([1, 3, 5, 7, 8, 9, 10, 11, 12]) * self.ureg.m,
         )
 
-    def test_ndarray_downcast(self):
-        with pytest.warns(UnitStrippedWarning):
-            np.asarray(self.q)
-
-    def test_ndarray_downcast_with_dtype(self):
-        with pytest.warns(UnitStrippedWarning):
-            qarr = np.asarray(self.q, dtype=np.float64)
-            assert qarr.dtype == np.float64
-
     def test_array_protocol_unavailable(self):
-        for attr in ("__array_struct__", "__array_interface__"):
+        for attr in ("__array__", "__array_struct__", "__array_interface__"):
             with pytest.raises(AttributeError):
                 getattr(self.q, attr)
 

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -653,7 +653,7 @@ class TestQuantity(QuantityTestCase):
 
     @helpers.requires_not_numpy()
     def test_no_ndarray_coercion_without_numpy(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(AttributeError):
             self.Q_(1, "m").__array__()
 
     @patch(


### PR DESCRIPTION
- [ ] Closes https://github.com/hgrecco/pint-pandas/issues/174
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] ~Documented in docs/ as appropriate~
- [ ] Added an entry to the CHANGES file

In hunting down options to address https://github.com/hgrecco/pint-pandas/issues/174 , the only solution i found so far to reliably work was to get rid of the `__array__` interface entirely, as a more extreme version of the discussion in https://github.com/hgrecco/pint/issues/1128 .

I was quite surprised to learn that nothing in pint directly depends on the interface, but i guess it would be too much of a breaking change. Nevertheless, I like the idea of pint not ever implictly stripping units.

More realistically this means a proper implementation of the `__array_ufunc__` alternative might solve at least the linked issue.

I guess you all are exhausted by these discussion already, sorry that i am pbb missing all the basics.