### PR TITLE
Added a facet for array uncertainty propagation

### DIFF
--- a/pint/compat.py
+++ b/pint/compat.py
@@ -155,6 +155,15 @@ except ImportError:
     ufloat = None
     HAS_UNCERTAINTIES = False
 
+
+try:
+    from auto_uncertainties import Uncertainty
+
+    HAS_AUTOUNCERTAINTIES = True
+except ImportError:
+    Uncertainty = None
+    HAS_AUTOUNCERTAINTIES = False
+
 try:
     from babel import Locale
     from babel import units as babel_units

--- a/pint/facets/__init__.py
+++ b/pint/facets/__init__.py
@@ -83,6 +83,7 @@ from .nonmultiplicative import (
 from .numpy import NumpyRegistry, GenericNumpyRegistry
 from .plain import PlainRegistry, GenericPlainRegistry, QuantityT, UnitT, MagnitudeT
 from .system import SystemRegistry, GenericSystemRegistry
+from .uncertainties import UncertaintyRegistry, GenericUncertaintyRegistry
 
 __all__ = [
     "ContextRegistry",
@@ -106,4 +107,6 @@ __all__ = [
     "QuantityT",
     "UnitT",
     "MagnitudeT",
+    "UncertaintyRegistry",
+    "GenericUncertaintyRegistry",
 ]

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -741,23 +741,23 @@ def _base_unit_if_needed(a):
 
 
 @implements("trapz", "function")
-def _trapz(a, x=None, dx=1.0, **kwargs):
-    a = _base_unit_if_needed(a)
-    units = a.units
+def _trapz(y, x=None, dx=1.0, **kwargs):
+    y = _base_unit_if_needed(y)
+    units = y.units
     if x is not None:
         if hasattr(x, "units"):
             x = _base_unit_if_needed(x)
             units *= x.units
             x = x._magnitude
-        ret = np.trapz(a._magnitude, x, **kwargs)
+        ret = np.trapz(y._magnitude, x, **kwargs)
     else:
         if hasattr(dx, "units"):
             dx = _base_unit_if_needed(dx)
             units *= dx.units
             dx = dx._magnitude
-        ret = np.trapz(a._magnitude, dx=dx, **kwargs)
+        ret = np.trapz(y._magnitude, dx=dx, **kwargs)
 
-    return a.units._REGISTRY.Quantity(ret, units)
+    return y.units._REGISTRY.Quantity(ret, units)
 
 
 def implement_mul_func(func):

--- a/pint/facets/uncertainties/__init__.py
+++ b/pint/facets/uncertainties/__init__.py
@@ -1,0 +1,57 @@
+"""
+    pint.facets.Uncertainty
+    ~~~~~~~~~~~~~~~~
+
+    Adds pint the capability to interoperate with Uncertainty
+
+    :copyright: 2022 by Pint Authors, see AUTHORS for more details.
+    :license: BSD, see LICENSE for more details.
+"""
+
+
+from __future__ import annotations
+
+from typing import Generic, Any
+
+from ...compat import Uncertainty, TypeAlias
+from ..plain import (
+    GenericPlainRegistry,
+    PlainQuantity,
+    QuantityT,
+    UnitT,
+    PlainUnit,
+    MagnitudeT,
+)
+
+
+class UncertaintyQuantity(Generic[MagnitudeT], PlainQuantity[MagnitudeT]):
+    @property
+    def value(self):
+        if isinstance(self._magnitude, Uncertainty):
+            return self._magnitude.value * self.units
+        else:
+            return self._magnitude * self.units
+
+    @property
+    def error(self):
+        if isinstance(self._magnitude, Uncertainty):
+            return self._magnitude.error * self.units
+        else:
+            return (0 * self._magnitude) * self.units
+
+
+class UncertaintyUnit(PlainUnit):
+    pass
+
+
+class GenericUncertaintyRegistry(
+    Generic[QuantityT, UnitT], GenericPlainRegistry[QuantityT, UnitT]
+):
+    pass
+
+
+class UncertaintyRegistry(
+    GenericUncertaintyRegistry[UncertaintyQuantity[Any], UncertaintyUnit]
+):
+    Quantity: TypeAlias = UncertaintyQuantity[Any]
+    Unit: TypeAlias = UncertaintyUnit

--- a/pint/facets/uncertainties/__init__.py
+++ b/pint/facets/uncertainties/__init__.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from typing import Generic, Any
 
-from ...compat import Uncertainty, TypeAlias
+from ...compat import TypeAlias, HAS_AUTOUNCERTAINTIES
 from ..plain import (
     GenericPlainRegistry,
     PlainQuantity,
@@ -22,6 +22,11 @@ from ..plain import (
     PlainUnit,
     MagnitudeT,
 )
+
+if HAS_AUTOUNCERTAINTIES:
+    from auto_uncertainties import Uncertainty
+else:
+    Uncertainty = None
 
 
 class UncertaintyQuantity(Generic[MagnitudeT], PlainQuantity[MagnitudeT]):

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -30,6 +30,7 @@ from .compat import TypeAlias
 class Quantity(
     facets.SystemRegistry.Quantity,
     facets.ContextRegistry.Quantity,
+    facets.UncertaintyRegistry.Quantity,
     facets.DaskRegistry.Quantity,
     facets.NumpyRegistry.Quantity,
     facets.MeasurementRegistry.Quantity,
@@ -43,6 +44,7 @@ class Quantity(
 class Unit(
     facets.SystemRegistry.Unit,
     facets.ContextRegistry.Unit,
+    facets.UncertaintyRegistry.Unit,
     facets.DaskRegistry.Unit,
     facets.NumpyRegistry.Unit,
     facets.MeasurementRegistry.Unit,
@@ -57,6 +59,7 @@ class GenericUnitRegistry(
     Generic[facets.QuantityT, facets.UnitT],
     facets.GenericSystemRegistry[facets.QuantityT, facets.UnitT],
     facets.GenericContextRegistry[facets.QuantityT, facets.UnitT],
+    facets.GenericUncertaintyRegistry[facets.QuantityT, facets.UnitT],
     facets.GenericDaskRegistry[facets.QuantityT, facets.UnitT],
     facets.GenericNumpyRegistry[facets.QuantityT, facets.UnitT],
     facets.GenericMeasurementRegistry[facets.QuantityT, facets.UnitT],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ pandas = ["pint-pandas >= 0.3"]
 xarray = ["xarray"]
 dask = ["dask"]
 mip = ["mip >= 1.13"]
+auto_uncertainties = ["auto-uncertainties >= 0.4.0"]
 
 [project.urls]
 Homepage = "https://github.com/hgrecco/pint"


### PR DESCRIPTION
I found pint quite useful in my research, but the one feature I've always wanted was units + uncertainty propagation + support for arrays. I made a small package that uses automatic differentiation to propagate uncertainties for all numpy functions, and I figured adding a facet for it in pint might be of interest! Let me know what you think.


