### PR TITLE
Number comparison with quantity

### DIFF
--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -1383,6 +1383,10 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
                         return op(self.to_base_units()._magnitude, other)
                     else:
                         raise OffsetUnitCalculusError(self._units)
+            elif isinstance(
+                other, (numbers.Number, np.number) if HAS_NUMPY else numbers.Number
+            ):
+                return op(self._magnitude, other)
             else:
                 raise ValueError(f"Cannot compare PlainQuantity and {type(other)}")
 


### PR DESCRIPTION
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

Haven't added tests yet, just a proposal enabling:

```python
import pint

d = pint.Quantity(5, "m")
print(d > 6)
d = pint.Quantity(10, "m")
print(d > 6)
```

For now, `pint` gives an error:

```sh
ValueError: Cannot compare PlainQuantity and <class 'int'>
```

This is something of interest within the integration of `pydantic` and `pint`