### PR TITLE
depreciate ureg.__getitem__

### DIFF
--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -366,11 +366,11 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
         # self.Unit will call parse_units
         return self.Unit(item)
 
+    @deprecated(
+        "Calling the getitem method from a UnitRegistry will be removed in future versions of pint.\n"
+        "use `parse_expression` method or use the registry as a callable."
+    )
     def __getitem__(self, item: str) -> UnitT:
-        logger.warning(
-            "Calling the getitem method from a UnitRegistry is deprecated. "
-            "use `parse_expression` method or use the registry as a callable."
-        )
         return self.parse_expression(item)
 
     def __contains__(self, item: str) -> bool:


### PR DESCRIPTION
I hadn't noticed a depreciate warning for ureg.__getitem__ when using pint. This PR changes the depreciation from a logger message to DeprecationWarning.

metioned in #1303 