### PR TITLE
chore(bench): update CodSpeed/action to v2

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -26,7 +26,7 @@ jobs:
         run: pip install .[bench]
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v1
+        uses: CodSpeedHQ/action@v2
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: pytest . --codspeed


### PR DESCRIPTION
Upgrading to the v2 of https://github.com/CodSpeedHQ/action will bring a better base run selection algorithm, better logging, and continued support.
