### PR TITLE
fix(docs): add graphviz package to render graphviz graphs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,6 +3,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+    - graphviz
 sphinx:
   configuration: docs/conf.py
   fail_on_warning: false


### PR DESCRIPTION
Documentation on readthedocs fails to render graphs for  numpy page https://pint.readthedocs.io/en/stable/user/numpy.html adding graphviz apt package should do the trick
