### PR TITLE
to_compact: support uncertainties' Magnitudes

### DIFF
--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -831,7 +831,7 @@ class TestQuantityToCompact(QuantityTestCase):
     def test_nonnumeric_magnitudes(self):
         ureg = self.ureg
         x = "some string" * ureg.m
-        with pytest.warns(RuntimeWarning):
+        with pytest.raises(TypeError):
             self.compare_quantity_compact(x, x)
 
     def test_very_large_to_compact(self):


### PR DESCRIPTION
Fix #584, make to_compact also raise a `TypeError` instead of a `RuntimeWarning`.

- [x] Closes #584
- [ ] ~~Executed `pre-commit run --all-files` with no errors~~ No, but I ran `black` on the files I changed.
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

Haven't completed the 2 above tasks, as I seek an approval for the change in behavior.