### PR TITLE
Support numpy.geomspace

### DIFF
--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -903,6 +903,7 @@ for func_str, unit_arguments, wrap_output in (
     ("append", ["arr", "values"], True),
     ("compress", "a", True),
     ("linspace", ["start", "stop"], True),
+    ("geomspace", ["start", "stop"], True),
     ("tile", "A", True),
     ("lib.stride_tricks.sliding_window_view", "x", True),
     ("rot90", "m", True),


### PR DESCRIPTION
- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

This PR adds support for the numpy.geomspace function:

## Explanation:

`numpy.geomspace(start, stop, ...)` generates numbers spaced evenly on a log scale (a geometric progression) between start and stop.
For physical quantities, both start and stop must have compatible units. The output should have the same units as the inputs.
This registration ensures that Pint will automatically convert start and stop to consistent units and wrap the output array with the correct unit.

## Example code
```python
import numpy as np
from pint import UnitRegistry

ureg = UnitRegistry()
start = 1 * ureg.meter
stop = 1 * ureg.kilometer
result = np.geomspace(start, stop, num=4)
print(result)
```
