### PR TITLE
Replace references to the deprecated `UnitRegistry.default_format`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ Pint Changelog
 - Support permille units and `‰` symbol (PR #2033, Issue #1963)
 - Switch from appdirs to platformdirs.
 - Fixes issues related to GenericPlainRegistry.__getattr__ type (PR #2038, Issues #1946 and #1804)
+- Removed deprecated references in documentation and tests (PR #2058, Issue #2057)
 
 
 0.24.1 (2024-06-24)

--- a/docs/getting/tutorial.rst
+++ b/docs/getting/tutorial.rst
@@ -415,7 +415,7 @@ Additionally, you can specify a default format specification:
    >>> accel = 1.3 * ureg.parse_units('meter/second**2')
    >>> 'The acceleration is {}'.format(accel)
    'The acceleration is 1.3 meter / second ** 2'
-   >>> ureg.default_format = 'P'
+   >>> ureg.formatter.default_format = 'P'
    >>> 'The acceleration is {}'.format(accel)
    'The acceleration is 1.3 meter/second²'
 
@@ -446,7 +446,7 @@ and by doing that, string formatting is now localized:
 
 .. doctest::
 
-    >>> ureg.default_format = 'P'
+    >>> ureg.formatter.default_format = 'P'
     >>> accel = 1.3 * ureg.parse_units('meter/second**2')
     >>> str(accel)
     '1,3 mètres par seconde²'

--- a/docs/user/nonmult.rst
+++ b/docs/user/nonmult.rst
@@ -18,7 +18,7 @@ For example, to convert from celsius to fahrenheit:
 
     >>> from pint import UnitRegistry
     >>> ureg = UnitRegistry()
-    >>> ureg.default_format = '.3f'
+    >>> ureg.formatter.default_format = '.3f'
     >>> Q_ = ureg.Quantity
     >>> home = Q_(25.4, ureg.degC)
     >>> print(home.to('degF'))

--- a/pint/testsuite/test_babel.py
+++ b/pint/testsuite/test_babel.py
@@ -66,7 +66,7 @@ def test_unit_format_babel():
     volume = ureg.Unit("ml")
     assert volume.format_babel() == "millilitre"
 
-    ureg.default_format = "~"
+    ureg.formatter.default_format = "~"
     assert volume.format_babel() == "ml"
 
     dimensionless_unit = ureg.Unit("")

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -70,7 +70,7 @@ class TestUnit(QuantityTestCase):
             "Lx~": r"\si[]{\%}",
         }.items():
             with subtests.test(spec):
-                ureg.default_format = spec
+                ureg.formatter.default_format = spec
                 assert f"{x}" == result, f"Failed for {spec}, got {x} expected {result}"
         # no '#' here as it's a comment char when define()ing new units
         ureg.define(r"weirdunit = 1 = \~_^&%$_{}")
@@ -83,7 +83,7 @@ class TestUnit(QuantityTestCase):
             # "Lx~": r"\si[]{\textbackslash \textasciitilde \_\textasciicircum \&\%\$\_\{\}}",
         }.items():
             with subtests.test(spec):
-                ureg.default_format = spec
+                ureg.formatter.default_format = spec
                 assert f"{x}" == result, f"Failed for {spec}, {result}"
 
     def test_unit_default_formatting(self, subtests):
@@ -104,13 +104,13 @@ class TestUnit(QuantityTestCase):
             ("C~", "kg*m**2/s"),
         ):
             with subtests.test(spec):
-                ureg.default_format = spec
+                ureg.formatter.default_format = spec
                 assert f"{x}" == result, f"Failed for {spec}, {result}"
 
     @pytest.mark.xfail(reason="Still not clear how default formatting will work.")
     def test_unit_formatting_defaults_warning(self):
         ureg = UnitRegistry()
-        ureg.default_format = "~P"
+        ureg.formatter.default_format = "~P"
         x = ureg.Unit("m / s ** 2")
 
         with pytest.warns(DeprecationWarning):
@@ -136,7 +136,7 @@ class TestUnit(QuantityTestCase):
             ("C~", "oil_bbl"),
         ):
             with subtests.test(spec):
-                ureg.default_format = spec
+                ureg.formatter.default_format = spec
                 assert f"{x}" == result, f"Failed for {spec}, {result}"
 
     def test_unit_formatting_custom(self, monkeypatch):
@@ -177,7 +177,7 @@ class TestUnit(QuantityTestCase):
         )
         x._repr_pretty_(Pretty, False)
         assert "".join(alltext) == "kilogram·meter²/second"
-        ureg.default_format = "~"
+        ureg.formatter.default_format = "~"
         assert x._repr_html_() == "kg m<sup>2</sup>/s"
         assert (
             x._repr_latex_() == r"$\frac{\mathrm{kg} \cdot \mathrm{m}^{2}}{\mathrm{s}}$"
@@ -322,11 +322,11 @@ class TestRegistry(QuantityTestCase):
         q = ureg.meter
         s1 = f"{q}"
         s2 = f"{q:~}"
-        ureg.default_format = "~"
+        ureg.formatter.default_format = "~"
         s3 = f"{q}"
         assert s2 == s3
         assert s1 != s3
-        assert ureg.default_format == "~"
+        assert ureg.formatter.default_format == "~"
 
     def test_iterate(self):
         ureg = UnitRegistry()


### PR DESCRIPTION
- [x] Closes #2057 
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
