### PR TITLE
Replace pkg_resources in test_load

### DIFF
--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -293,11 +293,11 @@ class TestRegistry(QuantityTestCase):
         assert len(dir(ureg)) > 0
 
     def test_load(self):
-        import pkg_resources
+        from importlib.resources import files
 
         from .. import compat
 
-        data = pkg_resources.resource_filename(compat.__name__, "default_en.txt")
+        data = files(compat.__package__).joinpath("default_en.txt")
         ureg1 = UnitRegistry()
         ureg2 = UnitRegistry(data)
         assert dir(ureg1) == dir(ureg2)


### PR DESCRIPTION
Replace `pkg_resources.resource_filename` with
`importlib.resources.files`. This removes an implicit dependency on `setuptools` (to which `pkg_resources` belongs); furthermore, the entire `pkg_resources` API is deprecated.

Regarding the switch from `__file__` to `__package__`, see: https://github.com/python/importlib_resources/issues/60

- [ ] Closes # (insert issue number) **N/A, no issue filed**
- [x] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests **N/A, only test code is modified**
- [ ] Documented in docs/ as appropriate **N/A, no user-visible change**
- [ ] Added an entry to the CHANGES file **Do we really need a changelog entry for this?**
