### PR TITLE
Dim sort

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,9 @@ Pint Changelog
 0.24 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Add `dim_sort` function to _formatter_helpers.
+- Add `dim_order` and `default_sort_func` properties to FullFormatter.
+  (PR #????, fixes Issue #1841)
 
 
 0.23 (2023-12-08)

--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,7 @@ Pint Changelog
 
 - Add `dim_sort` function to _formatter_helpers.
 - Add `dim_order` and `default_sort_func` properties to FullFormatter.
-  (PR #????, fixes Issue #1841)
+  (PR #1926, fixes Issue #1841)
 
 
 0.23 (2023-12-08)

--- a/pint/delegates/formatter/_format_helpers.py
+++ b/pint/delegates/formatter/_format_helpers.py
@@ -288,7 +288,7 @@ def dim_sort(items: Iterable[tuple[str, Number]], registry: UnitRegistry):
     KeyError
         If unit cannot be found in the registry.
     """
-    
+
     if registry is None:
         return items
     ret_dict = dict()

--- a/pint/delegates/formatter/_format_helpers.py
+++ b/pint/delegates/formatter/_format_helpers.py
@@ -265,6 +265,9 @@ def format_compound_unit(
     if locale is not None:
         out = localized_form(out, use_plural, length or "long", locale)
 
+    if registry:
+        out = registry.formatter.default_sort_func(out, registry)
+
     return out
 
 

--- a/pint/delegates/formatter/full.py
+++ b/pint/delegates/formatter/full.py
@@ -24,7 +24,12 @@ from ._format_helpers import BabelKwds
 from ._to_register import REGISTERED_FORMATTERS
 
 if TYPE_CHECKING:
-    from ...facets.plain import PlainQuantity, PlainUnit, MagnitudeT
+    from ...facets.plain import (
+        GenericPlainRegistry,
+        PlainQuantity,
+        PlainUnit,
+        MagnitudeT,
+    )
     from ...facets.measurement import Measurement
     from ...compat import Locale
 
@@ -50,8 +55,11 @@ class FullFormatter:
         "[temperature]",
     )
     default_sort_func: Optional[
-        Callable[Iterable[tuple[str, Number]]], Iterable[tuple[str, Number]]
-    ] = None
+        Callable[
+            [Iterable[tuple[str, Number]], GenericPlainRegistry],
+            Iterable[tuple[str, Number]],
+        ]
+    ] = lambda self, x, registry: sorted(x)
 
     locale: Optional[Locale] = None
     babel_length: Literal["short", "long", "narrow"] = "long"

--- a/pint/delegates/formatter/full.py
+++ b/pint/delegates/formatter/full.py
@@ -11,7 +11,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Literal, Optional, Any
+from typing import TYPE_CHECKING, Callable, Iterable, Literal, Optional, Any
 import locale
 from ...compat import babel_parse, Number, Unpack
 from ...util import iterable
@@ -49,7 +49,9 @@ class FullFormatter:
         "[time]",
         "[temperature]",
     )
-    default_sort_func: Optional[Callable[Iterable[tuple[str, Number]]], Iterable[tuple[str, Number]]] = None
+    default_sort_func: Optional[
+        Callable[Iterable[tuple[str, Number]]], Iterable[tuple[str, Number]]
+    ] = None
 
     locale: Optional[Locale] = None
     babel_length: Literal["short", "long", "narrow"] = "long"

--- a/pint/delegates/formatter/full.py
+++ b/pint/delegates/formatter/full.py
@@ -11,9 +11,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Optional, Any
+from typing import TYPE_CHECKING, Callable, Literal, Optional, Any
 import locale
-from ...compat import babel_parse, Unpack
+from ...compat import babel_parse, Number, Unpack
 from ...util import iterable
 
 from ..._typing import Magnitude
@@ -38,6 +38,18 @@ class FullFormatter:
     _formatters: dict[str, Any] = {}
 
     default_format: str = ""
+    # TODO: This can be over-riden by the registry definitions file
+    dim_order = (
+        "[substance]",
+        "[mass]",
+        "[current]",
+        "[luminosity]",
+        "[length]",
+        "[]",
+        "[time]",
+        "[temperature]",
+    )
+    default_sort_func: Optional[Callable[Iterable[tuple[str, Number]]], Iterable[tuple[str, Number]]] = None
 
     locale: Optional[Locale] = None
     babel_length: Literal["short", "long", "narrow"] = "long"

--- a/pint/delegates/formatter/html.py
+++ b/pint/delegates/formatter/html.py
@@ -78,6 +78,12 @@ class HTMLFormatter:
         self, unit: PlainUnit, uspec: str = "", **babel_kwds: Unpack[BabelKwds]
     ) -> str:
         units = format_compound_unit(unit, uspec, **babel_kwds)
+        if unit._REGISTRY.formatter.default_sort_func is not None:
+            sort_func = lambda x: unit._REGISTRY.formatter.default_sort_func(
+                x, unit._REGISTRY
+            )
+        else:
+            sort_func = None
 
         return formatter(
             units,
@@ -87,9 +93,7 @@ class HTMLFormatter:
             division_fmt=r"{}/{}",
             power_fmt=r"{}<sup>{}</sup>",
             parentheses_fmt=r"({})",
-            sort_func=lambda x: unit._REGISTRY.formatter.default_sort_func(
-                x, unit._REGISTRY
-            ),
+            sort_func=sort_func,
         )
 
     def format_quantity(

--- a/pint/delegates/formatter/html.py
+++ b/pint/delegates/formatter/html.py
@@ -87,7 +87,9 @@ class HTMLFormatter:
             division_fmt=r"{}/{}",
             power_fmt=r"{}<sup>{}</sup>",
             parentheses_fmt=r"({})",
-            sort_func=lambda x: unit._REGISTRY.formatter.default_sort_func(x, unit._REGISTRY),
+            sort_func=lambda x: unit._REGISTRY.formatter.default_sort_func(
+                x, unit._REGISTRY
+            ),
         )
 
     def format_quantity(

--- a/pint/delegates/formatter/html.py
+++ b/pint/delegates/formatter/html.py
@@ -87,6 +87,7 @@ class HTMLFormatter:
             division_fmt=r"{}/{}",
             power_fmt=r"{}<sup>{}</sup>",
             parentheses_fmt=r"({})",
+            sort_func=lambda x: unit._REGISTRY.formatter.default_sort_func(x, unit._REGISTRY),
         )
 
     def format_quantity(

--- a/pint/delegates/formatter/html.py
+++ b/pint/delegates/formatter/html.py
@@ -86,9 +86,7 @@ class HTMLFormatter:
             division_fmt=r"{}/{}",
             power_fmt=r"{}<sup>{}</sup>",
             parentheses_fmt=r"({})",
-            sort_func=lambda x: unit._REGISTRY.formatter.default_sort_func(
-                x, unit._REGISTRY
-            ),
+            sort_func=None,
         )
 
     def format_quantity(

--- a/pint/delegates/formatter/html.py
+++ b/pint/delegates/formatter/html.py
@@ -78,13 +78,6 @@ class HTMLFormatter:
         self, unit: PlainUnit, uspec: str = "", **babel_kwds: Unpack[BabelKwds]
     ) -> str:
         units = format_compound_unit(unit, uspec, **babel_kwds)
-        if unit._REGISTRY.formatter.default_sort_func is not None:
-            sort_func = lambda x: unit._REGISTRY.formatter.default_sort_func(
-                x, unit._REGISTRY
-            )
-        else:
-            sort_func = None
-
         return formatter(
             units,
             as_ratio=True,
@@ -93,7 +86,9 @@ class HTMLFormatter:
             division_fmt=r"{}/{}",
             power_fmt=r"{}<sup>{}</sup>",
             parentheses_fmt=r"({})",
-            sort_func=sort_func,
+            sort_func=lambda x: unit._REGISTRY.formatter.default_sort_func(
+                x, unit._REGISTRY
+            ),
         )
 
     def format_quantity(

--- a/pint/delegates/formatter/latex.py
+++ b/pint/delegates/formatter/latex.py
@@ -173,9 +173,8 @@ class LatexFormatter:
         self, unit: PlainUnit, uspec: str = "", **babel_kwds: Unpack[BabelKwds]
     ) -> str:
         units = format_compound_unit(unit, uspec, **babel_kwds)
-        if unit._REGISTRY.formatter.default_sort_func:
-            # Lift the sorting by dimensions b/c the preprocessed units are unrecognizeable
-            units = unit._REGISTRY.formatter.default_sort_func(units, unit._REGISTRY)
+        # Lift the sorting by dimensions b/c the preprocessed units are unrecognizeable
+        units = unit._REGISTRY.formatter.default_sort_func(units, unit._REGISTRY)
 
         preprocessed = {rf"\mathrm{{{latex_escape(u)}}}": p for u, p in units}
         formatted = formatter(

--- a/pint/delegates/formatter/latex.py
+++ b/pint/delegates/formatter/latex.py
@@ -173,6 +173,9 @@ class LatexFormatter:
         self, unit: PlainUnit, uspec: str = "", **babel_kwds: Unpack[BabelKwds]
     ) -> str:
         units = format_compound_unit(unit, uspec, **babel_kwds)
+        if unit._REGISTRY.formatter.default_sort_func:
+            # Lift the sorting by dimensions b/c the preprocessed units are unrecognizeable
+            units = unit._REGISTRY.formatter.default_sort_func(units, unit._REGISTRY)
 
         preprocessed = {rf"\mathrm{{{latex_escape(u)}}}": p for u, p in units}
         formatted = formatter(
@@ -183,6 +186,7 @@ class LatexFormatter:
             division_fmt=r"\frac[{}][{}]",
             power_fmt="{}^[{}]",
             parentheses_fmt=r"\left({}\right)",
+            sort_func=None,
         )
         return formatted.replace("[", "{").replace("]", "}")
 

--- a/pint/delegates/formatter/latex.py
+++ b/pint/delegates/formatter/latex.py
@@ -173,8 +173,6 @@ class LatexFormatter:
         self, unit: PlainUnit, uspec: str = "", **babel_kwds: Unpack[BabelKwds]
     ) -> str:
         units = format_compound_unit(unit, uspec, **babel_kwds)
-        # Lift the sorting by dimensions b/c the preprocessed units are unrecognizeable
-        units = unit._REGISTRY.formatter.default_sort_func(units, unit._REGISTRY)
 
         preprocessed = {rf"\mathrm{{{latex_escape(u)}}}": p for u, p in units}
         formatted = formatter(

--- a/pint/delegates/formatter/plain.py
+++ b/pint/delegates/formatter/plain.py
@@ -269,7 +269,9 @@ class PrettyFormatter:
             power_fmt="{}{}",
             parentheses_fmt="({})",
             exp_call=pretty_fmt_exponent,
-            sort_func=lambda x: unit._REGISTRY.formatter.default_sort_func(x, unit._REGISTRY),
+            sort_func=lambda x: unit._REGISTRY.formatter.default_sort_func(
+                x, unit._REGISTRY
+            ),
         )
 
     def format_quantity(

--- a/pint/delegates/formatter/plain.py
+++ b/pint/delegates/formatter/plain.py
@@ -269,6 +269,7 @@ class PrettyFormatter:
             power_fmt="{}{}",
             parentheses_fmt="({})",
             exp_call=pretty_fmt_exponent,
+            sort_func=lambda x: unit._REGISTRY.formatter.default_sort_func(x, unit._REGISTRY),
         )
 
     def format_quantity(

--- a/pint/delegates/formatter/plain.py
+++ b/pint/delegates/formatter/plain.py
@@ -259,13 +259,6 @@ class PrettyFormatter:
         self, unit: PlainUnit, uspec: str = "", **babel_kwds: Unpack[BabelKwds]
     ) -> str:
         units = format_compound_unit(unit, uspec, **babel_kwds)
-        if unit._REGISTRY.formatter.default_sort_func is not None:
-            sort_func = lambda x: unit._REGISTRY.formatter.default_sort_func(
-                x, unit._REGISTRY
-            )
-        else:
-            sort_func = None
-
         return formatter(
             units,
             as_ratio=True,
@@ -275,7 +268,9 @@ class PrettyFormatter:
             power_fmt="{}{}",
             parentheses_fmt="({})",
             exp_call=pretty_fmt_exponent,
-            sort_func=sort_func,
+            sort_func=lambda x: unit._REGISTRY.formatter.default_sort_func(
+                x, unit._REGISTRY
+            ),
         )
 
     def format_quantity(

--- a/pint/delegates/formatter/plain.py
+++ b/pint/delegates/formatter/plain.py
@@ -77,6 +77,7 @@ class DefaultFormatter:
             division_fmt=" / ",
             power_fmt="{} ** {}",
             parentheses_fmt=r"({})",
+            sort_func=None,
         )
 
     def format_quantity(
@@ -175,6 +176,7 @@ class CompactFormatter:
             division_fmt="/",
             power_fmt="{}**{}",
             parentheses_fmt=r"({})",
+            sort_func=None,
         )
 
     def format_quantity(
@@ -268,9 +270,7 @@ class PrettyFormatter:
             power_fmt="{}{}",
             parentheses_fmt="({})",
             exp_call=pretty_fmt_exponent,
-            sort_func=lambda x: unit._REGISTRY.formatter.default_sort_func(
-                x, unit._REGISTRY
-            ),
+            sort_func=None,
         )
 
     def format_quantity(

--- a/pint/delegates/formatter/plain.py
+++ b/pint/delegates/formatter/plain.py
@@ -259,6 +259,12 @@ class PrettyFormatter:
         self, unit: PlainUnit, uspec: str = "", **babel_kwds: Unpack[BabelKwds]
     ) -> str:
         units = format_compound_unit(unit, uspec, **babel_kwds)
+        if unit._REGISTRY.formatter.default_sort_func is not None:
+            sort_func = lambda x: unit._REGISTRY.formatter.default_sort_func(
+                x, unit._REGISTRY
+            )
+        else:
+            sort_func = None
 
         return formatter(
             units,
@@ -269,9 +275,7 @@ class PrettyFormatter:
             power_fmt="{}{}",
             parentheses_fmt="({})",
             exp_call=pretty_fmt_exponent,
-            sort_func=lambda x: unit._REGISTRY.formatter.default_sort_func(
-                x, unit._REGISTRY
-            ),
+            sort_func=sort_func,
         )
 
     def format_quantity(

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1170,7 +1170,6 @@ def test_issues_1841(subtests):
     ):
         with subtests.test(spec):
             ur.default_format = spec
-            breakpoint()
             assert f"{x}" == result, f"Failed for {spec}, {result}"
 
 
@@ -1189,7 +1188,6 @@ def test_issues_1841_xfail():
     # Note that `radian` (and `bit` and `count`) are treated as dimensionless.
     # And note that dimensionless quantities are stripped by this process,
     # leading to errorneous output.  Suggestions?
-    breakpoint()
     assert (
         fmt.format_unit(q.u._units, spec="", registry=ur, sort_dims=True)
         == "radian * hour"

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1158,16 +1158,15 @@ def test_issues_1505():
 
 
 def test_issues_1841(subtests):
-    import pint
     from pint.delegates.formatter._format_helpers import dim_sort
 
     ur = UnitRegistry()
     ur.formatter.default_sort_func = dim_sort
 
     for x, spec, result in (
-            (ur.Unit(UnitsContainer(hour=1,watt=1)), "P~", "W·h"),
-            (ur.Unit(UnitsContainer(ampere=1,volt=1)), "P~", "V·A"),
-            (ur.Unit(UnitsContainer(meter=1,newton=1)), "P~", "N·m"),
+        (ur.Unit(UnitsContainer(hour=1, watt=1)), "P~", "W·h"),
+        (ur.Unit(UnitsContainer(ampere=1, volt=1)), "P~", "V·A"),
+        (ur.Unit(UnitsContainer(meter=1, newton=1)), "P~", "N·m"),
     ):
         with subtests.test(spec):
             ur.default_format = spec
@@ -1177,9 +1176,7 @@ def test_issues_1841(subtests):
 
 @pytest.mark.xfail
 def test_issues_1841_xfail():
-    import pint
     from pint import formatting as fmt
-    import pint.delegates.formatter._format_helpers
     from pint.delegates.formatter._format_helpers import dim_sort
 
     # sets compact display mode by default


### PR DESCRIPTION
Adapt PR#1841 to the new Pint formatter.

- [x] Closes #1841 
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

TODO: show we can override default in registry init file.