### PR TITLE
bump typing_extension min requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 platformdirs>=2.1.0
-typing_extensions>=4.0.0
+typing_extensions>=4.5.0
 flexcache>=0.3
 flexparser>=0.4


### PR DESCRIPTION
`pint.compat` uses `typing_extensions.deprecated`,  which was added in v4.5.0

```pytb
/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/pint/compat.py:50: in <module>
    from typing_extensions import deprecated  # noqa
E   ImportError: cannot import name 'deprecated' from 'typing_extensions' (/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/typing_extensions.py)
```