### PR TITLE
Use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "Pint"
 authors = [
   {name="Hernan E. Grecco", email="hernan.grecco@gmail.com"}
 ]
-license = {text = "BSD"}
+license = {text = "BSD-3-Clause"}
 description = "Physical quantities module"
 readme = "README.rst"
 maintainers = [


### PR DESCRIPTION
Add the SPDX license identifier as recommended by [PEP 639](https://peps.python.org/pep-0639/).
https://spdx.org/licenses/BSD-3-Clause.html
