### PR TITLE
Adding GitHub content protection rule to CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,6 +10,9 @@ on:
   # performance analysis in order to generate initial data.
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   benchmarks:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test-linux:
     strategy:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,9 @@ name: Documentation Build
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   docbuild:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What is the change?

I have constrained the permissions of the GitHub Actions in this repo.

The permissions I set are maximally constrained so that a bad actor can't use a PR into your repo to do various things like: commit to your main branch, modify a GH "Discussion" in your repo, or author an official release.

## A Little Background

GitHub added [this security feature](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions) in 2021.

This is not a complete solution in itself, of course. But it pairs really well with the setting pint has where Pint team members have to "approve a workflow" from a non-team member, to run CI.

For a shorter discussion of the topic than the full GitHub docs, see [this blog post](https://dev.to/azu/how-to-set-github-actions-s-permissions-hln).

## The Checklist

- [ ] Closes # (insert issue number)
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file