### PR TITLE
Detailed Error Message for `get_dimensionality()`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,8 @@ Pint Changelog
   (PR #1819)
 - Add numpy.linalg.norm implementation.
   (PR #1251)
+- Improved error message in `get_dimensionality()` when non existent units are passed.
+  (PR #1874, Issue #1716)
 
 0.22 (2023-05-25)
 -----------------

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -727,7 +727,12 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
         for key in ref:
             exp2 = exp * ref[key]
             if _is_dim(key):
-                reg = self._dimensions[key]
+                try:
+                    reg = self._dimensions[key]
+                except KeyError:
+                    raise ValueError(
+                        f"{key} is not defined as dimension in the pint UnitRegistry"
+                    )
                 if isinstance(reg, DerivedDimensionDefinition):
                     self._get_dimensionality_recurse(reg.reference, exp2, accumulator)
                 else:

--- a/pint/testsuite/test_errors.py
+++ b/pint/testsuite/test_errors.py
@@ -142,3 +142,10 @@ class TestErrors:
 
                     with pytest.raises(PintError):
                         raise ex
+                    
+    def test_dimensionality_error_message(self):
+        ureg =  UnitRegistry(system="SI")
+        with pytest.raises(ValueError) as error:
+            ureg.get_dimensionality("[bilbo]")
+        
+        assert str(error.value) == "[bilbo] is not defined as dimension in the pint UnitRegistry"

--- a/pint/testsuite/test_errors.py
+++ b/pint/testsuite/test_errors.py
@@ -142,10 +142,13 @@ class TestErrors:
 
                     with pytest.raises(PintError):
                         raise ex
-                    
+
     def test_dimensionality_error_message(self):
-        ureg =  UnitRegistry(system="SI")
+        ureg = UnitRegistry(system="SI")
         with pytest.raises(ValueError) as error:
             ureg.get_dimensionality("[bilbo]")
-        
-        assert str(error.value) == "[bilbo] is not defined as dimension in the pint UnitRegistry"
+
+        assert (
+            str(error.value)
+            == "[bilbo] is not defined as dimension in the pint UnitRegistry"
+        )


### PR DESCRIPTION
- [x] Closes https://github.com/hgrecco/pint/issues/1716
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

This PR addresses the issue referenced above, it wraps `self._dimensions[key]` in a `try` - `except` block that provides a detailed error message which alerts the user that their `key` (or unit) does not exist in the `UnitRegistrty`.