### PR TITLE
Wraps benchmark

### DIFF
--- a/pint/registry_helpers.py
+++ b/pint/registry_helpers.py
@@ -134,7 +134,7 @@ def _parse_wrap_args(args, registry=None):
         for ndx in dependent_args_ndx:
             value = values[ndx]
             assert _replace_units(args_as_uc[ndx][0], values_by_name) is not None
-            new_values[ndx] = ureg.convert(
+            new_values[ndx] = ureg._convert(
                 getattr(value, "_magnitude", value),
                 getattr(value, "_units", UnitsContainer({})),
                 _replace_units(args_as_uc[ndx][0], values_by_name),
@@ -143,7 +143,7 @@ def _parse_wrap_args(args, registry=None):
         # third pass: convert other arguments
         for ndx in unit_args_ndx:
             if isinstance(values[ndx], ureg.Quantity):
-                new_values[ndx] = ureg.convert(
+                new_values[ndx] = ureg._convert(
                     values[ndx]._magnitude, values[ndx]._units, args_as_uc[ndx][0]
                 )
             else:
@@ -151,7 +151,7 @@ def _parse_wrap_args(args, registry=None):
                     if isinstance(values[ndx], str):
                         # if the value is a string, we try to parse it
                         tmp_value = ureg.parse_expression(values[ndx])
-                        new_values[ndx] = ureg.convert(
+                        new_values[ndx] = ureg._convert(
                             tmp_value._magnitude, tmp_value._units, args_as_uc[ndx][0]
                         )
                     else:

--- a/pint/testsuite/benchmarks/test_20_quantity.py
+++ b/pint/testsuite/benchmarks/test_20_quantity.py
@@ -53,3 +53,39 @@ def test_op2(benchmark, setup, keys, op):
     _, data = setup
     key1, key2 = keys
     benchmark(op, data[key1], data[key2])
+
+
+@pytest.mark.parametrize("key", ALL_VALUES_Q)
+def test_wrapper(benchmark, setup, key):
+    ureg, data = setup
+    value, unit = key.split("_")
+
+    @ureg.wraps(None, (unit,))
+    def f(a):
+        pass
+
+    benchmark(f, data[key])
+
+
+@pytest.mark.parametrize("key", ALL_VALUES_Q)
+def test_wrapper_nonstrict(benchmark, setup, key):
+    ureg, data = setup
+    value, unit = key.split("_")
+
+    @ureg.wraps(None, (unit,), strict=False)
+    def f(a):
+        pass
+
+    benchmark(f, data[value])
+
+
+@pytest.mark.parametrize("key", ALL_VALUES_Q)
+def test_wrapper_ret(benchmark, setup, key):
+    ureg, data = setup
+    value, unit = key.split("_")
+
+    @ureg.wraps(unit, (unit,))
+    def f(a):
+        return a
+
+    benchmark(f, data[key])


### PR DESCRIPTION
In relation to #1792, I added some basic tests to cover the performances of the wrapper. I also made some small changes to improve the performances (about 3x improvement):

![image](https://github.com/hgrecco/pint/assets/34129209/ac8c9843-7986-4dda-bd07-49827f6a8d57)

There are definitely some ways to improve it again  (especially by removing the call to `bind`), but that would require bigger internal changes. 

- [ ] Closes # (insert issue number)
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
