### PR TITLE
explicitly implement `dtype` on `numpy` quantities

### DIFF
--- a/pint/facets/numpy/quantity.py
+++ b/pint/facets/numpy/quantity.py
@@ -175,6 +175,10 @@ class NumpyQuantity(Generic[MagnitudeT], PlainQuantity[MagnitudeT]):
     def shape(self) -> Shape:
         return self._magnitude.shape
 
+    @property
+    def dtype(self):
+        return self._magnitude.dtype
+
     @shape.setter
     def shape(self, value):
         self._magnitude.shape = value

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1016,6 +1016,11 @@ class TestNumpyUnclassified(TestNumpyMethods):
         u.shape = 4, 3
         assert u.magnitude.shape == (4, 3)
 
+    def test_dtype(self):
+        u = self.Q_(np.arange(12, dtype="uint32"))
+
+        assert u.dtype == "uint32"
+
     @helpers.requires_array_function_protocol()
     def test_shape_numpy_func(self):
         assert np.shape(self.q) == (2, 2)


### PR DESCRIPTION
This is important because runtime-checkable protocols require the attribute to be in the class `dict` from 3.12 onwards, bypassing `__getattr__`.

- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Added an entry to the CHANGES file