### PR TITLE
feat: Add meter per second squared to standard definitions and provid…

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -252,6 +252,7 @@ sverdrup = 1e6 * meter ** 3 / second = sv
 # Acceleration
 [acceleration] = [velocity] / [time]
 galileo = centimeter / second ** 2 = Gal
+meter_per_second_squared = meter / second ** 2
 
 # Force
 [force] = [mass] * [acceleration]

--- a/pint/testsuite/test_definitions.py
+++ b/pint/testsuite/test_definitions.py
@@ -101,6 +101,25 @@ class TestDefinition:
                 "degF = 9 / 5 * kelvin; offset: 255.372222 bla",
             )
 
+        x = Definition.from_string(f"meter_per_second_squared = acceleration")
+
+        assert isinstance(x, UnitDefinition)
+        assert x.name == "meter_per_second_squared"
+        assert x.aliases == ()
+        assert x.symbol == "meter_per_second_squared"
+        assert not x.is_base
+        assert isinstance(x.converter, ScaleConverter)
+        assert x.reference == UnitsContainer(acceleration=1)
+        x = Definition.from_string("kilometer_per_second = velocity")
+        assert isinstance(x, UnitDefinition)
+
+        assert x.name == "kilometer_per_second"
+        assert x.aliases == ()
+        assert x.symbol == "kilometer_per_second"
+        assert not x.is_base
+        assert isinstance(x.converter, ScaleConverter)
+        assert x.reference == UnitsContainer(velocity=1)
+
     def test_log_unit_definition(self):
         x = Definition.from_string(
             "decibelmilliwatt = 1e-3 watt; logbase: 10; logfactor: 10 = dBm"

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -513,6 +513,8 @@ class TestQuantity(QuantityTestCase):
     def test_both_symbol(self):
         assert self.Q_(2, "ms") == self.Q_(2, "millisecond")
         assert self.Q_(2, "cm") == self.Q_(2, "centimeter")
+        assert self.Q_(2, "mm / s ** 2") == self.Q_(
+            2, "millimeter_per_second_squared")
 
     def test_dimensionless_units(self):
         assert (


### PR DESCRIPTION
This works on issue #2118 

Adding the first meter_per_second_squared. I added a few tests. Are there proposals to add further, what is required?

- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
