### PR TITLE
Fix return type of PlainQuantity.to

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Pint Changelog
 
 - Add docs to the functions in ``pint.testing`` (PR #2070)
 - Fix round function returning float instead of int (#2081)
+- Fix return type of `PlainQuantity.to` (#2088)
 
 
 0.24.4 (2024-11-07)

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -19,6 +19,7 @@ from typing import (
     Any,
     Generic,
     Iterable,
+    Self,
     TypeVar,
     overload,
 )
@@ -515,7 +516,7 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
 
     def to(
         self, other: QuantityOrUnitLike | None = None, *contexts, **ctx_kwargs
-    ) -> PlainQuantity:
+    ) -> Self:
         """Return PlainQuantity rescaled to different units.
 
         Parameters

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -19,7 +19,6 @@ from typing import (
     Any,
     Generic,
     Iterable,
-    Self,
     TypeVar,
     overload,
 )
@@ -33,6 +32,7 @@ from ...compat import (
     is_duck_array_type,
     is_upcast_type,
     np,
+    Self,
     zero_or_nan,
 )
 from ...errors import DimensionalityError, OffsetUnitCalculusError, PintTypeError


### PR DESCRIPTION
- [x] Closes #2088
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
