### PR TITLE
fix: Fix round function returning `float` instead of `int`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Pint Changelog
 -------------------
 
 - Add docs to the functions in ``pint.testing`` (PR #2070)
+- Fix round function returning float instead of int (#2081)
 
 
 0.24.4 (2024-11-07)

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -1,9 +1,9 @@
 """
-    pint.facets.plain.quantity
-    ~~~~~~~~~~~~~~~~~~~~~~~~~
+pint.facets.plain.quantity
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    :copyright: 2022 by Pint Authors, see AUTHORS for more details.
-    :license: BSD, see LICENSE for more details.
+:copyright: 2022 by Pint Authors, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
 """
 
 from __future__ import annotations
@@ -1288,8 +1288,8 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
     def __abs__(self) -> PlainQuantity[MagnitudeT]:
         return self.__class__(abs(self._magnitude), self._units)
 
-    def __round__(self, ndigits: int | None = 0) -> PlainQuantity[MagnitudeT]:
-        return self.__class__(round(self._magnitude, ndigits=ndigits), self._units)
+    def __round__(self, ndigits: int | None = None) -> PlainQuantity[int]:
+        return self.__class__(round(self._magnitude, ndigits), self._units)
 
     def __pos__(self) -> PlainQuantity[MagnitudeT]:
         return self.__class__(operator.pos(self._magnitude), self._units)

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -60,6 +60,11 @@ class TestQuantity(QuantityTestCase):
             assert 4.2 * self.ureg.meter == self.Q_(4.2, 2 * self.ureg.meter)
         assert len(caplog.records) == 1
 
+    def test_round(self):
+        x = self.Q_(1.1, "kg")
+        assert isinstance(round(x).magnitude, int)
+        assert isinstance(round(x, 0).magnitude, float)
+
     def test_quantity_with_quantity(self):
         x = self.Q_(4.2, "m")
         assert self.Q_(x, "m").magnitude == 4.2


### PR DESCRIPTION
Fix #2081

- [x] Closes #2081
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
