### PR TITLE
Fix custom formatters needing registry

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Pint Changelog
 0.25 (unreleased)
 -----------------
 
-Nothing added yet.
+- Fix custom formatter needing the registry object. (PR #2011)
 
 
 0.24 (2024-06-07)

--- a/docs/user/formatting.rst
+++ b/docs/user/formatting.rst
@@ -98,7 +98,8 @@ formats:
    '2.3e-06 kilogram ** -1 * meter ** 3 * second ** -2'
 
 where ``unit`` is a :py:class:`dict` subclass containing the unit names and
-their exponents.
+their exponents, ``registry`` is the current instance of :py:class:``UnitRegistry`` and
+``options`` is not yet implemented.
 
 You can choose to replace the complete formatter. Briefly, the formatter if an object with the
 following methods: `format_magnitude`, `format_unit`, `format_quantity`, `format_uncertainty`,

--- a/pint/delegates/formatter/_to_register.py
+++ b/pint/delegates/formatter/_to_register.py
@@ -61,6 +61,8 @@ def register_unit_format(name: str):
             raise ValueError(f"format {name!r} already exists")  # or warn instead
 
         class NewFormatter(BaseFormatter):
+            spec = name
+
             def format_magnitude(
                 self,
                 magnitude: Magnitude,

--- a/pint/delegates/formatter/full.py
+++ b/pint/delegates/formatter/full.py
@@ -103,11 +103,17 @@ class FullFormatter(BaseFormatter):
                 return v
 
         try:
-            return REGISTERED_FORMATTERS[spec]
+            orphan_fmt = REGISTERED_FORMATTERS[spec]
         except KeyError:
-            pass
+            return self._formatters["D"]
 
-        return self._formatters["D"]
+        try:
+            fmt = orphan_fmt.__class__(self._registry)
+            spec = getattr(fmt, "spec", spec)
+            self._formatters[spec] = fmt
+            return fmt
+        except Exception:
+            return orphan_fmt
 
     def format_magnitude(
         self, magnitude: Magnitude, mspec: str = "", **babel_kwds: Unpack[BabelKwds]

--- a/pint/testsuite/test_formatting.py
+++ b/pint/testsuite/test_formatting.py
@@ -59,6 +59,8 @@ def test_split_format(format, default, flag, expected):
 def test_register_unit_format(func_registry):
     @fmt.register_unit_format("custom")
     def format_custom(unit, registry, **options):
+        # Ensure the registry is correct..
+        registry.Unit(unit)
         return "<formatted unit>"
 
     quantity = 1.0 * func_registry.meter


### PR DESCRIPTION
- [x] Closes #2009
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

Fixes #2009 according to the suggestions in the thread. I also added a note to the doc to describe the arguments passed to the custom formatters. And added a line to the test.