### PR TITLE
Add wrapper benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ pint/testsuite/dask-worker-space
 # WebDAV file system cache files
 .DAV/
 
+# pytest benchmarks folder
+.benchmarks
+
 # tags files (from ctags)
 tags
 

--- a/pint/cache.py
+++ b/pint/cache.py
@@ -201,6 +201,6 @@ def _lru_cache_wrapper(user_function: Callable[..., T]) -> Callable[..., T]:
 ################################################################################
 
 
-def cache(user_function: Callable[..., Any], /):
+def cache(user_function: T, /) -> T:
     'Simple lightweight unbounded cache.  Sometimes called "memoize".'
     return lru_cache(user_function)

--- a/pint/cache.py
+++ b/pint/cache.py
@@ -1,0 +1,163 @@
+"""functools.py - Tools for working with functions and callable objects
+"""
+# Python module wrapper for _functools C module
+# to allow utilities written in Python to be added
+# to the functools module.
+# Written by Nick Coghlan <ncoghlan at gmail.com>,
+# Raymond Hettinger <python at rcn.com>,
+# and Łukasz Langa <lukasz at langa.pl>.
+#   Copyright (C) 2006-2013 Python Software Foundation.
+# See C source code for _functools credits/copyright
+
+from __future__ import annotations
+
+__all__ = [
+    "cache",
+    "lru_cache",
+]
+from weakref import WeakKeyDictionary
+
+from functools import update_wrapper
+
+from typing import Any, Callable, Protocol, TYPE_CHECKING, TypeVar
+
+T = TypeVar("T")
+
+if TYPE_CHECKING:
+    from . import UnitRegistry
+
+
+################################################################################
+### LRU Cache function decorator
+################################################################################
+
+
+class Hashable(Protocol):
+    def __hash__(self) -> int:
+        ...
+
+
+class _HashedSeq(list[Any]):
+    """This class guarantees that hash() will be called no more than once
+    per element.  This is important because the lru_cache() will hash
+    the key multiple times on a cache miss.
+
+    """
+
+    __slots__ = "hashvalue"
+
+    def __init__(self, tup: tuple[Any, ...], hashfun: Callable[[Any], int] = hash):
+        self[:] = tup
+        self.hashvalue = hashfun(tup)
+
+    def __hash__(self) -> int:
+        return self.hashvalue
+
+
+def _make_key(
+    args: tuple[Any, ...],
+    kwds: dict[str, Any],
+    kwd_mark: tuple[Any, ...] = (object(),),
+    fasttypes: set[type] = {int, str},
+    tuple: type = tuple,
+    type: type = type,
+    len: Callable[[Any], int] = len,
+) -> Hashable:
+    """Make a cache key from optionally typed positional and keyword arguments
+
+    The key is constructed in a way that is flat as possible rather than
+    as a nested structure that would take more memory.
+
+    If there is only a single argument and its data type is known to cache
+    its hash value, then that argument is returned without a wrapper.  This
+    saves space and improves lookup speed.
+
+    """
+    # All of code below relies on kwds preserving the order input by the user.
+    # Formerly, we sorted() the kwds before looping.  The new way is *much*
+    # faster; however, it means that f(x=1, y=2) will now be treated as a
+    # distinct call from f(y=2, x=1) which will be cached separately.
+    key = args
+    if kwds:
+        key += kwd_mark
+        for item in kwds.items():
+            key += item
+    if len(key) == 1 and type(key[0]) in fasttypes:
+        return key[0]
+    return _HashedSeq(key)
+
+
+def lru_cache():
+    """Least-recently-used cache decorator.
+
+    If *maxsize* is set to None, the LRU features are disabled and the cache
+    can grow without bound.
+
+    If *typed* is True, arguments of different types will be cached separately.
+    For example, f(decimal.Decimal("3.0")) and f(3.0) will be treated as
+    distinct calls with distinct results. Some types such as str and int may
+    be cached separately even when typed is false.
+
+    Arguments to the cached function must be hashable.
+
+    View the cache statistics named tuple (hits, misses, maxsize, currsize)
+    with f.cache_info().  Clear the cache and statistics with f.cache_clear().
+    Access the underlying function with f.__wrapped__.
+
+    See:  https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)
+
+    """
+
+    # Users should only access the lru_cache through its public API:
+    #       cache_info, cache_clear, and f.__wrapped__
+    # The internals of the lru_cache are encapsulated for thread safety and
+    # to allow the implementation to change (including a possible C version).
+
+    def decorating_function(user_function: Callable[..., T]) -> Callable[..., T]:
+        wrapper = _lru_cache_wrapper(user_function)
+        return update_wrapper(wrapper, user_function)
+
+    return decorating_function
+
+
+def _lru_cache_wrapper(user_function: Callable[..., T]) -> Callable[..., T]:
+    # Constants shared by all lru cache instances:
+    sentinel = object()  # unique object used to signal cache misses
+    make_key = _make_key  # build a key from the function arguments
+
+    cache: WeakKeyDictionary[object, dict[Any, T]] = WeakKeyDictionary()
+
+    def wrapper(self: UnitRegistry, *args: Any, **kwds: Any) -> T:
+        # Simple caching without ordering or size limit
+
+        key = make_key(args, kwds)
+
+        subcache = cache.get(self, None)
+        if subcache is None:
+            cache[self] = subcache = {}
+
+        result = subcache.get(key, sentinel)
+
+        if result is not sentinel:
+            return result
+
+        subcache[key] = result = user_function(self, *args, **kwds)
+        return result
+
+    def cache_clear(self: UnitRegistry):
+        """Clear the cache and cache statistics"""
+        if self in cache:
+            cache[self].clear()
+
+    wrapper.cache_clear = cache_clear
+    return wrapper
+
+
+################################################################################
+### cache -- simplified access to the infinity cache
+################################################################################
+
+
+def cache(user_function: Callable[..., Any], /):
+    'Simple lightweight unbounded cache.  Sometimes called "memoize".'
+    return lru_cache()(user_function)

--- a/pint/facets/context/registry.py
+++ b/pint/facets/context/registry.py
@@ -39,7 +39,6 @@ class ContextCacheOverlay:
     def __init__(self, registry_cache: RegistryCache) -> None:
         self.dimensional_equivalents = registry_cache.dimensional_equivalents
         self.root_units = {}
-        self.parse_unit = registry_cache.parse_unit
 
 
 class GenericContextRegistry(

--- a/pint/facets/context/registry.py
+++ b/pint/facets/context/registry.py
@@ -17,7 +17,13 @@ from ...compat import TypeAlias
 from ..._typing import F, Magnitude
 from ...errors import UndefinedUnitError
 from ...util import find_connected_nodes, find_shortest_path, logger, UnitsContainer
-from ..plain import GenericPlainRegistry, UnitDefinition, QuantityT, UnitT
+from ..plain import (
+    GenericPlainRegistry,
+    UnitDefinition,
+    QuantityT,
+    UnitT,
+    RegistryCache,
+)
 from .definitions import ContextDefinition
 from . import objects
 
@@ -30,11 +36,12 @@ class ContextCacheOverlay:
     active contexts which contain unit redefinitions.
     """
 
-    def __init__(self, registry_cache) -> None:
+    def __init__(self, registry_cache: RegistryCache) -> None:
         self.dimensional_equivalents = registry_cache.dimensional_equivalents
         self.root_units = {}
         self.dimensionality = registry_cache.dimensionality
         self.parse_unit = registry_cache.parse_unit
+        self.parse_unit_name = registry_cache.parse_unit_name
 
 
 class GenericContextRegistry(

--- a/pint/facets/context/registry.py
+++ b/pint/facets/context/registry.py
@@ -80,6 +80,11 @@ class GenericContextRegistry(
         super()._register_definition_adders()
         self._register_adder(ContextDefinition, self.add_context)
 
+    def _clear_cache(self):
+        super()._clear_cache()
+        for func in self._cache_methods:
+            func.cache_clear(self)
+
     def add_context(self, context: Union[objects.Context, ContextDefinition]) -> None:
         """Add a context object to the registry.
 

--- a/pint/facets/context/registry.py
+++ b/pint/facets/context/registry.py
@@ -39,7 +39,6 @@ class ContextCacheOverlay:
     def __init__(self, registry_cache: RegistryCache) -> None:
         self.dimensional_equivalents = registry_cache.dimensional_equivalents
         self.root_units = {}
-        self.dimensionality = registry_cache.dimensionality
         self.parse_unit = registry_cache.parse_unit
 
 

--- a/pint/facets/context/registry.py
+++ b/pint/facets/context/registry.py
@@ -367,7 +367,8 @@ class GenericContextRegistry(
         value: Magnitude,
         src: UnitsContainer,
         dst: UnitsContainer,
-        inplace: bool = False,
+        inplace: bool,
+        check_dimensionality: bool,
     ) -> Magnitude:
         """Convert value from some source to destination units.
 
@@ -406,7 +407,7 @@ class GenericContextRegistry(
 
                 value, src = src._magnitude, src._units
 
-        return super()._convert(value, src, dst, inplace)
+        return super()._convert(value, src, dst, inplace, check_dimensionality)
 
     def _get_compatible_units(
         self, input_units: UnitsContainer, group_or_system: Optional[str] = None

--- a/pint/facets/context/registry.py
+++ b/pint/facets/context/registry.py
@@ -41,7 +41,6 @@ class ContextCacheOverlay:
         self.root_units = {}
         self.dimensionality = registry_cache.dimensionality
         self.parse_unit = registry_cache.parse_unit
-        self.parse_unit_name = registry_cache.parse_unit_name
 
 
 class GenericContextRegistry(

--- a/pint/facets/context/registry.py
+++ b/pint/facets/context/registry.py
@@ -248,6 +248,7 @@ class GenericContextRegistry(
 
         # Finally we add them to the active context.
         self._active_ctx.insert_contexts(*contexts)
+        self._get_root_units.cache_stack_push(self)
         self._switch_context_cache_and_units()
 
     def disable_contexts(self, n: Optional[int] = None) -> None:
@@ -259,6 +260,7 @@ class GenericContextRegistry(
             Number of contexts to disable. Default: disable all contexts.
         """
         self._active_ctx.remove_contexts(n)
+        self._get_root_units.cache_stack_pop(self)
         self._switch_context_cache_and_units()
 
     @contextmanager

--- a/pint/facets/nonmultiplicative/registry.py
+++ b/pint/facets/nonmultiplicative/registry.py
@@ -209,7 +209,12 @@ class GenericNonMultiplicativeRegistry(
         return all_units
 
     def _convert(
-        self, value: T, src: UnitsContainer, dst: UnitsContainer, inplace: bool = False
+        self,
+        value: T,
+        src: UnitsContainer,
+        dst: UnitsContainer,
+        inplace: bool,
+        check_dimensionality: bool,
     ) -> T:
         """Convert value from some source to destination units.
 
@@ -251,7 +256,7 @@ class GenericNonMultiplicativeRegistry(
             )
 
         if not (src_offset_unit or dst_offset_unit):
-            return super()._convert(value, src, dst, inplace)
+            return super()._convert(value, src, dst, inplace, check_dimensionality)
 
         src_dim = self._get_dimensionality(src)
         dst_dim = self._get_dimensionality(dst)

--- a/pint/facets/plain/__init__.py
+++ b/pint/facets/plain/__init__.py
@@ -19,7 +19,13 @@ from .definitions import (
     UnitDefinition,
 )
 from .objects import PlainQuantity, PlainUnit
-from .registry import PlainRegistry, GenericPlainRegistry, QuantityT, UnitT
+from .registry import (
+    PlainRegistry,
+    GenericPlainRegistry,
+    QuantityT,
+    UnitT,
+    RegistryCache,
+)
 from .quantity import MagnitudeT
 
 __all__ = [
@@ -27,6 +33,7 @@ __all__ = [
     "PlainUnit",
     "PlainQuantity",
     "PlainRegistry",
+    "RegistryCache",
     "AliasDefinition",
     "DefaultsDefinition",
     "DimensionDefinition",

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -580,6 +580,11 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
 
         return parsed_project
 
+    def _clear_cache(self):
+        self._cache = RegistryCache()
+        for func in self._cache_methods:
+            func.cache_clear(self)
+
     def _build_cache(self, loaded_files=None) -> None:
         """Build a cache of dimensionality and plain units."""
 
@@ -591,7 +596,7 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
                 diskcache.save(self._cache, loaded_files, "build_cache")
             return
 
-        self._cache = RegistryCache()
+        self._clear_cache()
 
         deps: dict[str, set[str]] = {
             name: set(definition.reference.keys()) if definition.reference else set()

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -63,6 +63,9 @@ from ..._typing import (
     Handler,
 )
 
+
+from ...cache import cache as methodcache
+
 from ..._vendor import appdirs
 from ...compat import babel_parse, tokenizer, TypeAlias, Self
 from ...errors import DimensionalityError, RedefinitionError, UndefinedUnitError
@@ -1084,7 +1087,7 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
 
         return self._parse_single_unit(unit_name, case_sensitive)
 
-    @functools.cache
+    @methodcache
     def _parse_single_unit(
         self, unit_name: str, case_sensitive: bool
     ) -> tuple[tuple[str, str, str], ...]:

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -802,6 +802,7 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
 
         return f, self.Unit(units)
 
+    @methodcache
     def _get_root_units(
         self,
         numerator: UnitsContainer,

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -1161,14 +1161,58 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
 
         """
 
+        case_sensitive = (
+            self.case_sensitive if case_sensitive is None else case_sensitive
+        )
+
+        as_delta = (
+            getattr(self, "default_as_delta", True) if as_delta is None else as_delta
+        )
+
         units = self._parse_units(input_string, as_delta, case_sensitive)
         return self.Unit(units)
+
+    def parse_units_as_container(
+        self,
+        input_string: str,
+        as_delta: Optional[bool] = None,
+        case_sensitive: Optional[bool] = None,
+    ) -> UnitsContainer:
+        """Parse a units expression and returns a UnitContainer with
+        the canonical names.
+
+        The expression can only contain products, ratios and powers of units.
+
+        Parameters
+        ----------
+        input_string : str
+        as_delta : bool or None
+            if the expression has multiple units, the parser will
+            interpret non multiplicative units as their `delta_` counterparts. (Default value = None)
+        case_sensitive : bool or None
+            Control if unit parsing is case sensitive. Defaults to None, which uses the
+            registry's setting.
+
+        Returns
+        -------
+            pint.Unit
+
+        """
+        case_sensitive = (
+            self.case_sensitive if case_sensitive is None else case_sensitive
+        )
+
+        as_delta = (
+            getattr(self, "default_as_delta", True) if as_delta is None else as_delta
+        )
+
+        return self._parse_units(input_string, as_delta, case_sensitive)
 
     def _parse_units(
         self,
         input_string: str,
-        as_delta: bool = True,
-        case_sensitive: Optional[bool] = None,
+        as_delta: bool,
+        case_sensitive: bool,
     ) -> UnitsContainer:
         """Parse a units expression and returns a UnitContainer with
         the canonical names.

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -981,15 +981,15 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
         if src == dst:
             return value
 
-        return self._convert(value, src, dst, inplace)
+        return self._convert(value, src, dst, inplace, True)
 
     def _convert(
         self,
         value: T,
         src: UnitsContainer,
         dst: UnitsContainer,
-        inplace: bool = False,
-        check_dimensionality: bool = True,
+        inplace: bool,
+        check_dimensionality: bool,
     ) -> T:
         """Convert value from some source to destination units.
 

--- a/pint/registry_helpers.py
+++ b/pint/registry_helpers.py
@@ -134,7 +134,7 @@ def _parse_wrap_args(args, registry=None):
         for ndx in dependent_args_ndx:
             value = values[ndx]
             assert _replace_units(args_as_uc[ndx][0], values_by_name) is not None
-            new_values[ndx] = ureg._convert(
+            new_values[ndx] = ureg.convert(
                 getattr(value, "_magnitude", value),
                 getattr(value, "_units", UnitsContainer({})),
                 _replace_units(args_as_uc[ndx][0], values_by_name),
@@ -143,7 +143,7 @@ def _parse_wrap_args(args, registry=None):
         # third pass: convert other arguments
         for ndx in unit_args_ndx:
             if isinstance(values[ndx], ureg.Quantity):
-                new_values[ndx] = ureg._convert(
+                new_values[ndx] = ureg.convert(
                     values[ndx]._magnitude, values[ndx]._units, args_as_uc[ndx][0]
                 )
             else:
@@ -151,7 +151,7 @@ def _parse_wrap_args(args, registry=None):
                     if isinstance(values[ndx], str):
                         # if the value is a string, we try to parse it
                         tmp_value = ureg.parse_expression(values[ndx])
-                        new_values[ndx] = ureg._convert(
+                        new_values[ndx] = ureg.convert(
                             tmp_value._magnitude, tmp_value._units, args_as_uc[ndx][0]
                         )
                     else:

--- a/pint/registry_helpers.py
+++ b/pint/registry_helpers.py
@@ -168,14 +168,13 @@ def _parse_wrap_args(args, registry=None):
     return _converter
 
 
-def _apply_defaults(func, args, kwargs):
+def _apply_defaults(sig, args, kwargs):
     """Apply default keyword arguments.
 
     Named keywords may have been left blank. This function applies the default
     values so that every argument is defined.
     """
 
-    sig = signature(func)
     bound_arguments = sig.bind(*args, **kwargs)
     for param in sig.parameters.values():
         if param.name not in bound_arguments.arguments:
@@ -254,7 +253,8 @@ def wraps(
         ret = _to_units_container(ret, ureg)
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Quantity]:
-        count_params = len(signature(func).parameters)
+        sig = signature(func)
+        count_params = len(sig.parameters)
         if len(args) != count_params:
             raise TypeError(
                 "%s takes %i parameters, but %i units were passed"
@@ -270,7 +270,7 @@ def wraps(
 
         @functools.wraps(func, assigned=assigned, updated=updated)
         def wrapper(*values, **kw) -> Quantity:
-            values, kw = _apply_defaults(func, values, kw)
+            values, kw = _apply_defaults(sig, values, kw)
 
             # In principle, the values are used as is
             # When then extract the magnitudes when needed.
@@ -335,7 +335,8 @@ def check(
     ]
 
     def decorator(func):
-        count_params = len(signature(func).parameters)
+        sig = signature(func)
+        count_params = len(sig.parameters)
         if len(dimensions) != count_params:
             raise TypeError(
                 "%s takes %i parameters, but %i dimensions were passed"
@@ -351,7 +352,7 @@ def check(
 
         @functools.wraps(func, assigned=assigned, updated=updated)
         def wrapper(*args, **kwargs):
-            list_args, empty = _apply_defaults(func, args, kwargs)
+            list_args, empty = _apply_defaults(sig, args, kwargs)
 
             for dim, value in zip(dimensions, list_args):
                 if dim is None:

--- a/pint/testsuite/benchmarks/test_10_registry.py
+++ b/pint/testsuite/benchmarks/test_10_registry.py
@@ -132,8 +132,8 @@ def test_convert_from_uc(benchmark, my_setup: SetupType, key: str, pre_run: bool
     src, dst = key
     ureg, data = my_setup
     if pre_run:
-        no_benchmark(ureg._convert, 1.0, data[src], data[dst])
-    benchmark(ureg._convert, 1.0, data[src], data[dst])
+        no_benchmark(ureg._convert, 1.0, data[src], data[dst], False, True)
+    benchmark(ureg._convert, 1.0, data[src], data[dst], False, True)
 
 
 def test_parse_math_expression(benchmark, my_setup):

--- a/pint/testsuite/benchmarks/test_10_registry.py
+++ b/pint/testsuite/benchmarks/test_10_registry.py
@@ -71,8 +71,8 @@ def test_getitem(benchmark, setup: SetupType, key: str, pre_run: bool):
 def test_parse_unit_name(benchmark, setup: SetupType, key: str, pre_run: bool):
     ureg, _ = setup
     if pre_run:
-        no_benchmark(ureg.parse_unit_name, key)
-    benchmark(ureg.parse_unit_name, key)
+        no_benchmark(ureg.parse_single_unit, key)
+    benchmark(ureg.parse_single_unit, key)
 
 
 @pytest.mark.parametrize("key", UNITS)

--- a/pint/testsuite/benchmarks/test_20_quantity.py
+++ b/pint/testsuite/benchmarks/test_20_quantity.py
@@ -53,3 +53,39 @@ def test_op2(benchmark, setup, keys, op):
     _, data = setup
     key1, key2 = keys
     benchmark(op, data[key1], data[key2])
+
+
+@pytest.mark.parametrize("key", ALL_VALUES_Q)
+def test_wrapper(benchmark, setup, key):
+    ureg, data = setup
+    value, unit = key.split("_")
+
+    @ureg.wraps(None, (unit,))
+    def f(a):
+        pass
+
+    benchmark(f, data[key])
+
+
+@pytest.mark.parametrize("key", ALL_VALUES_Q)
+def test_wrapper_nonstrict(benchmark, setup, key):
+    ureg, data = setup
+    value, unit = key.split("_")
+
+    @ureg.wraps(None, (unit,), strict=False)
+    def f(a):
+        pass
+
+    benchmark(f, data[value])
+
+
+@pytest.mark.parametrize("key", ALL_VALUES_Q)
+def test_wrapper_ret(benchmark, setup, key):
+    ureg, data = setup
+    value, unit = key.split("_")
+
+    @ureg.wraps(unit, (unit,))
+    def f(a):
+        return a
+
+    benchmark(f, data[key])

--- a/pint/testsuite/test_cache.py
+++ b/pint/testsuite/test_cache.py
@@ -22,6 +22,34 @@ class DerivedDemo(Demo):
         return self.value * value + 0.5
 
 
+def test_cache_methods():
+    assert hasattr(Demo, "_cache_methods")
+    assert isinstance(Demo._cache_methods, list)
+    assert Demo._cache_methods == [
+        Demo.calculated_value,
+    ]
+
+    assert hasattr(DerivedDemo, "_cache_methods")
+    assert isinstance(DerivedDemo._cache_methods, list)
+    assert DerivedDemo._cache_methods == [
+        DerivedDemo.calculated_value,
+    ]
+
+    d = Demo(1)
+    assert hasattr(d, "_cache_methods")
+    assert isinstance(d._cache_methods, list)
+    assert d._cache_methods == [
+        Demo.calculated_value,
+    ]
+
+    d = DerivedDemo(2)
+    assert hasattr(d, "_cache_methods")
+    assert isinstance(d._cache_methods, list)
+    assert d._cache_methods == [
+        DerivedDemo.calculated_value,
+    ]
+
+
 def test_cache_clear():
     demo = Demo(2)
 

--- a/pint/testsuite/test_cache.py
+++ b/pint/testsuite/test_cache.py
@@ -1,0 +1,72 @@
+# This is a weird test module as it is currently testing python's cache
+# Its purpose is to summarize the requirements for any replacements
+# and test for undocumented features.
+
+from pint.cache import cache
+
+
+class Demo:
+    def __init__(self, value) -> None:
+        self.value = value
+
+    @cache
+    def calculated_value(self, value):
+        return self.value * value
+
+
+class DerivedDemo(Demo):
+    @cache
+    def calculated_value(self, value):
+        if value is None:
+            return super().calculated_value(3)
+        return self.value * value + 0.5
+
+
+def test_cache_clear():
+    demo = Demo(2)
+
+    assert demo.calculated_value(3) == 6
+    assert demo.calculated_value(3) == 6
+    demo.value = 3
+    assert demo.calculated_value(3) == 6
+    demo.calculated_value.cache_clear(demo)
+    assert demo.calculated_value(3) == 9
+    assert demo.calculated_value(3) == 9
+
+
+def test_per_instance_cache():
+    demo2 = Demo(2)
+    demo3 = Demo(3)
+
+    assert demo2.calculated_value(3) == 6
+    assert demo2.calculated_value(3) == 6
+    assert demo3.calculated_value(3) == 9
+    assert demo3.calculated_value(3) == 9
+
+
+def test_per_instance_cache_clear():
+    demo2 = Demo(2)
+    demo3 = Demo(3)
+
+    demo2.calculated_value(3)
+    demo3.calculated_value(3)
+
+    demo2.value = 4
+    demo3.value = 5
+    assert demo2.calculated_value(3) == 6
+    assert demo3.calculated_value(3) == 9
+    demo2.calculated_value.cache_clear(demo2)
+    assert demo2.calculated_value(3) == 12
+    assert demo3.calculated_value(3) == 9
+    demo3.calculated_value.cache_clear(demo3)
+    assert demo3.calculated_value(5) == 25
+
+
+def test_inheritance():
+    demo = DerivedDemo(2)
+
+    assert demo.calculated_value(3) == 6.5
+    assert demo.calculated_value(3) == 6.5
+    assert demo.calculated_value(None) == 6
+    assert demo.calculated_value(None) == 6
+    assert demo.calculated_value(1)

--- a/pint/testsuite/test_contexts.py
+++ b/pint/testsuite/test_contexts.py
@@ -804,7 +804,8 @@ def test_redefine(subtests):
             assert asd.to("bar").magnitude == 4 * 3
             assert asd.to("baz").magnitude == 4
 
-        ureg.disable_contexts()
+            if enable_ctx:
+                ureg.disable_contexts(1)
 
 
 def test_define_nan():

--- a/pint/util.py
+++ b/pint/util.py
@@ -1039,8 +1039,7 @@ def to_units_container(
         return unit_like._units
     elif str in mro:
         if registry:
-            # TODO: Why not parse.units here?
-            return registry._parse_units(unit_like)
+            return registry.parse_units_as_container(unit_like)
         else:
             return ParserHelper.from_string(unit_like)
     elif dict in mro:


### PR DESCRIPTION
In relation to #1792, I added some basic tests to cover the performances of the wrapper. I also made some small changes to improve the performances:

![image](https://github.com/hgrecco/pint/assets/34129209/ac8c9843-7986-4dda-bd07-49827f6a8d57)

There are definitely some ways to improve it again  (especially by removing the call to `bind`), but that would require bigger internal changes. 

- [ ] Closes # (insert issue number)
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
