### PR TITLE
fix Formatted scientific notation breaks in Python 3.13

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Pint Changelog
 0.25.0 (unreleased)
 -------------------
 
-- Bump minimum Python version to 3.11.:
+- Bump minimum Python version to 3.11.
 - Upgrade code to Python 3.11.
 - Move to pixi/uv/ruff.
 - Refactor compat to make it easier to test.
@@ -22,6 +22,7 @@ Pint Changelog
 - Fix typo in ``pyproject.toml``: rename ``AS_MIP`` to ``HAS_MIP`` so that MIP support is correctly detected. (#2152)
 - Fix handling of extra arguments in conversion with enabled contexts (#2172)
 - Fix swapped left and right arguments in interp (#2187)
+- Fix formatted scientific notation bug in Python 3.13 (#2168)
 
 
 0.24.4 (2024-11-07)

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -240,7 +240,7 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
         if cache_folder == ":auto:":
             cache_folder = platformdirs.user_cache_path(appname="pint", appauthor=False)
 
-        from ... import delegates  # TODO: change thiss
+        from ... import delegates  # TODO: change this
 
         if cache_folder is not None:
             self._diskcache = delegates.build_disk_cache_class(non_int_type)(
@@ -261,6 +261,9 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
 
         # use a default preprocessor to support permille "‰"
         self.preprocessors.insert(0, lambda string: string.replace("‰", " permille "))
+
+        # use a default preprocessor to support multiplication sign "×"
+        self.preprocessors.insert(0, lambda string: string.replace("×", "*"))
 
         #: mode used to fill in the format defaults
         self.separate_format_defaults = separate_format_defaults

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -60,6 +60,8 @@ class TestQuantity(QuantityTestCase):
             assert 4.2 * self.ureg.meter == self.Q_(4.2, 2 * self.ureg.meter)
         assert len(caplog.records) == 1
 
+        assert self.Q_("4.2×10⁻¹² ft/s") == self.Q_(4.2e-12, "foot/second")
+
     def test_round(self):
         x = self.Q_(1.1, "kg")
         assert isinstance(round(x).magnitude, int)


### PR DESCRIPTION
- [ ] Closes #2168 
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
