### PR TITLE
Fix syntax highlighting in overview doc

### DIFF
--- a/docs/getting/overview.rst
+++ b/docs/getting/overview.rst
@@ -105,6 +105,7 @@ License
 -------
 
 .. literalinclude:: ../../LICENSE
+   :language: none
 
 .. _`comprehensive list of physical units, prefixes and constants`: https://github.com/hgrecco/pint/blob/master/pint/default_en.txt
 .. _`uncertainties package`: https://pythonhosted.org/uncertainties/


### PR DESCRIPTION
Remove bogus syntax highlighting on LICENSE in overview.rst

I haven't really worked with RST myself, so please check my work.

- ~~[ ] Closes # (insert issue number)~~
- [ ] Executed `pre-commit run --all-files` with no errors
- ~~[ ] The change is fully covered by automated unit tests~~
- ~~[ ] Documented in docs/ as appropriate~~
- ~~[ ] Added an entry to the CHANGES file~~
