### PR TITLE
support QUDT

### DIFF
--- a/mytest.py
+++ b/mytest.py
@@ -1,0 +1,7 @@
+import pint
+import flexparser as fp
+from dataclasses import dataclass
+import typing as ty
+from pint.facets.plain import definitions
+
+ureg = pint.UnitRegistry(r"E://unit_short.txt", parser = "qudt")

--- a/origtest.py
+++ b/origtest.py
@@ -1,0 +1,7 @@
+import pint
+import flexparser as fp
+from dataclasses import dataclass
+import typing as ty
+from pint.facets.plain import definitions
+
+ureg = pint.UnitRegistry()

--- a/pint/delegates/__init__.py
+++ b/pint/delegates/__init__.py
@@ -9,8 +9,14 @@
 """
 from __future__ import annotations
 
-from . import txt_defparser
+from . import qudt_parser, txt_defparser
 from .base_defparser import ParserConfig, build_disk_cache_class
 from .formatter import Formatter
 
-__all__ = ["txt_defparser", "ParserConfig", "build_disk_cache_class", "Formatter"]
+__all__ = [
+    "txt_defparser",
+    "qudt_parser",
+    "ParserConfig",
+    "build_disk_cache_class",
+    "Formatter",
+]

--- a/pint/delegates/qudt_parser/__init__.py
+++ b/pint/delegates/qudt_parser/__init__.py
@@ -1,0 +1,17 @@
+"""
+    pint.delegates.qudt_parser
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Parser for QUDT files
+    https://www.qudt.org/pages/HomePage.html
+
+    :copyright: 2024 by Pint Authors, see AUTHORS for more details.
+    :license: BSD, see LICENSE for more details.
+"""
+from __future__ import annotations
+
+from .qudtparser import QudtParser
+
+__all__ = [
+    "QudtParser",
+]

--- a/pint/delegates/qudt_parser/block.py
+++ b/pint/delegates/qudt_parser/block.py
@@ -1,0 +1,76 @@
+"""
+    pint.delegates.txt_defparser.block
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Classes for Pint Blocks, which are defined by:
+
+        @<block name>
+            <content>
+        @end
+
+    :copyright: 2022 by Pint Authors, see AUTHORS for more details.
+    :license: BSD, see LICENSE for more details.
+"""
+
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+import flexparser as fp
+
+from ..base_defparser import ParserConfig, PintParsedStatement
+
+
+
+@dataclass(frozen=True)
+class BeginDirectiveBlock(fp.ParsedStatement):
+    """An BeginDirectiveBlock is simply a "." statement.
+    example statement: 'unit:A'
+    example _object_type: 'unit'
+
+    """
+
+    _object_type = str
+
+    @classmethod
+    def from_string(cls, s):
+        if s[:len(cls._object_type)] == cls._object_type:
+            obj = cls()
+            obj.name = s[len(cls._object_type)+1:]
+            return obj
+
+        return None
+
+
+@dataclass(frozen=True)
+class EndDirectiveBlock(PintParsedStatement):
+    """An EndDirectiveBlock is simply a "." statement."""
+
+    @classmethod
+    def from_string(cls, s: str) -> fp.NullableParsedResult[EndDirectiveBlock]:
+        if s == ".":
+            return cls()
+        return None
+
+
+OPST = TypeVar("OPST", bound="PintParsedStatement") # Opening Parsed Statement Type
+IPST = TypeVar("IPST", bound="PintParsedStatement") #? Inner Parsed Statement Type
+
+DefT = TypeVar("DefT") # Definition? Type
+
+
+@dataclass(frozen=True)
+class DirectiveBlock(
+    Generic[DefT, OPST, IPST], fp.Block[OPST, IPST, EndDirectiveBlock, ParserConfig]
+):
+    """Directive blocks have beginning statement Begining with a @ character.
+    and ending with a "@end" (captured using a EndDirectiveBlock).
+
+    Subclass this class for convenience.
+    """
+
+    # is this needed below?
+    def derive_definition(self) -> DefT:
+        ...

--- a/pint/delegates/qudt_parser/common.py
+++ b/pint/delegates/qudt_parser/common.py
@@ -1,0 +1,153 @@
+"""
+    pint.delegates.txt_defparser.common
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Definitions for parsing an Import Statement
+
+    Also DefinitionSyntaxError
+
+    :copyright: 2022 by Pint Authors, see AUTHORS for more details.
+    :license: BSD, see LICENSE for more details.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import flexparser as fp
+
+from ... import errors
+from ..base_defparser import ParserConfig
+from ...facets.plain import definitions
+from . import block
+
+@dataclass(frozen=True)
+class DefinitionSyntaxError(errors.DefinitionSyntaxError, fp.ParsingError):
+    """A syntax error was found in a definition. Combines:
+
+    DefinitionSyntaxError: which provides a message placeholder.
+    fp.ParsingError: which provides raw text, and start and end column and row
+
+    and an extra location attribute in which the filename or reseource is stored.
+    """
+
+    location: str = field(init=False, default="")
+
+    def __str__(self) -> str:
+        msg = (
+            self.msg + "\n    " + (self.format_position or "") + " " + (self.raw or "")
+        )
+        if self.location:
+            msg += "\n    " + self.location
+        return msg
+
+    def set_location(self, value: str) -> None:
+        super().__setattr__("location", value)
+
+
+@dataclass(frozen=True)
+class ImportDefinition(fp.IncludeStatement[ParserConfig]):
+    value: str
+
+    @property
+    def target(self) -> str:
+        return self.value
+
+    @classmethod
+    def from_string(cls, s: str) -> fp.NullableParsedResult[ImportDefinition]:
+        if s.startswith("@import"):
+            return ImportDefinition(s[len("@import") :].strip())
+        return None
+
+###########################################
+
+@dataclass(frozen=True)
+class Attribute(fp.ParsedStatement):
+    """Parses the following `qudt:applicableSystem sou:CGS-EMU ;`
+    """
+
+    parent: str
+    attr: str
+    value: str
+    
+    @classmethod
+    def from_string(cls, s):
+        if ":" not in s and ";" not in s:
+            # This means: I do not know how to parse it
+            # try with another ParsedStatement class.
+            return None
+        s = s[:-1].strip()
+        parent, s = s.split(":", 1)
+        if " " not in s:
+            attr, value = s, ""
+        else:
+            attr, value = s.split(" ", 1)
+        
+        # if not str.isidentifier(lhs):
+        #     return InvalidIdentifier(lhs)
+
+        return cls(parent, attr, value)
+
+
+
+class BeginObject(fp.ParsedStatement):
+
+    _object_type = str
+
+    @classmethod
+    def from_string(cls, s):
+        if s[:len(cls._object_type)] == cls._object_type:
+            return cls()
+
+        return None
+
+
+class BeginHeader(fp.ParsedStatement):
+
+    @classmethod
+    def from_string(cls, s):
+        if s[:9] == "# baseURI":
+            return cls()
+
+        return None
+
+
+class End(fp.ParsedStatement):
+
+    @classmethod
+    def from_string(cls, s):
+        if s == ".":
+            return cls()
+
+        return None
+
+    
+class HeaderLine(fp.ParsedStatement):
+    # couldnt get BOF to work in place of this in HeaderBlock
+    def from_string(cls, s):
+        return cls()
+    
+# class HeaderBlock(fp.Block[BeginHeader, HeaderLine, End, ParserConfig], definitions.CommentDefinition):
+
+@dataclass(frozen=True)
+class HeaderBlock(fp.Block[BeginHeader, HeaderLine, End, ParserConfig]):
+    pass
+
+
+DIMENSIONS = 'substance, current, length, luminousity, mass, temperature, time, dimensionless'.split(', ')
+BASE_UNITS = 'mol, A, m, cd, kg, K, s'.split(', ')
+
+class BeginVoag(block.BeginDirectiveBlock):
+    _object_type = "voag"
+
+@dataclass(frozen=True)
+class VoagDefinitionBlock(fp.Block[BeginVoag, Attribute, block.EndDirectiveBlock, ParserConfig]):
+    pass
+
+
+class BeginVaem(block.BeginDirectiveBlock):
+    _object_type = "vaem"
+
+@dataclass(frozen=True)
+class VaemDefinitionBlock(fp.Block[BeginVaem, Attribute, block.EndDirectiveBlock, ParserConfig]):
+    pass

--- a/pint/delegates/qudt_parser/quantitykind.py
+++ b/pint/delegates/qudt_parser/quantitykind.py
@@ -1,0 +1,55 @@
+"""
+parser for unit file
+"""
+
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import flexparser as fp
+import typing as ty
+
+from ...converters import Converter
+from ...facets.plain import definitions
+from ...util import UnitsContainer
+from ..base_defparser import ParserConfig, PintParsedStatement
+from . import common, block
+import re
+
+
+class BeginQuantitykind(block.BeginDirectiveBlock):
+    _object_type = "quantitykind"
+
+
+@dataclass(frozen=True)
+class QuantitykindDefinitionBlock(fp.Block[BeginQuantitykind, common.Attribute, block.EndDirectiveBlock, ParserConfig]):
+    
+    qudt: dict[str, str] = field(default_factory=dict)
+
+    def parse_attribute(self) -> None:
+        for attr in self.body:
+            if isinstance(attr, common.Attribute) and attr.parent == "qudt":
+                self.qudt[attr.attr] = attr.value
+
+    def derive_definition(self) -> definitions.UnitDefinition:
+        self.parse_attribute()
+        qk_name = self.opening.name.replace("-", "_")
+        
+
+        definition = definitions.QuantitykindDefinition(
+                unit_name,
+                self.qudt['symbol'],
+                tuple(),
+                converter,
+                reference,
+            )
+        return definition
+
+
+@dataclass(frozen=True)
+class EntryBlock(fp.RootBlock[ty.Union[
+                 common.HeaderBlock,
+                 UnitDefinitionBlock
+                 ], ParserConfig]):
+    pass

--- a/pint/delegates/qudt_parser/qudtparser.py
+++ b/pint/delegates/qudt_parser/qudtparser.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import pathlib
+import typing as ty
+
+import flexcache as fc
+import flexparser as fp
+
+from ..base_defparser import ParserConfig
+# from . import block, common, context, defaults, group, plain, system
+from . import plain, common, unit
+from ...facets.plain import definitions
+
+
+# class QudtRootBlock(
+#     fp.RootBlock[
+#         ty.Union[
+#             plain.CommentDefinition,
+#             # common.ImportDefinition,
+#             # context.ContextDefinition,
+#             # defaults.DefaultsDefinition,
+#             # system.SystemDefinition,
+#             # group.GroupDefinition,
+#             # plain.AliasDefinition,
+#             # plain.DerivedDimensionDefinition,
+#             # plain.DimensionDefinition,
+#             # plain.PrefixDefinition,
+#             plain.UnitDefinition,
+#         ],
+#         ParserConfig,
+#     ]
+# ):
+#     pass
+
+class QudtRootBlock(
+    fp.RootBlock[
+        ty.Union[
+                 common.ImportDefinition,
+                 common.HeaderBlock,
+                 unit.UnitDefinitionBlock,
+                 common.VoagDefinitionBlock,
+                 common.VaemDefinitionBlock,
+        ],
+        ParserConfig,
+    ]
+):
+    pass
+
+
+class _QudtParser(fp.Parser[QudtRootBlock, ParserConfig]):
+    """Parser for the Qudt definition file, with cache."""
+
+    _delimiters = {
+        "#": (
+            fp.DelimiterInclude.SPLIT_BEFORE,
+            fp.DelimiterAction.CAPTURE_NEXT_TIL_EOL,
+        ),
+        **fp.SPLIT_EOL,
+    }
+    _root_block_class = QudtRootBlock
+    _strip_spaces = True
+
+    _diskcache: fc.DiskCache | None
+
+    def __init__(self, config: ParserConfig, *args: ty.Any, **kwargs: ty.Any):
+        self._diskcache = kwargs.pop("diskcache", None)
+        super().__init__(config, *args, **kwargs)
+
+    def parse_file(
+        self, path: pathlib.Path
+    ) -> fp.ParsedSource[QudtRootBlock, ParserConfig]:
+        if self._diskcache is None:
+            return super().parse_file(path)
+        content, _basename = self._diskcache.load(path, super().parse_file)
+        return content
+
+
+class QudtParser:
+    skip_classes: tuple[type, ...] = (
+        fp.BOF,
+        fp.BOR,
+        fp.BOS,
+        fp.EOS,
+        plain.CommentDefinition,
+        common.HeaderBlock,
+        common.VoagDefinitionBlock,
+        common.VaemDefinitionBlock,
+    )
+
+    def __init__(self, default_config: ParserConfig, diskcache: fc.DiskCache):
+        self._default_config = default_config
+        self._diskcache = diskcache
+
+    def iter_parsed_project(
+        self, parsed_project: fp.ParsedProject[QudtRootBlock, ParserConfig]
+    ) -> ty.Generator[fp.ParsedStatement[ParserConfig], None, None]:
+        last_location = None
+        
+        for dim in common.DIMENSIONS:
+            yield definitions.DimensionDefinition("["+dim+"]")
+        for stmt in parsed_project.iter_blocks():
+            if isinstance(stmt, fp.BOS):
+                if isinstance(stmt, fp.BOF):
+                    last_location = str(stmt.path)
+                    continue
+                elif isinstance(stmt, fp.BOR):
+                    last_location = (
+                        f"[package: {stmt.package}, resource: {stmt.resource_name}]"
+                    )
+                    continue
+                else:
+                    last_location = "orphan string"
+                    continue
+
+            if isinstance(stmt, self.skip_classes):
+                continue
+            if isinstance(stmt, unit.UnitDefinitionBlock):
+                yield stmt.derive_definition()
+                continue
+            assert isinstance(last_location, str)
+            if isinstance(stmt, common.DefinitionSyntaxError):
+                stmt.set_location(last_location)
+                raise stmt
+            # elif isinstance(stmt, block.DirectiveBlock):
+            #     for exc in stmt.errors:
+            #         exc = common.DefinitionSyntaxError(str(exc))
+            #         exc.set_position(*stmt.get_position())
+            #         exc.set_raw(
+            #             (stmt.opening.raw or "") + " [...] " + (stmt.closing.raw or "")
+            #         )
+            #         exc.set_location(last_location)
+            #         raise exc
+
+                # try:
+                #     yield stmt.derive_definition()
+                # except Exception as exc:
+                #     exc = common.DefinitionSyntaxError(str(exc))
+                #     exc.set_position(*stmt.get_position())
+                #     exc.set_raw(stmt.opening.raw + " [...] " + stmt.closing.raw)
+                #     exc.set_location(last_location)
+                #     raise exc
+            else:
+                yield stmt
+
+    def parse_file(
+        self, filename: pathlib.Path | str, cfg: ParserConfig | None = None
+    ) -> fp.ParsedProject[QudtRootBlock, ParserConfig]:
+        return fp.parse(
+            filename,
+            _QudtParser,
+            # cfg or self._default_config,
+            # diskcache=self._diskcache,
+            # strip_spaces=True,
+            # delimiters=_QudtParser._delimiters,
+        )
+
+    def parse_string(
+        self, content: str, cfg: ParserConfig | None = None
+    ) -> fp.ParsedProject[QudtRootBlock, ParserConfig]:
+        return fp.parse_bytes(
+            content.encode("utf-8"),
+            _QudtParser,
+            cfg or self._default_config,
+            diskcache=self._diskcache,
+            strip_spaces=True,
+            delimiters=_QudtParser._delimiters,
+        )

--- a/pint/delegates/qudt_parser/unit.py
+++ b/pint/delegates/qudt_parser/unit.py
@@ -1,0 +1,76 @@
+"""
+parser for unit file
+"""
+
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import flexparser as fp
+import typing as ty
+
+from ...converters import Converter
+from ...facets.plain import definitions
+from ...util import UnitsContainer
+from ..base_defparser import ParserConfig, PintParsedStatement
+from . import common, block
+import re
+
+
+class BeginUnit(block.BeginDirectiveBlock):
+    _object_type = "unit"
+
+
+def make_units_container(dimensionvector: str) -> UnitsContainer:
+    # use regex to split the dimension vector 'A0E1L0I0M0H0T0D0' into a dictionary of units
+    if ":" in dimensionvector:
+        dimensionvector = dimensionvector.split(":")[1]
+    dimensionvector = re.sub(r'[a-zA-Z]', r' ', dimensionvector).split()
+    units = {
+        unit: int(exponent) for unit, exponent in zip(common.BASE_UNITS, dimensionvector)
+    }
+    return UnitsContainer(units)
+
+
+@dataclass(frozen=True)
+class UnitDefinitionBlock(fp.Block[BeginUnit, common.Attribute, block.EndDirectiveBlock, ParserConfig]):
+    
+    qudt: dict[str, str] = field(default_factory=dict)
+
+    def parse_attribute(self) -> None:
+        self.qudt['symbol'] = None
+        self.qudt['conversionMultiplier'] = 1.
+        for attr in self.body:
+            if isinstance(attr, common.Attribute) and attr.parent == "qudt":
+                self.qudt[attr.attr] = attr.value
+                if attr.attr == "symbol":
+                    self.qudt['symbol'] = attr.value.strip('\"')
+
+    def derive_definition(self) -> definitions.UnitDefinition:
+        self.parse_attribute()
+        unit_name = self.opening.name.replace("-", "_")#.lower()
+        if self.qudt['symbol'] in common.BASE_UNITS:
+            dim = common.DIMENSIONS[common.BASE_UNITS.index(self.qudt['symbol'])]
+            reference = UnitsContainer({"["+dim+"]": 1})
+            self.qudt['conversionMultiplier'] = 1
+        else:
+            reference = make_units_container(self.qudt['hasDimensionVector'])
+
+        converter = Converter.from_arguments(scale=self.qudt['conversionMultiplier'])
+        definition = definitions.UnitDefinition(
+                unit_name,
+                self.qudt['symbol'],
+                tuple(),
+                converter,
+                reference,
+            )
+        return definition
+
+
+@dataclass(frozen=True)
+class EntryBlock(fp.RootBlock[ty.Union[
+                 common.HeaderBlock,
+                 UnitDefinitionBlock
+                 ], ParserConfig]):
+    pass

--- a/pint/facets/plain/definitions.py
+++ b/pint/facets/plain/definitions.py
@@ -114,6 +114,21 @@ class PrefixDefinition(NamedDefinition, errors.WithDefErr):
 
 
 @dataclass(frozen=True)
+class 
+(NamedDefinition, errors.WithDefErr):
+    """Definition of a quantitykind."""
+
+    #: canonical symbol
+    defined_symbol: str | None
+    #: Reference units.
+    reference: UnitsContainer | None
+    # valid units for this quantitykind
+    applicable_units: ty.Tuple[str, ...] = ()
+    metadata: ty.Dict[str, str] = ty.field(default_factory=dict)
+
+
+
+@dataclass(frozen=True)
 class UnitDefinition(NamedDefinition, errors.WithDefErr):
     """Definition of a unit."""
 

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -203,6 +203,8 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
         Separate the default format into magnitude and unit formats as soon as
         possible. The deprecated default is not to separate. This will change in a
         future release.
+    parser: str, optional (Default: 'pint')
+        'pint' or 'qudt'
     """
 
     Quantity: type[QuantityT]
@@ -226,6 +228,7 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
         cache_folder: str | pathlib.Path | None = None,
         separate_format_defaults: bool | None = None,
         mpl_formatter: str = "{:P}",
+        parser: str = "pint",
     ):
         #: Map a definition class to a adder methods.
         self._adders: Handler = {}
@@ -243,9 +246,14 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
                 cache_folder
             )
 
-        self._def_parser = delegates.txt_defparser.DefParser(
-            delegates.ParserConfig(non_int_type), diskcache=self._diskcache
-        )
+        if parser == "pint":
+            self._def_parser = delegates.txt_defparser.DefParser(
+                delegates.ParserConfig(non_int_type), diskcache=self._diskcache
+            )
+        elif parser == "qudt":
+            self._def_parser = delegates.qudt_parser.QudtParser(
+                delegates.ParserConfig(non_int_type), diskcache=self._diskcache
+            )
 
         self.formatter = delegates.Formatter(self)
         self._filename = filename

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -99,6 +99,8 @@ class UnitRegistry(GenericUnitRegistry[Quantity, Unit]):
     cache_folder : str or pathlib.Path or None, optional
         Specify the folder in which cache files are saved and loaded from.
         If None, the cache is disabled. (default)
+    parser: str, optional (Default: 'pint')
+        'pint' or 'qudt'
     """
 
     Quantity: TypeAlias = Quantity
@@ -120,6 +122,7 @@ class UnitRegistry(GenericUnitRegistry[Quantity, Unit]):
         non_int_type=float,
         case_sensitive: bool = True,
         cache_folder=None,
+        parser: str = "pint",
     ):
         super().__init__(
             filename=filename,
@@ -136,6 +139,7 @@ class UnitRegistry(GenericUnitRegistry[Quantity, Unit]):
             non_int_type=non_int_type,
             case_sensitive=case_sensitive,
             cache_folder=cache_folder,
+            parser=parser,
         )
 
     def pi_theorem(self, quantities):


### PR DESCRIPTION
- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

Started writing a parser for QUDT. QUDT has defined 1100 quantitykinds, which are like the 'kind' previously discussed in pint #676. There's also a load of metadata for the quantitykind and units:

<details>
  <summary>quantitykind and unit examples</summary>


.
unit:A
  a qudt:Unit ;
  dcterms:description """$\\textit{Ampere}$, often shortened to $\\text{amp}$, 
is the SI unit of electric current and is one of the seven SI base units defined as:

$$\\text{A} \\equiv \\frac{\\textit{C}}{\\textit{s}} 
\\equiv \\frac{\\textit{coulomb}}{\\textit{second}} 
\\equiv \\frac{\\text{joule}}{\\text{weber}}$$

Note that SI supports only the use of symbols and deprecates the use of any abbreviations for units.
"""^^qudt:LatexString ;
  qudt:applicableSystem sou:CGS-EMU ;
  qudt:applicableSystem sou:CGS-GAUSS ;
  qudt:applicableSystem sou:PLANCK ;
  qudt:applicableSystem sou:SI ;
  qudt:conversionMultiplier 1.0 ;
  qudt:conversionMultiplierSN 1.0E0 ;
  qudt:dbpediaMatch "http://dbpedia.org/resource/Ampere"^^xsd:anyURI ;
  qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T0D0 ;
  qudt:hasQuantityKind quantitykind:CurrentLinkage ;
  qudt:hasQuantityKind quantitykind:DisplacementCurrent ;
  qudt:hasQuantityKind quantitykind:ElectricCurrent ;
  qudt:hasQuantityKind quantitykind:ElectricCurrentPhasor ;
  qudt:hasQuantityKind quantitykind:MagneticTension ;
  qudt:hasQuantityKind quantitykind:MagnetomotiveForce ;
  qudt:hasQuantityKind quantitykind:TotalCurrent ;
  qudt:iec61360Code "0112/2///62720#UAA101" ;
  qudt:iec61360Code "0112/2///62720#UAD717" ;
  qudt:informativeReference "http://en.wikipedia.org/wiki/Ampere?oldid=494026699"^^xsd:anyURI ;
  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/ampere> ;
  qudt:siExactMatch si-unit:ampere ;
  qudt:symbol "A" ;
  qudt:ucumCode "A"^^qudt:UCUMcs ;
  qudt:udunitsCode "A" ;
  qudt:uneceCommonCode "AMP" ;
  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
  rdfs:label "Ampere"@de ;
  rdfs:label "amper"@hu ;
  rdfs:label "amper"@pl ;
  rdfs:label "amper"@ro ;
  rdfs:label "amper"@sl ;
  rdfs:label "amper"@tr ;
  rdfs:label "ampere"@en ;
  rdfs:label "ampere"@it ;
  rdfs:label "ampere"@ms ;
  rdfs:label "ampere"@pt ;
  rdfs:label "amperio"@es ;
  rdfs:label "amperium"@la ;
  rdfs:label "ampère"@fr ;
  rdfs:label "ampér"@cs ;
  rdfs:label "αμπέρ"@el ;
  rdfs:label "ампер"@bg ;
  rdfs:label "ампер"@ru ;
  rdfs:label "אמפר"@he ;
  rdfs:label "آمپر"@fa ;
  rdfs:label "أمبير"@ar ;
  rdfs:label "एम्पीयर"@hi ;
  rdfs:label "アンペア"@ja ;
  rdfs:label "安培"@zh ;
  skos:altLabel "amp" ;
.


#################################

quantitykind:Acceleration
  a qudt:QuantityKind ;
  dcterms:description "Acceleration is the (instantaneous) rate of change of velocity. Acceleration may be either linear acceleration, or angular acceleration. It is a vector quantity with dimension \\(length/time^{2}\\) for linear acceleration, or in the case of angular acceleration, with dimension \\(angle/time^{2}\\). In SI units, linear acceleration is measured in \\(meters/second^{2}\\) (\\(m \\cdot s^{-2}\\)) and angular acceleration is measured in \\(radians/second^{2}\\). In physics, any increase or decrease in speed is referred to as acceleration and similarly, motion in a circle at constant speed is also an acceleration, since the direction component of the velocity is changing."^^qudt:LatexString ;
  qudt:applicableUnit unit:CentiM-PER-SEC2 ;
  qudt:applicableUnit unit:FT-PER-SEC2 ;
  qudt:applicableUnit unit:G ;
  qudt:applicableUnit unit:GALILEO ;
  qudt:applicableUnit unit:IN-PER-SEC2 ;
  qudt:applicableUnit unit:KN-PER-SEC ;
  qudt:applicableUnit unit:KiloM-PER-SEC2 ;
  qudt:applicableUnit unit:KiloPA-M2-PER-GM ;
  qudt:applicableUnit unit:M-PER-SEC2 ;
  qudt:applicableUnit unit:MI_US-PER-SEC2 ;
  qudt:applicableUnit unit:MicroG ;
  qudt:applicableUnit unit:MilliG ;
  qudt:applicableUnit unit:MilliGAL ;
  qudt:applicableUnit unit:MilliM-PER-SEC2 ;
  qudt:applicableUnit unit:YD-PER-SEC2 ;
  qudt:dbpediaMatch "http://dbpedia.org/resource/Acceleration"^^xsd:anyURI ;
  qudt:exactMatch quantitykind:LinearAcceleration ;
  qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
  qudt:iec61360Code "0112/2///62720#UAD002" ;
  qudt:informativeReference "http://en.wikipedia.org/wiki/Acceleration"^^xsd:anyURI ;
  qudt:siExactMatch si-quantity:ACCE ;
  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
  rdfs:label "Beschleunigung"@de ;
  rdfs:label "Pecutan"@ms ;
  rdfs:label "Zrychlení"@cs ;
  rdfs:label "acceleratio"@la ;
  rdfs:label "acceleration"@en ;
  rdfs:label "accelerazione"@it ;
  rdfs:label "accelerație"@ro ;
  rdfs:label "accélération"@fr ;
  rdfs:label "aceleración"@es ;
  rdfs:label "aceleração"@pt ;
  rdfs:label "ivme"@tr ;
  rdfs:label "pospešek"@sl ;
  rdfs:label "przyspieszenie"@pl ;
  rdfs:label "Όγκος"@el ;
  rdfs:label "Ускоре́ние"@ru ;
  rdfs:label "التسارع"@ar ;
  rdfs:label "شتاب"@fa ;
  rdfs:label "त्वरण"@hi ;
  rdfs:label "加速度"@ja ;
  rdfs:label "加速度"@zh ;
.
  
</details>


I think Quantitykind definition can be split into another PR to make things smaller.

Not sure what the best way to right tests for parsing files is either. 

The QUDT data is updated regularly, so would need to be downloaded rather than be saved in pint, which would need an optional dependency like requests - Should I add code for downloading files to this?

Would be good to get @hgrecco 's thoughts on the parsing (I've mostly copied pint and adapted as needed  so far) 
I wonder if it would be possible/better to change the delimiter to "\n.\n" or something instead of using a block?
Also unsure on how to deal with multiline strings

todo:
- [x] parse units
- [ ] offset units
- [ ]  log units
- [ ] quantitykind definition
- [ ] parse quantitykind
- [ ] quantitykind method/interactions on quantity, eg quantity.kind()
- [ ] parse systems

I'm interested in what functionality quantitykind will allow.
