### PR TITLE
qto.py: Make nan/inf magnitude checks accept uncertainties

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ Pint Changelog
 - Switch from appdirs to platformdirs.
 - Fixes issues related to GenericPlainRegistry.__getattr__ type (PR #2038, Issues #1946 and #1804)
 - Removed deprecated references in documentation and tests (PR #2058, Issue #2057)
+- Fixed issue with `.to_compact` and Magnitudes with uncertainties / Quantities with units (PR #2069, issue #2044)
 
 
 0.24.1 (2024-06-24)

--- a/pint/facets/plain/qto.py
+++ b/pint/facets/plain/qto.py
@@ -110,12 +110,12 @@ def to_compact(
         )
         return quantity
 
-    if (
-        quantity.unitless
-        or quantity.magnitude == 0
-        or math.isnan(quantity.magnitude)
-        or math.isinf(quantity.magnitude)
-    ):
+    qm = (
+        quantity.magnitude
+        if not hasattr(quantity.magnitude, "nominal_value")
+        else quantity.magnitude.nominal_value
+    )
+    if quantity.unitless or qm == 0 or math.isnan(qm) or math.isinf(qm):
         return quantity
 
     SI_prefixes: dict[int, str] = {}

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -400,7 +400,7 @@ class TestIssues(QuantityTestCase):
         module_registry.Quantity(2, "Å")
 
     def test_alternative_angstrom_definition(self, module_registry):
-        module_registry.Quantity(2, "\u212B")
+        module_registry.Quantity(2, "\u212b")
 
     def test_micro_creation_U03bc(self, module_registry):
         module_registry.Quantity(2, "μm")
@@ -1331,3 +1331,21 @@ def test_issue2007():
     assert f"{q:~C}" == "1"
     assert f"{q:~D}" == "1"
     assert f"{q:~H}" == "1"
+
+
+@helpers.requires_uncertainties()
+@helpers.requires_numpy()
+def test_issue2044():
+    from numpy.testing import assert_almost_equal
+    from uncertainties import ufloat
+
+    ureg = UnitRegistry()
+    # First make sure this doesn't fail completely (A Measurement)
+    q = ureg.Quantity(10_000, "m").plus_minus(0.01).to_compact()
+    assert_almost_equal(q.m.n, 10.0)
+    assert q.u == "kilometer"
+
+    # Similarly, for a Ufloat with units
+    q = (ufloat(10_000, 0.01) * ureg.m).to_compact()
+    assert_almost_equal(q.m.n, 10.0)
+    assert q.u == "kilometer"


### PR DESCRIPTION
- [x] Closes #2044 (insert issue number)
- [x] Executed `ruff format` on the modified files, and checked that CI on my fork is green.
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
