### PR TITLE
Construct fraction and eliminate common terms when calculating conversion factor to increase accuracy

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,7 @@ Pint Changelog
 - Fix return type of `PlainQuantity.to` (#2088)
 - Update constants to CODATA 2022 recommended values. (#2049)
 - Fixed issue with `.to_compact` and Magnitudes with uncertainties / Quantities with units (PR #2069, issue #2044)
-
+- Fixed issue in unit conversion which led to loss of precision when using `decimal`. (#2107)
 
 0.24.4 (2024-11-07)
 -------------------

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -962,7 +962,11 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
             if reg.is_base:
                 accumulators[key] += exp2
             else:
-                accumulators[None] *= reg.converter.scale**exp2
+                # Use division operator for division instead of exponentiation
+                if exp2 < 0:
+                    accumulators[None] /= reg.converter.scale**abs(exp2)
+                else:
+                    accumulators[None] *= reg.converter.scale**abs(exp2)
                 if reg.reference is not None:
                     self._get_root_units_recurse(reg.reference, exp2, accumulators)
 

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1349,3 +1349,23 @@ def test_issue2044():
     q = (ufloat(10_000, 0.01) * ureg.m).to_compact()
     assert_almost_equal(q.m.n, 10.0)
     assert q.u == "kilometer"
+
+
+def test_issue2107():
+    # Use decimal
+    ureg = UnitRegistry(non_int_type=decimal.Decimal)
+    # 2 L/h is equal to 48 L/day
+    flow = decimal.Decimal('2')*ureg.L/ureg.h
+    assert flow.to(ureg.L/ureg.day).magnitude == 48.0
+    # 1 inch is equal to 1000 thou
+    distance = ureg.Quantity(decimal.Decimal("1.0"), ureg.inch)
+    assert distance.to(ureg.thou).magnitude == 1000.0
+
+    # Perform the same conversions without decimal
+    ureg = UnitRegistry()
+    # 2 L/h is equal to 48 L/day
+    flow = 2*ureg.L/ureg.h
+    assert flow.to(ureg.L/ureg.day).magnitude == 48.0
+    # 1 inch is equal to 1000 thou
+    distance = ureg.Quantity(1, ureg.inch)
+    assert distance.to(ureg.thou).magnitude == 1000.0


### PR DESCRIPTION
- [x] Closes #2107 (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

This change increases accuracy for unit conversions involving fractions which do not have real number representations.
Some conversions take long winding paths where premature evaluation of fractions lead to numerical errors.

### Example
Take for instance conversion from `inch` to thou. The factor is `1000` so conversion should be lossless. However, the conversion process is actually `inch`->`yard`->`meter`->`yard`->`inch`->`thou`. The fraction is built one multiplication at a time and this incurs a loss of precision.
The calculation is:
`factor = 1 * (1/36) * (1/0.9144) * 0.9144 * 36 * 1000`

This change first builds the fraction, then eliminates terms in the fraction and finally it is evaluated numerically. The numerator is built and elimination performed resulting in `factor = 1000`.