### PR TITLE
Switch from appdirs to platformdirs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ Pint Changelog
 - Added mu and mc as alternatives for SI micro prefix
 - Added ℓ as alternative for liter
 - Support permille units and `‰` symbol (PR #2033, Issue #1963)
+- Switch from appdirs to platformdirs.
 
 
 0.24.1 (2024-06-24)

--- a/docs/advanced/performance.rst
+++ b/docs/advanced/performance.rst
@@ -120,7 +120,7 @@ If you want to use the default cache folder provided by the OS, use **:auto:**
     >>> import pint
     >>> ureg = pint.UnitRegistry(cache_folder=":auto:")  # doctest: +SKIP
 
-Pint use an included version of appdirs_ to obtain the correct folder,
+Pint use an external dependency of platformdirs_ to obtain the correct folder,
 for example in macOS is `/Users/<username>/Library/Caches/pint`
 
 In any case, you can check the location of the cache folder.
@@ -146,5 +146,5 @@ In any case, you can check the location of the cache folder.
 
 
 .. _`brentq method`: http://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.brentq.html
-.. _appdirs: https://pypi.org/project/appdirs/
+.. _platformdirs: https://pypi.org/project/platformdirs
 .. _flexcache: https://github.com/hgrecco/flexcache/

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
     # from ..._typing import Quantity, Unit
 
-import appdirs
+import platformdirs
 
 from ... import pint_eval
 from ..._typing import (
@@ -233,8 +233,7 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
         self._init_dynamic_classes()
 
         if cache_folder == ":auto:":
-            cache_folder = appdirs.user_cache_dir(appname="pint", appauthor=False)
-            cache_folder = pathlib.Path(cache_folder)
+            cache_folder = platformdirs.user_cache_path(appname="pint", appauthor=False)
 
         from ... import delegates  # TODO: change thiss
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-appdirs>=1.4.4
+platformdirs>=2.1.0
 typing_extensions
 flexcache>=0.3
 flexparser>=0.3


### PR DESCRIPTION
appdirs has been officially deprecated upstream, the replacement module with more features is platformdirs.

- [ ] Closes # (insert issue number)
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
