### PR TITLE
typo in documentation

### DIFF
--- a/docs/getting/index.rst
+++ b/docs/getting/index.rst
@@ -8,7 +8,7 @@ The getting started guide aims to get you using pint productively as quickly as 
 Installation
 ------------
 
-Pint has no dependencies except Python itself. In runs on Python 3.9+.
+Pint has no dependencies except Python itself. It runs on Python 3.9+.
 
 .. grid:: 2
 


### PR DESCRIPTION
It looks like a typo in the documentation. 