### PR TITLE
Avoid numpy scalar deprecation warnings in __setitem__

### DIFF
--- a/pint/facets/numpy/quantity.py
+++ b/pint/facets/numpy/quantity.py
@@ -266,7 +266,7 @@ class NumpyQuantity(Generic[MagnitudeT], PlainQuantity[MagnitudeT]):
                 isinstance(self._magnitude, np.ma.MaskedArray)
                 and np.ma.is_masked(value)
                 and getattr(value, "size", 0) == 1
-            ) or math.isnan(value):
+            ) or (getattr(value, "ndim", 0) == 0 and math.isnan(value)):
                 self._magnitude[key] = value
                 return
         except TypeError:


### PR DESCRIPTION
NumPy as of 1.25 deprecated automatically converting any "scalar" with non-zero number of dimensions to a float value. Therefore, we should ensure our values have ndim == 0 before passing to math.isnan()

- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
