### PR TITLE
Short circuit for pint arrays

### DIFF
--- a/pint/matplotlib.py
+++ b/pint/matplotlib.py
@@ -34,6 +34,9 @@ class PintConverter(matplotlib.units.ConversionInterface):
 
     def convert(self, value, unit, axis):
         """Convert :`Quantity` instances for matplotlib to use."""
+        # Short circuit for arrays
+        if hasattr(value, "units"):
+            return value.to(unit).magnitude
         if iterable(value):
             return [self._convert_value(v, unit, axis) for v in value]
 


### PR DESCRIPTION
Avoid iterating over large arrays that share unit information

We (matplotlib) got a report of large arrays taking a long time to plot.

I noticed that the conversion interface in `matplotlib.py` was doing a list 
comprehension for all iterables, including those that could be converted more directly.

This adds the short circuit from `_convert_value` to `convert` prior to list comprehension


- [n/a] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
