### PR TITLE
fix: support pytest on python 3.12 wrt Fraction formatting change

### DIFF
--- a/pint/testing.py
+++ b/pint/testing.py
@@ -64,7 +64,7 @@ def assert_allclose(
     if msg is None:
         try:
             msg = f"Comparing {first!r} and {second!r}. "
-        except TypeError:
+        except (TypeError, ValueError):
             try:
                 msg = f"Comparing {first} and {second}. "
             except Exception:


### PR DESCRIPTION
python 3.12 supports float-style formatting for Fraction by https://github.com/python/cpython/pull/100161 .
With this change, when ":n" format specifier is used in format() for Fraction type, this now raises ValueError instead of previous TypeError.

To make pytest succeed with python 3.12, make
pint.testing.assert_allclose also rescue ValueError .

Fixes #1818 .

- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
