### PR TITLE
Fix tests for default preferred units

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - python-version: 3.9
             numpy: "numpy"
             uncertainties: "uncertainties"
-            extras: "sparse xarray netCDF4 dask[complete]==2023.4.0 graphviz babel==2.8"
+            extras: "sparse xarray netCDF4 dask[complete]==2023.4.0 graphviz babel==2.8 mip>=1.13"
     runs-on: ubuntu-latest
 
     env:

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -371,8 +371,8 @@ class TestQuantity(QuantityTestCase):
 
     @helpers.requires_mip
     def test_to_preferred(self):
-        ureg = UnitRegistry()
-        Q_ = ureg.Quantity
+        ureg = self.ureg
+        Q_ = self.Q_
 
         ureg.define("pound_force_per_square_foot = 47.8803 pascals = psf")
         ureg.define("pound_mass = 0.45359237 kg = lbm")
@@ -409,8 +409,8 @@ class TestQuantity(QuantityTestCase):
 
     @helpers.requires_mip
     def test_to_preferred_registry(self):
-        ureg = UnitRegistry()
-        Q_ = ureg.Quantity
+        ureg = self.ureg
+        Q_ = self.Q_
         ureg.default_preferred_units = [
             ureg.m,  # distance      L
             ureg.kg,  # mass          M
@@ -424,8 +424,8 @@ class TestQuantity(QuantityTestCase):
 
     @helpers.requires_mip
     def test_autoconvert_to_preferred(self):
-        ureg = UnitRegistry()
-        Q_ = ureg.Quantity
+        ureg = self.ureg
+        Q_ = self.Q_
         ureg.autoconvert_to_preferred = True
         ureg.default_preferred_units = [
             ureg.m,  # distance      L

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -411,7 +411,7 @@ class TestQuantity(QuantityTestCase):
     def test_to_preferred_registry(self):
         ureg = UnitRegistry()
         Q_ = ureg.Quantity
-        ureg.preferred_units = [
+        ureg.default_preferred_units = [
             ureg.m,  # distance      L
             ureg.kg,  # mass          M
             ureg.s,  # duration      T
@@ -426,7 +426,8 @@ class TestQuantity(QuantityTestCase):
     def test_autoconvert_to_preferred(self):
         ureg = UnitRegistry()
         Q_ = ureg.Quantity
-        ureg.preferred_units = [
+        ureg.autoconvert_to_preferred = True
+        ureg.default_preferred_units = [
             ureg.m,  # distance      L
             ureg.kg,  # mass          M
             ureg.s,  # duration      T


### PR DESCRIPTION
I noticed a few tests failing locally that are not covered by the CI run.

- [x] Closes # None
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
