### PR TITLE
rectifies a duplicate entry for the same fix in the changelog

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,10 +4,9 @@ Pint Changelog
 0.25 (unreleased)
 -----------------
 
-- Fix the default behaviour for pint-convert (cli) for importing uncertainties package
+- Fix the default behaviour for pint-convert (cli) for importing uncertainties package (PR #2032, Issue #2016)
 - Added mu and mc as alternatives for SI micro prefix
 - Added ℓ as alternative for liter
-- Fix the default behaviour for pint-convert (cli) for importing uncertainties package (PR #2032, Issue #2016)
 - Support permille units and `‰` symbol (PR #2033, Issue #1963)
 
 


### PR DESCRIPTION
* This rectifies a duplicate entry for the same fix, but only one entry now contains the associated numbers.

- [ ] Closes # (insert issue number)
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
