### PR TITLE
🎨 Fix styling of docs headings in dark mode

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -49,4 +49,3 @@ html[data-theme=dark] {
     color: #FFF;
   }
 }
-

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -38,14 +38,15 @@ pre, code {
 
 .sd-card .sd-card-header {
   border: none;
+  color: #150458;
   font-size: var(--pst-font-size-h5);
   font-weight: bold;
   padding: 2.5rem 0rem 0.5rem 0rem;
 }
 
-@media (prefers-color-scheme: light) {
+@media (prefers-color-scheme: dark) {
   .sd-card .sd-card-header {
-    color: #150458;
+    color: #FFF;
   }
 }
 

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -38,8 +38,14 @@ pre, code {
 
 .sd-card .sd-card-header {
   border: none;
-  color: #150458 !important;
   font-size: var(--pst-font-size-h5);
   font-weight: bold;
   padding: 2.5rem 0rem 0.5rem 0rem;
 }
+
+@media (prefers-color-scheme: light) {
+  .sd-card .sd-card-header {
+    color: #150458;
+  }
+}
+

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -44,7 +44,7 @@ pre, code {
   padding: 2.5rem 0rem 0.5rem 0rem;
 }
 
-@media (prefers-color-scheme: dark) {
+html[data-theme=dark] {
   .sd-card .sd-card-header {
     color: #FFF;
   }


### PR DESCRIPTION
This is a very minor change to the CSS in the docs to make it a little nicer to read in dark mode. 
This doesn't close any issues and I wouldn't expect it to need any test or docs updates.

- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

<details>
<summary>Before</summary>
<img width="782" alt="Screen Shot 2024-06-30 at 4 12 47 PM" src="https://github.com/hgrecco/pint/assets/1615322/ac7204e9-7c13-46cc-8040-0a9f1a939ab0">

</details>

<details>
<summary>After</summary>
<img width="780" alt="Screen Shot 2024-06-30 at 4 12 56 PM" src="https://github.com/hgrecco/pint/assets/1615322/da09c146-c663-4a62-bc76-44bbb88d46c4">

</details>