### PR TITLE
Document defaults of pint.UnitRegistry

### DIFF
--- a/pint/registry.py
+++ b/pint/registry.py
@@ -74,31 +74,38 @@ class UnitRegistry(GenericUnitRegistry[Quantity, Unit]):
     ----------
     filename :
         path of the units definition file to load or line-iterable object.
-        Empty to load the default definition file.
+        Empty string to load the default definition file. (default)
         None to leave the UnitRegistry empty.
     force_ndarray : bool
         convert any input, scalar or not to a numpy.ndarray.
+        (Default: False)
     force_ndarray_like : bool
         convert all inputs other than duck arrays to a numpy.ndarray.
+        (Default: False)
     default_as_delta :
         In the context of a multiplication of units, interpret
         non-multiplicative units as their *delta* counterparts.
+        (Default: False)
     autoconvert_offset_to_baseunit :
         If True converts offset units in quantities are
         converted to their plain units in multiplicative
-        context. If False no conversion happens.
+        context. If False no conversion happens. (Default: False)
     on_redefinition : str
         action to take in case a unit is redefined.
-        'warn', 'raise', 'ignore'
+        'warn', 'raise', 'ignore' (Default: 'raise')
     auto_reduce_dimensions :
         If True, reduce dimensionality on appropriate operations.
+        (Default: False)
     autoconvert_to_preferred :
         If True, converts preferred units on appropriate operations.
+        (Default: False)
     preprocessors :
         list of callables which are iteratively ran on any input expression
-        or unit string
+        or unit string or None for no preprocessor.
+        (Default=None)
     fmt_locale :
-        locale identifier string, used in `format_babel`. Default to None
+        locale identifier string, used in `format_babel` or None.
+        (Default=None)
     case_sensitive : bool, optional
         Control default case sensitivity of unit parsing. (Default: True)
     cache_folder : str or pathlib.Path or None, optional


### PR DESCRIPTION
This updates the doc-string to include the defaults for all parameters.

- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
