### PR TITLE
Bugfix for `_replace_units`

### DIFF
--- a/pint/registry_helpers.py
+++ b/pint/registry_helpers.py
@@ -43,7 +43,7 @@ def _replace_units(original_units, values_by_name):
     """
     q = 1
     for arg_name, exponent in original_units.items():
-        q = q * values_by_name[arg_name] ** exponent
+        q = q * values_by_name[arg_name].units ** exponent
 
     return getattr(q, "_units", UnitsContainer({}))
 


### PR DESCRIPTION
Closes #2111

I encountered the following bug:

This one works:
```python
def f(C, x, P):
    return np.linalg.norm(P) / np.linalg.norm(C) / x**2

f(np.random.randn(2, 3, 4), np.random.randn(5, 6), np.random.randn(7, 8))
```
This one doesn't:
```python
@ureg.wraps("=P/C/x**2", ("=C", "=x", "=P"))
def f(C, x, P):
    return np.linalg.norm(P) / np.linalg.norm(C) / x**2

f(np.random.randn(2, 3, 4) * ureg.gigapascal, np.random.randn(5, 6) * ureg.meter, np.random.randn(7, 8) * ureg.joule)
```
The fix I'm proposing here would solve the problem.

- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
