### PR TITLE
Avoid trapz DeprecationWarning on numpy 2

### DIFF
--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -740,8 +740,11 @@ def _base_unit_if_needed(a):
             raise OffsetUnitCalculusError(a.units)
 
 
+# Can remove trapz wrapping when we only support numpy>=2
 @implements("trapz", "function")
+@implements("trapezoid", "function")
 def _trapz(y, x=None, dx=1.0, **kwargs):
+    trapezoid = np.trapezoid if hasattr(np, "trapezoid") else np.trapz
     y = _base_unit_if_needed(y)
     units = y.units
     if x is not None:
@@ -749,13 +752,13 @@ def _trapz(y, x=None, dx=1.0, **kwargs):
             x = _base_unit_if_needed(x)
             units *= x.units
             x = x._magnitude
-        ret = np.trapz(y._magnitude, x, **kwargs)
+        ret = trapezoid(y._magnitude, x, **kwargs)
     else:
         if hasattr(dx, "units"):
             dx = _base_unit_if_needed(dx)
             units *= dx.units
             dx = dx._magnitude
-        ret = np.trapz(y._magnitude, dx=dx, **kwargs)
+        ret = trapezoid(y._magnitude, dx=dx, **kwargs)
 
     return y.units._REGISTRY.Quantity(ret, units)
 


### PR DESCRIPTION
I haven't exhaustively gone through the changes in numpy 2, but this is enough to allow MetPy's test suite to pass with no new warnings on numpy 2.

- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
