### PR TITLE
Added "mu" and "mc" prefixes.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Pint Changelog
 0.25 (unreleased)
 -----------------
 
-Nothing added yet.
+Added mu and mc as alternatives for SI micro prefix
 
 
 0.24 (2024-06-07)

--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -72,7 +72,7 @@ pico- =  1e-12 = p-
 nano- =  1e-9  = n-
 # The micro (U+00B5) and Greek mu (U+03BC) are both valid prefixes,
 # and they often use the same glyph.
-micro- = 1e-6  = µ- = μ- = u-
+micro- = 1e-6  = µ- = μ- = u- = mu- = mc-
 milli- = 1e-3  = m-
 centi- = 1e-2  = c-
 deci- =  1e-1  = d-

--- a/pint/testsuite/conftest.py
+++ b/pint/testsuite/conftest.py
@@ -14,7 +14,7 @@ atto- =  1e-18 = a-
 femto- = 1e-15 = f-
 pico- =  1e-12 = p-
 nano- =  1e-9  = n-
-micro- = 1e-6  = µ- = μ- = u-
+micro- = 1e-6  = µ- = μ- = u- = mu- = mc-
 milli- = 1e-3  = m-
 centi- = 1e-2  = c-
 deci- =  1e-1  = d-

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -403,6 +403,12 @@ class TestIssues(QuantityTestCase):
     def test_micro_creation_U00b5(self, module_registry):
         module_registry.Quantity(2, "µm")
 
+    def test_micro_creation_mu(self, module_registry):
+        module_registry.Quantity(2, "mug")
+
+    def test_micro_creation_mc(self, module_registry):
+        module_registry.Quantity(2, "mcg")
+
     @helpers.requires_numpy
     def test_issue171_real_imag(self, module_registry):
         qr = [1.0, 2.0, 3.0, 4.0] * module_registry.meter


### PR DESCRIPTION
Added "mu" and "mc" as alternatives for SI micro prefix. They are mostly used in chemistry and biomedical fields.