### PR TITLE
build: upper bound for sphinx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ all = [
   "pint[numpy,uncertainties,babel,pandas,pandas,xarray,dask,mip,matplotlib]",
 ]
 docs = [
-  "sphinx>=6",
+  "sphinx>=6,<8.2",
   "ipython<=8.12",
   "nbsphinx",
   "jupyter_client",


### PR DESCRIPTION
Docs are not building with the lastest version of sphinx (v8.2.0).

```python
Traceback
=========
File ".../pint/.pixi/envs/docs/lib/python3.11/site-packages/sphinx/events.py", line 415, in emit
  raise ExtensionError
    sphinx.errors.ExtensionError:
    Handler <function html_collect_pages at 0x11406d440> for event 'html-collect-pages'
    threw an exception (exception: module 'sphinx.util' has no attribute 'console')
```
