### PR TITLE
Add permille units with ‰ symbol

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Pint Changelog
 0.25 (unreleased)
 -----------------
 
-- Nothing added yet.
+- Support permille units and `‰` symbol (PR #2033, Issue #1963)
 
 
 0.24.1 (2024-06-24)

--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -150,6 +150,7 @@ byte = 8 * bit = B = octet
 
 # Ratios
 percent = 0.01 = %
+permille = 0.001 = ‰
 ppm = 1e-6
 
 # Length

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -255,6 +255,9 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
         # use a default preprocessor to support "%"
         self.preprocessors.insert(0, lambda string: string.replace("%", " percent "))
 
+        # use a default preprocessor to support permille "‰"
+        self.preprocessors.insert(0, lambda string: string.replace("‰", " permille "))
+
         #: mode used to fill in the format defaults
         self.separate_format_defaults = separate_format_defaults
 

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -884,6 +884,24 @@ class TestIssues(QuantityTestCase):
         assert c.to("percent").m == 50
         # assert c.to("%").m == 50  # TODO: fails.
 
+    def test_issue1963(self, module_registry):
+        ureg = module_registry
+        assert ureg("‰") == ureg("permille")
+        assert ureg("‰") == ureg.permille
+
+        a = ureg.Quantity("10 ‰")
+        b = ureg.Quantity("100 ppm")
+        c = ureg.Quantity("0.5")
+
+        assert f"{a}" == "10 permille"
+        assert f"{a:~}" == "10 ‰"
+
+        assert_equal(a, 0.01)
+        assert_equal(1e2 * b, a)
+        assert_equal(c, 50 * a)
+
+        assert_equal((1 * ureg.milligram) / (1 * ureg.gram), ureg.permille)
+
     @pytest.mark.xfail
     @helpers.requires_uncertainties()
     def test_issue_1300(self):


### PR DESCRIPTION
- [x] Closes #1963 
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
