### PR TITLE
ensure uncertainties does not depend on numpy

### DIFF
--- a/pint/compat.py
+++ b/pint/compat.py
@@ -75,7 +75,8 @@ class BehaviorChangeWarning(UserWarning):
 
 try:
     from uncertainties import UFloat, ufloat
-    from uncertainties import unumpy as unp
+
+    unp = None
 
     HAS_UNCERTAINTIES = True
 except ImportError:
@@ -92,6 +93,8 @@ try:
     HAS_NUMPY = True
     NUMPY_VER = np.__version__
     if HAS_UNCERTAINTIES:
+        from uncertainties import unumpy as unp
+
         NUMERIC_TYPES = (Number, Decimal, ndarray, np.number, UFloat)
     else:
         NUMERIC_TYPES = (Number, Decimal, ndarray, np.number)

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -922,6 +922,7 @@ class TestIssues(QuantityTestCase):
         assert q2.format_babel("~", locale="es_ES") == "3,1 W/cm"
         assert q2.format_babel("", locale="es_ES") == "3,1 vatios por centímetro"
 
+    @helpers.requires_numpy()
     @helpers.requires_uncertainties()
     def test_issue1611(self, module_registry):
         from numpy.testing import assert_almost_equal


### PR DESCRIPTION
Fix import ordering to ensure that uncertainties can be used without numpy, before this the check assumed that numpy was always installed.