### PR TITLE
allow non-quantity `atol` parameters for `isclose` and `allclose`

### DIFF
--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1068,6 +1068,10 @@ class TestNumpyUnclassified(TestNumpyMethods):
             np.isclose(self.q, q2, atol=1e-5 * self.ureg.mm, rtol=1e-7),
             np.array([[False, True], [True, False]]),
         )
+        self.assertNDArrayEqual(
+            np.isclose(self.q, q2, atol=1e-5, rtol=1e-7),
+            np.array([[False, True], [True, False]]),
+        )
 
     @helpers.requires_array_function_protocol()
     def test_interp_numpy_func(self):
@@ -1403,9 +1407,15 @@ class TestNumpyUnclassified(TestNumpyMethods):
             [1.0, np.nan] * self.ureg.m, [1.0, np.nan] * self.ureg.m, equal_nan=True
         )
 
+        assert np.allclose(
+            [1e10, 1e-8] * self.ureg.m, [1.00001e10, 1e-9] * self.ureg.m, atol=1e-8
+        )
+
         with pytest.raises(DimensionalityError):
             assert np.allclose(
-                [1e10, 1e-8] * self.ureg.m, [1.00001e10, 1e-9] * self.ureg.m, atol=1e-8
+                [1e10, 1e-8] * self.ureg.m,
+                [1.00001e10, 1e-9] * self.ureg.m,
+                atol=1e-8 * self.ureg.s,
             )
 
     @helpers.requires_array_function_protocol()


### PR DESCRIPTION
As suggested in https://github.com/hgrecco/pint/pull/1660#issuecomment-1536572859, this uses the unit of `a` if `atol` is a non-quantity (i.e. a non-`pint` type).

@dopplershift, this fixes the failing tests for `xarray` so I *think* it should also fix the failures for `metpy`, but it might be good to verify that before merging.

- [x] follow-up to #1660
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Added an entry to the CHANGES file