### PR TITLE
add error for prefixed non multi units

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,8 @@ Pint Changelog
   (PR #1949)
 - Fix unhandled TypeError when auto_reduce_dimensions=True and non_int_type=Decimal
   (PR #1853)
+- Creating prefixed offset units now raises an error.
+  (PR #1998)
 - Improved error message in `get_dimensionality()` when non existent units are passed.
   (PR #1874, Issue #1716)
 

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -60,7 +60,7 @@ from ..._typing import (
     UnitLike,
 )
 from ...compat import Self, TypeAlias, deprecated
-from ...errors import DimensionalityError, RedefinitionError, UndefinedUnitError
+from ...errors import DimensionalityError, RedefinitionError, UndefinedUnitError, OffsetUnitCalculusError
 from ...pint_eval import build_eval_tree
 from ...util import (
     ParserHelper,
@@ -664,6 +664,9 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
             )
 
         if prefix:
+            if not self._units[unit_name].is_multiplicative:
+                raise OffsetUnitCalculusError("Prefixing a unit requires multiplying the unit.")
+            
             name = prefix + unit_name
             symbol = self.get_symbol(name, case_sensitive)
             prefix_def = self._prefixes[prefix]

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -60,7 +60,12 @@ from ..._typing import (
     UnitLike,
 )
 from ...compat import Self, TypeAlias, deprecated
-from ...errors import DimensionalityError, RedefinitionError, UndefinedUnitError, OffsetUnitCalculusError
+from ...errors import (
+    DimensionalityError,
+    OffsetUnitCalculusError,
+    RedefinitionError,
+    UndefinedUnitError,
+)
 from ...pint_eval import build_eval_tree
 from ...util import (
     ParserHelper,
@@ -665,8 +670,10 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
 
         if prefix:
             if not self._units[unit_name].is_multiplicative:
-                raise OffsetUnitCalculusError("Prefixing a unit requires multiplying the unit.")
-            
+                raise OffsetUnitCalculusError(
+                    "Prefixing a unit requires multiplying the unit."
+                )
+
             name = prefix + unit_name
             symbol = self.get_symbol(name, case_sensitive)
             prefix_def = self._prefixes[prefix]

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -1043,3 +1043,8 @@ class TestConvertWithOffset(QuantityTestCase):
         # Define against unknown name
         with pytest.raises(KeyError):
             ureg.define("@alias notexist = something")
+
+    def test_prefix_offset_units(self):
+        ureg = UnitRegistry()
+        with pytest.raises(errors.OffsetUnitCalculusError):
+            ureg.parse_units("kilodegree_Celsius")


### PR DESCRIPTION
- [x] Closes #1504 #1754 #1995
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
