### PR TITLE
fix Custom formatters not working with modifiers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Pint Changelog
 - Fix custom formatter needing the registry object. (PR #2011)
 - Support python 3.9 following difficulties installing with NumPy 2. (PR #2019)
 - Fix default formatting of dimensionless unit issue. (PR #2012)
+- Fix bug preventing custom formatters with modifiers working. (PR #2021)
 
 0.24 (2024-06-07)
 -----------------

--- a/pint/delegates/formatter/full.py
+++ b/pint/delegates/formatter/full.py
@@ -102,9 +102,11 @@ class FullFormatter(BaseFormatter):
             if k in spec:
                 return v
 
-        try:
-            orphan_fmt = REGISTERED_FORMATTERS[spec]
-        except KeyError:
+        for k, v in REGISTERED_FORMATTERS.items():
+            if k in spec:
+                orphan_fmt = REGISTERED_FORMATTERS[k]
+                break
+        else:
             return self._formatters["D"]
 
         try:

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -7,7 +7,12 @@ import pprint
 
 import pytest
 
-from pint import Context, DimensionalityError, UnitRegistry, get_application_registry
+from pint import (
+    Context,
+    DimensionalityError,
+    UnitRegistry,
+    get_application_registry,
+)
 from pint.compat import np
 from pint.delegates.formatter._compound_unit_helpers import sort_by_dimensionality
 from pint.facets.plain.unit import UnitsContainer
@@ -1255,3 +1260,28 @@ def test_issue1949(registry_empty):
 def test_issue1772(given, expected):
     ureg = UnitRegistry(non_int_type=decimal.Decimal)
     assert f"{ureg(given):Lx}" == expected
+
+
+def test_issue2017():
+    ureg = UnitRegistry()
+
+    from pint import formatting as fmt
+
+    @fmt.register_unit_format("test")
+    def _test_format(unit, registry, **options):
+        print("format called")
+        proc = {u.replace("µ", "u"): e for u, e in unit.items()}
+        return fmt.formatter(
+            proc.items(),
+            as_ratio=True,
+            single_denominator=False,
+            product_fmt="*",
+            division_fmt="/",
+            power_fmt="{}{}",
+            parentheses_fmt="({})",
+            **options,
+        )
+
+    base_unit = ureg.microsecond
+    assert f"{base_unit:~test}" == "us"
+    assert f"{base_unit:test}" == "microsecond"

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1286,7 +1286,7 @@ def test_issue2017():
     assert f"{base_unit:~test}" == "us"
     assert f"{base_unit:test}" == "microsecond"
 
- 
+
 def test_issue2007():
     ureg = UnitRegistry()
     q = ureg.Quantity(1, "")


### PR DESCRIPTION
- [ ] Closes #2017 
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
