### PR TITLE
chore: fix type error in pyproject.toml file

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ Pint Changelog
 - Add absorbance unit and dimension. (#2114)
 - Add membrane filtration flux and permeability dimensionality, and shorthand "LMH". (#2116)
 - Fix find_shortest_path to use breadth first search (#2146)
+- Fix typo in `pyproject.toml`: rename `AS_MIP` to `HAS_MIP` so that MIP support is correctly detected. (#2152)
 
 
 0.24.4 (2024-11-07)

--- a/CHANGES
+++ b/CHANGES
@@ -18,7 +18,7 @@ Pint Changelog
 - Add absorbance unit and dimension. (#2114)
 - Add membrane filtration flux and permeability dimensionality, and shorthand "LMH". (#2116)
 - Fix find_shortest_path to use breadth first search (#2146)
-- Fix typo in `pyproject.toml`: rename `AS_MIP` to `HAS_MIP` so that MIP support is correctly detected. (#2152)
+- Fix typo in ``pyproject.toml``: rename ``AS_MIP`` to ``HAS_MIP`` so that MIP support is correctly detected. (#2152)
 
 
 0.24.4 (2024-11-07)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,5 +212,5 @@ exclude = ["pint/testsuite"]
 HAS_BABEL = true
 HAS_UNCERTAINTIES = true
 HAS_NUMPY = true
-AS_MIP = true
+HAS_MIP = true
 HAS_DASK = true


### PR DESCRIPTION
## Checklist
- [x] Closes #2152
- [x] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

## Overview
This PR fixes a typo in the pyproject.toml configuration file. The key AS_MIP has been corrected to HAS_MIP to ensure that the MIP support is properly recognized by the project.

## What Changed

<pre>
- AS_MIP = true
+ HAS_MIP = true
</pre>