### PR TITLE
Fix test_load_definitions_stage_2 benchmark

### DIFF
--- a/pint/testsuite/benchmarks/test_10_registry.py
+++ b/pint/testsuite/benchmarks/test_10_registry.py
@@ -174,8 +174,14 @@ def test_load_definitions_stage_2(benchmark, cache_folder, use_cache_folder):
     from pint import errors
 
     defpath = pathlib.Path(errors.__file__).parent / "default_en.txt"
-    empty_registry = pint.UnitRegistry(None, cache_folder=use_cache_folder)
-    benchmark(empty_registry.load_definitions, defpath, True)
+
+    def stage_2_functions():
+        # We cannot benchmark `load_definitions` by itself because timer calibration
+        # injects definitions into the registry, which raises when we measure
+        empty_registry = pint.UnitRegistry(None, cache_folder=use_cache_folder)
+        empty_registry.load_definitions(defpath, True)
+
+    benchmark(stage_2_functions)
 
 
 @pytest.mark.parametrize("use_cache_folder", (None, True))


### PR DESCRIPTION
Enabling pytest subtests revealed that test_load_definitions_stage_2 needed adjustment so that `load_definitions` could run multiple times (during both calibration phase and measurement phase of the benchmark function).

- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
