### PR TITLE
Updated definition of US survey units to reflect the 2022 revision by NIST/NGS

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Pint Changelog
 0.24 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Updated definition of US survey units to reflect the 2022 revision by NIST/NGS 
 
 
 0.23 (2023-12-08)

--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -538,23 +538,31 @@ neper = 1 ; logbase: 2.71828182845904523536028747135266249775724709369995; logfa
     cubic_yard = yd ** 3 = cu_yd
 @end
 
+# Note: historically, many of the units in this group were derived from each other (e.g. 1 chain = 10 fathoms = 4 rods = 100 links)
+# but we've followed the NIST's lead here and defined all of the units directly based on "common" units (feet and miles)
+# Source: U.S. Survey Foot: Revised Unit Conversion Factors <https://www.nist.gov/pml/us-surveyfoot/revised-unit-conversion-factors>
 @group USCSLengthSurvey
-    link = 1e-2 * chain = li = survey_link
-    survey_foot = 1200 / 3937 * meter = sft
-    fathom = 6 * survey_foot
-    rod = 16.5 * survey_foot = rd = pole = perch
-    chain = 4 * rod
-    furlong = 40 * rod = fur
-    cables_length = 120 * fathom
-    survey_mile = 5280 * survey_foot = smi = us_statute_mile
-    league = 3 * survey_mile
+    cables_length = 720 * foot
+    chain = 66 * foot = ch
+    fathom = 6 * foot
+    furlong = 660 * foot = fur
+    league = 3 * mile
+    link = 0.66 * foot = li = survey_link
+    rod = 16.5 * foot = rd = pole = perch
 
-    square_rod = rod ** 2 = sq_rod = sq_pole = sq_perch
-    acre = 10 * chain ** 2
-    square_survey_mile = survey_mile ** 2 = _ = section
+    square_rod = rod ** 2 = sq_rd = sq_rod = sq_pole = sq_perch
+    acre = 43560 * square_foot
     square_league = league ** 2
+    acre_foot = acre * foot = _ = acre_feet
+@end
 
-    acre_foot = acre * survey_foot = _ = acre_feet
+# The adoption of the international foot in 1959 temporarily permitted the continued use of the 1893 definition of the foot for survey purposes.
+# That established the Survey Foot. After 2022, that exception was no longer permitted and all feet are feet (survey or otherwise).
+# Source: U.S. Survey Foot <https://www.nist.gov/pml/us-surveyfoot>
+@group USCSLengthSurveyMendenhall
+    survey_foot = 1200 / 3937 * meter = sft
+    survey_mile = 5280 * survey_foot = smi = us_statute_mile
+    square_survey_mile = survey_mile ** 2
 @end
 
 @group USCSDryVolume


### PR DESCRIPTION
Addresses issue #1912. 

This is my first time contributing to Pint so I wasn't sure what your deprecation and versioning practices are. I added a placeholder in `CHANGES` for now but let me know what version you'd include this in (given that it's technically a breaking change) and how/if some notice should be given ahead of time (e.g. `warn("The definition of acre will change in version 0.x to conform the 2022 revision by NIST")` or whatever).

- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
