### PR TITLE
Complete sentences about readonly objects in utils

### DIFF
--- a/pint/util.py
+++ b/pint/util.py
@@ -440,6 +440,7 @@ class UnitsContainer(Mapping[str, Scalar]):
     exponent and implements the corresponding operations.
 
     UnitsContainer is a read-only mapping. All operations (even in place ones)
+    return new instances.
 
     Parameters
     ----------
@@ -678,6 +679,7 @@ class ParserHelper(UnitsContainer):
     Briefly is a UnitsContainer with a scaling factor.
 
     ParserHelper is a read-only mapping. All operations (even in place ones)
+    return new instances.
 
     WARNING : The hash value used does not take into account the scale
     attribute so be careful if you use it as a dict key and then two unequal


### PR DESCRIPTION
Was incorrectly removed in #958

- [N/A] Closes # (insert issue number)
- [N/A] Executed `pre-commit run --all-files` with no errors
- [N/A] The change is fully covered by automated unit tests
- [N/A] Documented in docs/ as appropriate
- [N/A] Added an entry to the CHANGES file
