### PR TITLE
Fix pylint warning `no-else-return`

### DIFF
--- a/pint/compat.py
+++ b/pint/compat.py
@@ -263,9 +263,8 @@ def check_upcast_type(obj: type) -> bool:
     fqn = fully_qualified_name(obj)
     if fqn not in upcast_type_map:
         return False
-    else:
-        module_name, class_name = fqn.rsplit(".", 1)
-        cls = getattr(import_module(module_name), class_name)
+    module_name, class_name = fqn.rsplit(".", 1)
+    cls = getattr(import_module(module_name), class_name)
 
     upcast_type_map[fqn] = cls
     # This is to check we are importing the same thing.
@@ -359,7 +358,7 @@ def isnan(obj: Any, check_all: bool) -> bool | Iterable[bool]:
         return out.any() if check_all else out
     if isinstance(obj, np_datetime64):
         return np.isnat(obj)
-    elif HAS_UNCERTAINTIES and isinstance(obj, UFloat):
+    if HAS_UNCERTAINTIES and isinstance(obj, UFloat):
         return unp.isnan(obj)
     try:
         return math.isnan(obj)

--- a/pint/delegates/formatter/_compound_unit_helpers.py
+++ b/pint/delegates/formatter/_compound_unit_helpers.py
@@ -267,8 +267,7 @@ def prepare_compount_unit(
     if len(out) == 0:
         if "~" in spec:
             return ([], [])
-        else:
-            return ([("dimensionless", 1)], [])
+        return ([("dimensionless", 1)], [])
 
     if "~" in spec:
         if registry is None:

--- a/pint/delegates/formatter/_format_helpers.py
+++ b/pint/delegates/formatter/_format_helpers.py
@@ -50,17 +50,13 @@ def format_number(value: Any, spec: str = "") -> str:
     """
     if isinstance(value, float):
         return format(value, spec or ".16n")
-
-    elif isinstance(value, int):
+    if isinstance(value, int):
         return format(value, spec or "n")
-
-    elif isinstance(value, ndarray) and value.ndim == 0:
+    if isinstance(value, ndarray) and value.ndim == 0:
         if issubclass(value.dtype.type, np_integer):
             return format(value, spec or "n")
-        else:
-            return format(value, spec or ".16n")
-    else:
-        return str(value)
+        return format(value, spec or ".16n")
+    return str(value)
 
 
 def builtin_format(value: Any, spec: str = "") -> str:

--- a/pint/delegates/formatter/latex.py
+++ b/pint/delegates/formatter/latex.py
@@ -83,17 +83,16 @@ def ndarray_to_latex_parts(
         return [vector_to_latex(ndarr, fmtfun)]
     if ndarr.ndim == 2:
         return [matrix_to_latex(ndarr, fmtfun)]
-    else:
+    if ndarr.ndim == 3:
+        header = ("arr[%s," % ",".join("%d" % d for d in dim)) + "%d,:,:]"
         ret = []
-        if ndarr.ndim == 3:
-            header = ("arr[%s," % ",".join("%d" % d for d in dim)) + "%d,:,:]"
-            for elno, el in enumerate(ndarr):
-                ret += [header % elno + " = " + matrix_to_latex(el, fmtfun)]
-        else:
-            for elno, el in enumerate(ndarr):
-                ret += ndarray_to_latex_parts(el, fmtfun, dim + (elno,))
-
+        for elno, el in enumerate(ndarr):
+            ret += [header % elno + " = " + matrix_to_latex(el, fmtfun)]
         return ret
+    ret = []
+    for elno, el in enumerate(ndarr):
+        ret += ndarray_to_latex_parts(el, fmtfun, dim + (elno,))
+    return ret
 
 
 def ndarray_to_latex(
@@ -128,15 +127,13 @@ def siunitx_format_unit(
         if power == int(power):
             if power == 1:
                 return ""
-            elif power == 2:
+            if power == 2:
                 return r"\squared"
-            elif power == 3:
+            if power == 3:
                 return r"\cubed"
-            else:
-                return rf"\tothe{{{int(power):d}}}"
-        else:
-            # limit float powers to 3 decimal places
-            return rf"\tothe{{{power:.3f}}}".rstrip("0")
+            return rf"\tothe{{{int(power):d}}}"
+        # limit float powers to 3 decimal places
+        return rf"\tothe{{{power:.3f}}}".rstrip("0")
 
     lpos = []
     lneg = []

--- a/pint/facets/dask/__init__.py
+++ b/pint/facets/dask/__init__.py
@@ -30,11 +30,10 @@ def check_dask_array(f):
     def wrapper(self, *args, **kwargs):
         if isinstance(self._magnitude, dask_array.Array):
             return f(self, *args, **kwargs)
-        else:
-            msg = "Method {} only implemented for objects of {}, not {}".format(
-                f.__name__, dask_array.Array, self._magnitude.__class__
-            )
-            raise AttributeError(msg)
+        msg = "Method {} only implemented for objects of {}, not {}".format(
+            f.__name__, dask_array.Array, self._magnitude.__class__
+        )
+        raise AttributeError(msg)
 
     return wrapper
 

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -778,7 +778,7 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
         dim1, dim2 = (self.get_dimensionality(unit) for unit in (unit1, unit2))
         if dim1 == dim2:
             return 1
-        elif not dim1 or not dim2 or dim1.keys() != dim2.keys():  # not comparable
+        if not dim1 or not dim2 or dim1.keys() != dim2.keys():  # not comparable
             return None
 
         ratios = (dim2[key] / val for key, val in dim1.items())
@@ -1292,23 +1292,21 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
         if token_type == NAME:
             if token_text == "dimensionless":
                 return self.Quantity(1)
-            elif token_text.lower() in ("inf", "infinity"):
+            if token_text.lower() in ("inf", "infinity"):
                 return self.non_int_type("inf")
-            elif token_text.lower() == "nan":
+            if token_text.lower() == "nan":
                 return self.non_int_type("nan")
-            elif token_text in values:
+            if token_text in values:
                 return self.Quantity(values[token_text])
-            else:
-                return self.Quantity(
-                    1,
-                    self.UnitsContainer(
-                        {self.get_name(token_text, case_sensitive=case_sensitive): 1}
-                    ),
-                )
-        elif token_type == NUMBER:
+            return self.Quantity(
+                1,
+                self.UnitsContainer(
+                    {self.get_name(token_text, case_sensitive=case_sensitive): 1}
+                ),
+            )
+        if token_type == NUMBER:
             return ParserHelper.eval_token(token, non_int_type=self.non_int_type)
-        else:
-            raise Exception("unknown token type")
+        raise Exception("unknown token type")
 
     def parse_pattern(
         self,

--- a/pint/facets/plain/unit.py
+++ b/pint/facets/plain/unit.py
@@ -142,48 +142,44 @@ class PlainUnit(PrettyIPython, SharedRegistryObject):
         return self.dimensionless
 
     def __mul__(self, other):
-        if self._check(other):
-            if isinstance(other, self.__class__):
-                return self.__class__(self._units * other._units)
-            else:
+            if self._check(other):
+                if isinstance(other, self.__class__):
+                    return self.__class__(self._units * other._units)
                 qself = self._REGISTRY.Quantity(1, self._units)
                 return qself * other
 
-        if isinstance(other, Number) and other == 1:
-            return self._REGISTRY.Quantity(other, self._units)
+            if isinstance(other, Number) and other == 1:
+                return self._REGISTRY.Quantity(other, self._units)
 
-        return self._REGISTRY.Quantity(1, self._units) * other
+            return self._REGISTRY.Quantity(1, self._units) * other
 
     __rmul__ = __mul__
 
     def __truediv__(self, other):
-        if self._check(other):
-            if isinstance(other, self.__class__):
-                return self.__class__(self._units / other._units)
-            else:
+            if self._check(other):
+                if isinstance(other, self.__class__):
+                    return self.__class__(self._units / other._units)
                 qself = 1 * self
                 return qself / other
 
-        return self._REGISTRY.Quantity(1 / other, self._units)
+            return self._REGISTRY.Quantity(1 / other, self._units)
 
     def __rtruediv__(self, other):
-        # As PlainUnit and Quantity both handle truediv with each other rtruediv can
-        # only be called for something different.
-        if isinstance(other, NUMERIC_TYPES):
-            return self._REGISTRY.Quantity(other, 1 / self._units)
-        elif isinstance(other, UnitsContainer):
-            return self.__class__(other / self._units)
+            # As PlainUnit and Quantity both handle truediv with each other rtruediv can
+            # only be called for something different.
+            if isinstance(other, NUMERIC_TYPES):
+                return self._REGISTRY.Quantity(other, 1 / self._units)
+            if isinstance(other, UnitsContainer):
+                return self.__class__(other / self._units)
 
-        return NotImplemented
+            return NotImplemented
 
     __div__ = __truediv__
     __rdiv__ = __rtruediv__
 
     def __pow__(self, other) -> PlainUnit:
-        if isinstance(other, NUMERIC_TYPES):
-            return self.__class__(self._units**other)
-
-        else:
+            if isinstance(other, NUMERIC_TYPES):
+                return self.__class__(self._units**other)
             mess = f"Cannot power PlainUnit by {type(other)}"
             raise TypeError(mess)
 
@@ -191,32 +187,27 @@ class PlainUnit(PrettyIPython, SharedRegistryObject):
         return self._units.__hash__()
 
     def __eq__(self, other) -> bool:
-        # We compare to the plain class of PlainUnit because each PlainUnit class is
-        # unique.
-        if self._check(other):
-            if isinstance(other, self.__class__):
-                return self._units == other._units
-            else:
+            # We compare to the plain class of PlainUnit because each PlainUnit class is
+            # unique.
+            if self._check(other):
+                if isinstance(other, self.__class__):
+                    return self._units == other._units
+            elif isinstance(other, NUMERIC_TYPES):
                 return other == self._REGISTRY.Quantity(1, self._units)
-
-        elif isinstance(other, NUMERIC_TYPES):
-            return other == self._REGISTRY.Quantity(1, self._units)
-
-        else:
             return self._units == other
 
     def __ne__(self, other) -> bool:
         return not (self == other)
 
     def compare(self, other, op) -> bool:
-        self_q = self._REGISTRY.Quantity(1, self)
+            self_q = self._REGISTRY.Quantity(1, self)
 
-        if isinstance(other, NUMERIC_TYPES):
-            return self_q.compare(other, op)
-        elif isinstance(other, (PlainUnit, UnitsContainer, dict)):
-            return self_q.compare(self._REGISTRY.Quantity(1, other), op)
+            if isinstance(other, NUMERIC_TYPES):
+                return self_q.compare(other, op)
+            if isinstance(other, (PlainUnit, UnitsContainer, dict)):
+                return self_q.compare(self._REGISTRY.Quantity(1, other), op)
 
-        return NotImplemented
+            return NotImplemented
 
     __lt__ = lambda self, other: self.compare(other, op=operator.lt)
     __le__ = lambda self, other: self.compare(other, op=operator.le)
@@ -263,10 +254,9 @@ class PlainUnit(PrettyIPython, SharedRegistryObject):
             if not isinstance(value, self._REGISTRY.Quantity):
                 value = self._REGISTRY.Quantity(1, value)
             return value.to(self)
-        elif strict:
+        if strict:
             raise ValueError("%s must be a Quantity" % value)
-        else:
-            return value * self
+        return value * self
 
     def m_from(self, value, strict=True, name="value"):
         """Converts a numerical value or quantity to this unit, then returns

--- a/pint/formatting.py
+++ b/pint/formatting.py
@@ -149,8 +149,7 @@ def format_unit(unit, spec: str, registry=None, **options):
     if not unit:
         if spec.endswith("%"):
             return ""
-        else:
-            return "dimensionless"
+        return "dimensionless"
 
     if not spec:
         spec = "D"

--- a/pint/pint_eval.py
+++ b/pint/pint_eval.py
@@ -75,8 +75,7 @@ class tokens_with_lookahead:
     def __next__(self):
         if self.buffer:
             return self.buffer.pop(0)
-        else:
-            return self.iter.__next__()
+        return self.iter.__next__()
 
     def lookahead(self, n):
         """Return an item n entries ahead in the iteration."""
@@ -383,7 +382,7 @@ class EvalTreeNode:
                 self.left.evaluate(define_op, bin_op, un_op),
                 self.right.evaluate(define_op, bin_op, un_op),
             )
-        elif self.operator:
+        if self.operator:
             assert isinstance(self.left, EvalTreeNode), "self.left not EvalTreeNode (4)"
             # unary operator
             op_text = self.operator.string

--- a/pint/util.py
+++ b/pint/util.py
@@ -725,9 +725,8 @@ class ParserHelper(UnitsContainer):
         """
         if non_int_type is float:
             return cls(1, [(input_word, 1)], non_int_type=non_int_type)
-        else:
-            ONE = non_int_type("1")
-            return cls(ONE, [(input_word, ONE)], non_int_type=non_int_type)
+        ONE = non_int_type("1")
+        return cls(ONE, [(input_word, ONE)], non_int_type=non_int_type)
 
     @classmethod
     def eval_token(cls, token: tokenize.TokenInfo, non_int_type: type = float):
@@ -818,14 +817,14 @@ class ParserHelper(UnitsContainer):
         self.scale = state[-1]
 
     def __eq__(self, other: Any) -> bool:
-        if isinstance(other, ParserHelper):
-            return self.scale == other.scale and super().__eq__(other)
-        elif isinstance(other, str):
-            return self == ParserHelper.from_string(other, self._non_int_type)
-        elif isinstance(other, Number):
-            return self.scale == other and not len(self._d)
+            if isinstance(other, ParserHelper):
+                return self.scale == other.scale and super().__eq__(other)
+            if isinstance(other, str):
+                return self == ParserHelper.from_string(other, self._non_int_type)
+            if isinstance(other, Number):
+                return self.scale == other and not len(self._d)
 
-        return self.scale == 1 and super().__eq__(other)
+            return self.scale == 1 and super().__eq__(other)
 
     def operate(self, items, op=operator.iadd, cleanup: bool = True):
         d = udict(self._d)
@@ -991,14 +990,12 @@ class SharedRegistryObject:
         """
         if self._REGISTRY is getattr(other, "_REGISTRY", None):
             return True
-
-        elif isinstance(other, SharedRegistryObject):
+        if isinstance(other, SharedRegistryObject):
             mess = "Cannot operate with {} and {} of different registries."
             raise ValueError(
                 mess.format(self.__class__.__name__, other.__class__.__name__)
             )
-        else:
-            return False
+        return False
 
 
 class PrettyIPython:
@@ -1048,21 +1045,19 @@ def to_units_container(
     mro = type(unit_like).mro()
     if UnitsContainer in mro:
         return unit_like
-    elif SharedRegistryObject in mro:
+    if SharedRegistryObject in mro:
         return unit_like._units
-    elif str in mro:
+    if str in mro:
         if registry:
             # TODO: document how to whether to lift preprocessing loop out to caller
             for p in registry.preprocessors:
                 unit_like = p(unit_like)
             return registry.parse_units_as_container(unit_like)
-        else:
-            return ParserHelper.from_string(unit_like)
-    elif dict in mro:
+        return ParserHelper.from_string(unit_like)
+    if dict in mro:
         if registry:
             return registry.UnitsContainer(unit_like)
-        else:
-            return UnitsContainer(unit_like)
+        return UnitsContainer(unit_like)
 
 
 def infer_base_unit(


### PR DESCRIPTION
### Changes Made:

- Applied automated fixes for the pylint warning `no-else-return`.
"Used in order to highlight an unnecessary block of code following an if containing a return statement. As such, it will warn when it encounters an else following a chain of ifs, all of them containing a return statement.. See [https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html)"

### Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.