### PR TITLE
have year shortened to 'yr' not 'a'

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -181,7 +181,7 @@ hour = 60 * minute = h = hr
 day = 24 * hour = d
 week = 7 * day
 fortnight = 2 * week
-year = 365.25 * day = a = yr = julian_year
+year = 365.25 * day = yr = julian_year
 month = year / 12
 
 # decade = 10 * year


### PR DESCRIPTION
- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

Unsure as to why year is abbreviated to 'a' and propose we abbreviate to 'yr' instead.

Have made proposal accordingly, although not tested the result of these changes, please let me know if you agree then we can test the change has the desired results. 
