### PR TITLE
Fix siunitx format of integer powers with non_int_type=decimal.Decimal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ MANIFEST
 .mypy_cache
 pip-wheel-metadata
 pint/testsuite/dask-worker-space
+venv
+.envrc
 
 # WebDAV file system cache files
 .DAV/

--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Pint Changelog
 - Add `dim_sort` function to _formatter_helpers.
 - Add `dim_order` and `default_sort_func` properties to FullFormatter.
   (PR #1926, fixes Issue #1841)
+- Fix LaTeX siuntix formatting when using non_int_type=decimal.Decimal.
 
 
 0.23 (2023-12-08)

--- a/pint/delegates/formatter/latex.py
+++ b/pint/delegates/formatter/latex.py
@@ -124,8 +124,8 @@ def siunitx_format_unit(
 ) -> str:
     """Returns LaTeX code for the unit that can be put into an siunitx command."""
 
-    def _tothe(power: int | float) -> str:
-        if isinstance(power, int) or (isinstance(power, float) and power.is_integer()):
+    def _tothe(power) -> str:
+        if power == int(power):
             if power == 1:
                 return ""
             elif power == 2:

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1201,3 +1201,20 @@ def test_issues_1841_xfail():
 
     # this prints "2*pi hour * radian", not "2*pi radian * hour" unless sort_dims is True
     # print(q)
+
+
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        (
+            "8.989e9 newton * meter^2 / coulomb^2",
+            r"\SI[]{8.989E+9}{\meter\squared\newton\per\coulomb\squared}",
+        ),
+        ("5 * meter / second", r"\SI[]{5}{\meter\per\second}"),
+        ("2.2 * meter^4", r"\SI[]{2.2}{\meter\tothe{4}}"),
+        ("2.2 * meter^-4", r"\SI[]{2.2}{\per\meter\tothe{4}}"),
+    ],
+)
+def test_issue1772(given, expected):
+    ureg = UnitRegistry(non_int_type=decimal.Decimal)
+    assert f"{ureg(given):Lx}" == expected


### PR DESCRIPTION
- [x] Closes #1772 
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] (not applicable) Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

I've also added `venv` and `.envrc` to the `.gitignore` file:

- `venv` is created when following the Contributing guide: https://pint.readthedocs.io/en/stable/dev/contributing.html
- `.envrc` is a file for [direnv](https://direnv.net/), which facilitates loading and unloading virtual environments (or any other env variables) 