### PR TITLE
fix GenericPlainRegistry getattr type

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Pint Changelog
 - Added ℓ as alternative for liter
 - Support permille units and `‰` symbol (PR #2033, Issue #1963)
 - Switch from appdirs to platformdirs.
+- Fixes issues related to GenericPlainRegistry.__getattr__ type (PR #2038, Issues #1946 and #1804)
 
 
 0.24.1 (2024-06-24)

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -367,7 +367,7 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
         new._init_dynamic_classes()
         return new
 
-    def __getattr__(self, item: str) -> QuantityT:
+    def __getattr__(self, item: str) -> UnitT:
         getattr_maybe_raise(self, item)
 
         # self.Unit will call parse_units

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -2014,3 +2014,10 @@ class TestCompareNeutral(QuantityTestCase):
         assert q2 > 0
         with pytest.raises(DimensionalityError):
             q1.__gt__(ureg.Quantity(0, ""))
+
+
+    def test_types(self):
+        quantity = self.Q_(1.0, "m")
+        assert type(quantity) == self.Q_
+        assert type(quantity.units) == self.ureg.Unit
+        assert type(quantity.m) == float

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -2020,3 +2020,5 @@ class TestCompareNeutral(QuantityTestCase):
         assert isinstance(quantity, self.Q_)
         assert isinstance(quantity.units, self.ureg.Unit)
         assert isinstance(quantity.m, float)
+
+        assert isinstance(self.ureg.m, self.ureg.Unit)

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -2015,9 +2015,8 @@ class TestCompareNeutral(QuantityTestCase):
         with pytest.raises(DimensionalityError):
             q1.__gt__(ureg.Quantity(0, ""))
 
-
     def test_types(self):
         quantity = self.Q_(1.0, "m")
-        assert type(quantity) == self.Q_
-        assert type(quantity.units) == self.ureg.Unit
-        assert type(quantity.m) == float
+        assert isinstance(quantity, self.Q_)
+        assert isinstance(quantity.units, self.ureg.Unit)
+        assert isinstance(quantity.m, float)


### PR DESCRIPTION
- [x] Closes #1946 and #1804
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate  -- no need to document, it's a bugfix for type
- [x] Added an entry to the CHANGES file

I'm aware that there exists PR #1948 , but it's not been merged for a while