### PR TITLE
fix: flip left/right in np.interp wrapper

### DIFF
--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -559,7 +559,7 @@ def _full_like(a, fill_value, **kwargs):
 def _interp(x, xp, fp, left=None, right=None, period=None):
     # Need to handle x and y units separately
     (x, xp, period), _ = unwrap_and_wrap_consistent_units(x, xp, period)
-    (fp, right, left), output_wrap = unwrap_and_wrap_consistent_units(fp, left, right)
+    (fp, left, right), output_wrap = unwrap_and_wrap_consistent_units(fp, left, right)
     return output_wrap(np.interp(x, xp, fp, left=left, right=right, period=period))
 
 

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1095,22 +1095,62 @@ class TestNumpyUnclassified(TestNumpyMethods):
 
     @helpers.requires_array_function_protocol()
     def test_interp_numpy_func(self):
-        x = [1, 4] * self.ureg.m
+        x = [-1, 1, 4] * self.ureg.m
         xp = np.linspace(0, 3, 5) * self.ureg.m
         fp = self.Q_([0, 5, 10, 15, 20], self.ureg.degC)
+        left = self.Q_(-999.0, self.ureg.degC)
+        right = self.Q_(999.0, self.ureg.degC)
         helpers.assert_quantity_almost_equal(
-            np.interp(x, xp, fp), self.Q_([6.66667, 20.0], self.ureg.degC), rtol=1e-5
+            np.interp(x, xp, fp),
+            self.Q_([0.0, 6.66667, 20.0], self.ureg.degC),
+            rtol=1e-5,
+        )
+        helpers.assert_quantity_almost_equal(
+            np.interp(x, xp, fp, right=right),
+            self.Q_([0.0, 6.6667, 999.0], self.ureg.degC),
+            rtol=1e-5,
+        )
+        helpers.assert_quantity_almost_equal(
+            np.interp(x, xp, fp, left=left),
+            self.Q_([-999.0, 6.6667, 20], self.ureg.degC),
+            rtol=1e-5,
+        )
+        helpers.assert_quantity_almost_equal(
+            np.interp(x, xp, fp, left=left, right=right),
+            self.Q_([-999.0, 6.6667, 999.0], self.ureg.degC),
+            rtol=1e-5,
         )
 
-        x_ = np.array([1, 4])
+        x_ = np.array([-1, 1, 4])
         xp_ = np.linspace(0, 3, 5)
         fp_ = [0, 5, 10, 15, 20]
+        left_ = -999.0
+        right_ = 999.0
 
         helpers.assert_quantity_almost_equal(
-            np.interp(x_, xp_, fp), self.Q_([6.6667, 20.0], self.ureg.degC), rtol=1e-5
+            np.interp(x_, xp_, fp),
+            self.Q_([0.0, 6.6667, 20.0], self.ureg.degC),
+            rtol=1e-5,
         )
         helpers.assert_quantity_almost_equal(
-            np.interp(x, xp, fp_), [6.6667, 20.0], rtol=1e-5
+            np.interp(x, xp, fp_),
+            [0.0, 6.6667, 20.0],
+            rtol=1e-5,
+        )
+        helpers.assert_quantity_almost_equal(
+            np.interp(x, xp, fp_, right=right_),
+            [0.0, 6.6667, 999.0],
+            rtol=1e-5,
+        )
+        helpers.assert_quantity_almost_equal(
+            np.interp(x, xp, fp_, left=left_),
+            [-999.0, 6.6667, 20],
+            rtol=1e-5,
+        )
+        helpers.assert_quantity_almost_equal(
+            np.interp(x, xp, fp_, left=left_, right=right_),
+            [-999.0, 6.6667, 999.0],
+            rtol=1e-5,
         )
 
     def test_comparisons(self):


### PR DESCRIPTION
- [ ] Closes #2184
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
