### PR TITLE
Rename the first positional arg in _trapz to match numpy

### DIFF
--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -741,23 +741,23 @@ def _base_unit_if_needed(a):
 
 
 @implements("trapz", "function")
-def _trapz(a, x=None, dx=1.0, **kwargs):
-    a = _base_unit_if_needed(a)
-    units = a.units
+def _trapz(y, x=None, dx=1.0, **kwargs):
+    y = _base_unit_if_needed(y)
+    units = y.units
     if x is not None:
         if hasattr(x, "units"):
             x = _base_unit_if_needed(x)
             units *= x.units
             x = x._magnitude
-        ret = np.trapz(a._magnitude, x, **kwargs)
+        ret = np.trapz(y._magnitude, x, **kwargs)
     else:
         if hasattr(dx, "units"):
             dx = _base_unit_if_needed(dx)
             units *= dx.units
             dx = dx._magnitude
-        ret = np.trapz(a._magnitude, dx=dx, **kwargs)
+        ret = np.trapz(y._magnitude, dx=dx, **kwargs)
 
-    return a.units._REGISTRY.Quantity(ret, units)
+    return y.units._REGISTRY.Quantity(ret, units)
 
 
 def implement_mul_func(func):


### PR DESCRIPTION
As implemented currently, the `trapz` function is not consistent between numpy and pint 

```python
x = np.linspace(0,1)
x2 = x * unit_registry('m')
y = x**2 
y2 = x2 ** 2

np.trapz(x=x,y=y) # Works 

np.trapz(x=x2,y=y2) # Throws error 
```

The reason is that as in the [numpy documentation](https://numpy.org/doc/stable/reference/generated/numpy.trapz.html), the first positional argument for `trapz` is `y`, while pint's overriding implementation has it as `a`, which is more like the unary numpy functions. 