### PR TITLE
Improve MIP issue management (#2188 and #2121)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,8 +25,6 @@ Pint Changelog
 - Fix formatted scientific notation bug in Python 3.13 (#2168)
 - Fix ability to add dB units, and to add dB (dimensionless) to referenced dB units, such as dBm or dBW (#1160)
 - Improve pressure unit definitions in default definition file (#2186)
-- Fix issues with MIP and Dask at the install level (#2188)
-- Skip false xfail tests (#2188)
 - Avoid and document known issues with MIP during install, testing and runtime (#2188 and #2121)
 - Fix issue with Dask by restricting its version to < 2025.3.0 (#2188 and Dask #1016)
 - Skip false xfail tests linked to a known numpy issue (#2188 and #1776)

--- a/CHANGES
+++ b/CHANGES
@@ -25,8 +25,9 @@ Pint Changelog
 - Fix formatted scientific notation bug in Python 3.13 (#2168)
 - Fix ability to add dB units, and to add dB (dimensionless) to referenced dB units, such as dBm or dBW (#1160)
 - Improve pressure unit definitions in default definition file (#2186)
-- Fix issues with MIP and Dask at the install level (#2188)
-- Skip false xfail tests (#2188)
+- Avoid and document known issues with MIP during install, testing and runtime (#2188 and #2121)
+- Fix issue with Dask by restricting its version to < 2025.3.0 (#2188 and Dask #1016)
+- Skip false xfail tests linked to a known numpy issue (#2188 and #1776)
 - Improve `Contributing` documentation (#2188)
 
 

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -76,7 +76,7 @@ Then type::
     $ conda install git
     $ pip install -e ".[test]"
     $ pip install -r requirements_docs.txt
-    $ pip install pre-commit # This step and the next are optional but recommended.
+    $ pip install pre-commit
     $ pre-commit install
 
 All

--- a/pint/facets/plain/qto.py
+++ b/pint/facets/plain/qto.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import bisect
 import math
 import numbers
+import sys
 import warnings
 from typing import TYPE_CHECKING
 
@@ -176,6 +177,8 @@ def to_preferred(
 ) -> PlainQuantity:
     """Return Quantity converted to a unit composed of the preferred units.
 
+    Note: this feature crashes on Python >= 3.12 (issue #2121).
+
     Examples
     --------
 
@@ -186,6 +189,9 @@ def to_preferred(
     >>> (1 * (ureg.force_pound * ureg.m)).to_preferred([ureg.W])
     <Quantity(4.44822162, 'watt * second')>
     """
+
+    if sys.version_info.major == 3 and sys.version_info.minor >= 12:
+        raise Exception("This feature crashes on Python >= 3.12 (issue #2121)")
 
     units = _get_preferred(quantity, preferred_units)
     return quantity.to(units)
@@ -196,6 +202,8 @@ def ito_preferred(
 ) -> PlainQuantity:
     """Return Quantity converted to a unit composed of the preferred units.
 
+    Note: this feature crashes on Python >= 3.12 (issue #2121).
+
     Examples
     --------
 
@@ -206,6 +214,9 @@ def ito_preferred(
     >>> (1 * (ureg.force_pound * ureg.m)).to_preferred([ureg.W])
     <Quantity(4.44822162, 'watt * second')>
     """
+
+    if sys.version_info.major == 3 and sys.version_info.minor >= 12:
+        raise Exception("This feature crashes on Python >= 3.12 (issue #2121)")
 
     units = _get_preferred(quantity, preferred_units)
     return quantity.ito(units)

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -6,6 +6,7 @@ import logging
 import math
 import operator as op
 import pickle
+import sys
 import warnings
 from unittest.mock import patch
 
@@ -385,6 +386,10 @@ class TestQuantity(QuantityTestCase):
         )
 
     @helpers.requires_mip
+    @pytest.mark.skipif(
+        sys.version_info.major == 3 and sys.version_info.minor > 11,
+        reason="Crashes on Python>=3.12 (issue #2121).",
+    )
     def test_to_preferred(self):
         ureg = self.ureg
         Q_ = self.Q_
@@ -423,6 +428,10 @@ class TestQuantity(QuantityTestCase):
         assert result.units == ureg.volts
 
     @helpers.requires_mip
+    @pytest.mark.skipif(
+        sys.version_info.major == 3 and sys.version_info.minor > 11,
+        reason="Crashes on Python>=3.12 (issue #2121).",
+    )
     def test_to_preferred_registry(self):
         ureg = self.ureg
         Q_ = self.Q_
@@ -438,6 +447,10 @@ class TestQuantity(QuantityTestCase):
         assert pressure.units == ureg.Pa
 
     @helpers.requires_mip
+    @pytest.mark.skipif(
+        sys.version_info.major == 3 and sys.version_info.minor > 11,
+        reason="Crashes on Python>=3.12 (issue #2121).",
+    )
     def test_autoconvert_to_preferred(self):
         ureg = self.ureg
         Q_ = self.Q_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,8 @@ pandas = ["pint-pandas >= 0.3"]
 xarray = ["xarray"]
 # Impose Dask < 2025.3.0, otherwise it causes "RuntimeError: Attempting to use an asynchronous Client in a synchronous context of `dask.compute`" (see Issue #1016 in Dask).
 dask = ["dask < 2025.3.0"]
-# Only install mip if Python is less than 3.12, otherwise it causes "Windows fatal exception: access violation" (see Issue #2121).
-mip = ["mip >= 1.13; python_version < '3.12'"]
+# Install of mip crashes from Python 3.13 due to cffi dependency issue (see https://github.com/python-cffi/cffi/issues/48 and https://stackoverflow.com/questions/79463080/building-wheel-for-cffi-fails-when-installing-python-mip)
+mip = ["mip >= 1.13; python_version < '3.13'"]
 matplotlib = ["matplotlib"]
 all = [
   "pint[numpy,uncertainties,babel,pandas,pandas,xarray,dask,mip,matplotlib]",

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,8 +1,8 @@
 sphinx<8
 ipython<=8.12
 matplotlib
-# Only install mip if Python is less than 3.12, otherwise it causes "Windows fatal exception: access violation" (see Issue #2121).
-mip>=1.13; python_version < '3.12'
+# Install of mip crashes from Python 3.13 due to cffi dependency issue (see https://github.com/python-cffi/cffi/issues/48 and https://stackoverflow.com/questions/79463080/building-wheel-for-cffi-fails-when-installing-python-mip)
+mip>=1.13; python_version < '3.13'
 nbsphinx
 numpy
 pytest


### PR DESCRIPTION
I improved the management of known MIP issues (#2188 and #2121):

- Allow MIP installation on Python 3.12 (since this is possible; not on 3.13)
- Skip tests that make the suite crash with MIP on Python 3.12
- Document the known runtime problem with MIP on Python 3.12 in the ´to_preferred()´ docstring

- [ ] Closes # (insert issue number)
- [X] Executed `pre-commit run --all-files` with no errors
- [X] The change is fully covered by automated unit tests
- [X] Documented in docs/ as appropriate
- [X] Added an entry to the CHANGES file
