### PR TITLE
2035 pandas3

### DIFF
--- a/pint/compat.py
+++ b/pint/compat.py
@@ -240,6 +240,8 @@ upcast_type_names = (
     "xarray.core.variable.Variable",
     "pandas.core.series.Series",
     "pandas.core.frame.DataFrame",
+    "pandas.Series",
+    "pandas.DataFrame",
     "xarray.core.dataarray.DataArray",
 )
 

--- a/pint/compat.py
+++ b/pint/compat.py
@@ -242,6 +242,7 @@ upcast_type_names = (
     "pandas.core.frame.DataFrame",
     "pandas.Series",
     "pandas.DataFrame",
+    "xarray.core.dataarray.DataArray",
 )
 
 #: Map type name to the actual type (for upcast types).

--- a/pint/compat.py
+++ b/pint/compat.py
@@ -242,7 +242,6 @@ upcast_type_names = (
     "pandas.core.frame.DataFrame",
     "pandas.Series",
     "pandas.DataFrame",
-    "xarray.core.dataarray.DataArray",
 )
 
 #: Map type name to the actual type (for upcast types).


### PR DESCRIPTION
- [x] Closes 2035 
- [x] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

It is difficult to add test to `is_upcast_type` function since it would need `pandas`, `pint-pandas` an `xarray` to be installed.

I removed one duplicate in the list.