### PR TITLE
Support more numpy functions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Pint Changelog
 - Fix raising exception in `Quantity.from_tuple` with invalid units (#2199)
 - Add devcontainer.json to add GitHub Codespace support (#2208)
 - Add support for `numpy.geomspace` (#2206)
+- Add support for `linalg.diagonal`, `linalg.matrix_transpose`, `diag`, `tril`, `triu`, `linalg.eigvals`, `linalg.eigvalsh`, `linalg.matrix_norm` and `linalg.vector_norm` (#2210)
 
 
 0.25.0 (2025-08-25)

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -1041,6 +1041,9 @@ for func_str in (
     "nancumsum",
     "linalg.norm",
     "linalg.eigvals",
+    "linalg.eigvalsh",
+    "linalg.matrix_norm",
+    "linalg.vector_norm",
 ):
     implement_func("function", func_str, input_units=None, output_unit="sum")
 for func_str in ("diff", "ediff1d", "std", "nanstd"):

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -415,6 +415,7 @@ matching_input_copy_units_output_ufuncs = [
     "conjugate",
     "copy",
     "diagonal",
+    "linalg.diagonal",
     "max",
     "mean",
     "min",
@@ -1034,10 +1035,12 @@ for func_str in (
 # Handle functions with output unit defined by operation
 for func_str in (
     "sum",
+    "diag",
     "nansum",
     "cumsum",
     "nancumsum",
     "linalg.norm",
+    "linalg.eigvals",
 ):
     implement_func("function", func_str, input_units=None, output_unit="sum")
 for func_str in ("diff", "ediff1d", "std", "nanstd"):

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -284,7 +284,9 @@ def implement_func(func_type, func_str, input_units=None, output_unit=None):
     if func is None:
         return
     for func_str_piece in func_str_split[1:]:
-        func = getattr(func, func_str_piece)
+        func = getattr(func, func_str_piece, None)
+        if func is None:
+            return
 
     @implements(func_str, func_type)
     def implementation(*args, **kwargs):

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -390,7 +390,6 @@ set_units_ufuncs = {
     "exp": ("", ""),
     "expm1": ("", ""),
     "exp2": ("", ""),
-    "vander": ("", ""),
     "log": ("", ""),
     "log10": ("", ""),
     "log1p": ("", ""),
@@ -418,7 +417,6 @@ matching_input_copy_units_output_ufuncs = [
     "conjugate",
     "copy",
     "diagonal",
-    "linalg.diagonal",
     "max",
     "mean",
     "min",
@@ -432,7 +430,6 @@ matching_input_copy_units_output_ufuncs = [
     "take",
     "trace",
     "transpose",
-    "linalg.matrix_transpose",
     "roll",
     "ceil",
     "floor",
@@ -874,6 +871,7 @@ for func_str, unit_arguments, wrap_output in (
     ("moveaxis", "a", True),
     ("around", "a", True),
     ("diagonal", "a", True),
+    ("linalg.diagonal", "x", True),
     ("mean", "a", True),
     ("ptp", "a", True),
     ("ravel", "a", True),
@@ -883,6 +881,7 @@ for func_str, unit_arguments, wrap_output in (
     ("median", "a", True),
     ("nanmedian", "a", True),
     ("transpose", "a", True),
+    ("linalg.matrix_transpose", "x", True),
     ("roll", "a", True),
     ("copy", "a", True),
     ("average", "a", True),
@@ -1056,7 +1055,7 @@ for func_str in ("diff", "ediff1d", "std", "nanstd"):
     implement_func("function", func_str, input_units=None, output_unit="delta")
 for func_str in ("gradient",):
     implement_func("function", func_str, input_units=None, output_unit="delta,div")
-for func_str in ("linalg.solve", "linalg.lstsq"):
+for func_str in ("linalg.solve",):
     implement_func("function", func_str, input_units=None, output_unit="invdiv")
 for func_str in ("var", "nanvar"):
     implement_func("function", func_str, input_units=None, output_unit="variance")

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -1059,8 +1059,6 @@ for func_str in ("linalg.solve",):
     implement_func("function", func_str, input_units=None, output_unit="invdiv")
 for func_str in ("var", "nanvar"):
     implement_func("function", func_str, input_units=None, output_unit="variance")
-for func_str in ("linalg.inv", "linalg.pinv"):
-    implement_func("function", func_str, input_units=None, output_unit="reciprocal")
 
 
 @implements("geomspace", "function")

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -388,6 +388,7 @@ set_units_ufuncs = {
     "exp": ("", ""),
     "expm1": ("", ""),
     "exp2": ("", ""),
+    "vander": ("", ""),
     "log": ("", ""),
     "log10": ("", ""),
     "log1p": ("", ""),
@@ -429,6 +430,7 @@ matching_input_copy_units_output_ufuncs = [
     "take",
     "trace",
     "transpose",
+    "linalg.matrix_transpose",
     "roll",
     "ceil",
     "floor",
@@ -1036,6 +1038,8 @@ for func_str in (
 for func_str in (
     "sum",
     "diag",
+    "tril",
+    "triu",
     "nansum",
     "cumsum",
     "nancumsum",
@@ -1050,10 +1054,12 @@ for func_str in ("diff", "ediff1d", "std", "nanstd"):
     implement_func("function", func_str, input_units=None, output_unit="delta")
 for func_str in ("gradient",):
     implement_func("function", func_str, input_units=None, output_unit="delta,div")
-for func_str in ("linalg.solve",):
+for func_str in ("linalg.solve", "linalg.lstsq"):
     implement_func("function", func_str, input_units=None, output_unit="invdiv")
 for func_str in ("var", "nanvar"):
     implement_func("function", func_str, input_units=None, output_unit="variance")
+for func_str in ("linalg.inv", "linalg.pinv"):
+    implement_func("function", func_str, input_units=None, output_unit="reciprocal")
 
 
 def numpy_wrap(func_type, func, args, kwargs, types):

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -140,6 +140,13 @@ class TestNumpyArrayManipulation(TestNumpyMethods):
         )
 
     @helpers.requires_array_function_protocol()
+    @helpers.requires_numpy_at_least("2.0")
+    def test_linalg_matrix_transpose(self):
+        helpers.assert_quantity_equal(
+            np.linalg.matrix_transpose(self.q), [[1, 3], [2, 4]] * self.ureg.m
+        )
+
+    @helpers.requires_array_function_protocol()
     def test_flip_numpy_func(self):
         helpers.assert_quantity_equal(
             np.flip(self.q, axis=0), [[3, 4], [1, 2]] * self.ureg.m
@@ -566,6 +573,25 @@ class TestNumpyMathematicalFunctions(TestNumpyMethods):
         with pytest.raises(DimensionalityError):
             op.ipow(arr_cp, q_cp)
 
+    # Advanced matrix operations
+    def test_eigvals(self):
+        q = [[2, 1], [1, 2]] * self.ureg.m
+        helpers.assert_quantity_equal(np.linalg.eigvals(q), [3, 1] * self.ureg.m)
+
+    def test_eigvals_offset(self):
+        q = self.Q_([[2, 1], [1, 2]], self.ureg.degC)
+        with pytest.raises(OffsetUnitCalculusError):
+            np.linalg.eigvals(q)
+
+    def test_eigvalsh(self):
+        q = [[5 + 2j, 9 - 2j], [0 + 2j, 2 - 1j]] * self.ureg.m
+        helpers.assert_quantity_equal(np.linalg.eigvalsh(q), [1, 6] * self.ureg.m)
+
+    def test_eigvalsh_offset(self):
+        q = self.Q_([[5 + 2j, 9 - 2j], [0 + 2j, 2 - 1j]], self.ureg.degC)
+        with pytest.raises(OffsetUnitCalculusError):
+            np.linalg.eigvalsh(q)
+
 
 class TestNumpyUnclassified(TestNumpyMethods):
     def test_tolist(self):
@@ -639,6 +665,53 @@ class TestNumpyUnclassified(TestNumpyMethods):
     def test_diagonal_numpy_func(self):
         q = [[1, 2, 3], [1, 2, 3], [1, 2, 3]] * self.ureg.m
         helpers.assert_quantity_equal(np.diagonal(q, offset=-1), [1, 2] * self.ureg.m)
+
+    @helpers.requires_array_function_protocol()
+    @helpers.requires_numpy_at_least("2.0")
+    def test_linalg_diagonal(self):
+        q = [[1, 2, 3], [1, 2, 3], [1, 2, 3]] * self.ureg.m
+        helpers.assert_quantity_equal(
+            np.linalg.diagonal(q, offset=-1), [1, 2] * self.ureg.m
+        )
+
+    @helpers.requires_array_function_protocol()
+    def test_tril(self):
+        q = [[1, 2, 3], [1, 2, 3], [1, 2, 3]] * self.ureg.m
+        helpers.assert_quantity_equal(
+            np.tril(q), [[1, 0, 0], [1, 2, 0], [1, 2, 3]] * self.ureg.m
+        )
+
+    @helpers.requires_array_function_protocol()
+    def test_tril_offset(self):
+        q = self.Q_([[1, 2, 3], [1, 2, 3], [1, 2, 3]], self.ureg.degC)
+        with pytest.raises(OffsetUnitCalculusError):
+            np.tril(q)
+
+    @helpers.requires_array_function_protocol()
+    def test_triu(self):
+        q = [[1, 2, 3], [1, 2, 3], [1, 2, 3]] * self.ureg.m
+        helpers.assert_quantity_equal(
+            np.triu(q), [[1, 2, 3], [0, 2, 3], [0, 0, 3]] * self.ureg.m
+        )
+
+    @helpers.requires_array_function_protocol()
+    def test_triu_offset(self):
+        q = self.Q_([[1, 2, 3], [1, 2, 3], [1, 2, 3]], self.ureg.degC)
+        with pytest.raises(OffsetUnitCalculusError):
+            np.triu(q)
+
+    @helpers.requires_array_function_protocol()
+    def test_diag(self):
+        q = [1, 2, 3] * self.ureg.m
+        helpers.assert_quantity_equal(
+            np.diag(q), [[1, 0, 0], [0, 2, 0], [0, 0, 3]] * self.ureg.m
+        )
+
+    @helpers.requires_array_function_protocol()
+    def test_diag_offset(self):
+        q = self.Q_([1, 2, 3], self.ureg.degC)
+        with pytest.raises(OffsetUnitCalculusError):
+            np.diag(q)
 
     def test_compress(self):
         helpers.assert_quantity_equal(
@@ -1498,6 +1571,18 @@ class TestNumpyUnclassified(TestNumpyMethods):
         q = np.array([[3, 5, 8], [4, 12, 15]]) * self.ureg.m
         expected = [5, 13, 17] * self.ureg.m
         helpers.assert_quantity_equal(np.linalg.norm(q, axis=0), expected)
+
+    @helpers.requires_array_function_protocol()
+    def test_linalg_vector_norm(self):
+        q = np.array([[3, 5, 8], [4, 12, 15]]) * self.ureg.m
+        expected = [5, 13, 17] * self.ureg.m
+        helpers.assert_quantity_equal(np.linalg.vector_norm(q, axis=0), expected)
+
+    @helpers.requires_array_function_protocol()
+    def test_linalg_matrix_norm(self):
+        helpers.assert_quantity_equal(
+            np.linalg.matrix_norm(self.q, ord=1), 6 * self.ureg.m
+        )
 
     @helpers.requires_array_function_protocol()
     def test_geomspace(self):

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -1573,12 +1573,14 @@ class TestNumpyUnclassified(TestNumpyMethods):
         helpers.assert_quantity_equal(np.linalg.norm(q, axis=0), expected)
 
     @helpers.requires_array_function_protocol()
+    @helpers.requires_numpy_at_least("2.0")
     def test_linalg_vector_norm(self):
         q = np.array([[3, 5, 8], [4, 12, 15]]) * self.ureg.m
         expected = [5, 13, 17] * self.ureg.m
         helpers.assert_quantity_equal(np.linalg.vector_norm(q, axis=0), expected)
 
     @helpers.requires_array_function_protocol()
+    @helpers.requires_numpy_at_least("2.0")
     def test_linalg_matrix_norm(self):
         helpers.assert_quantity_equal(
             np.linalg.matrix_norm(self.q, ord=1), 6 * self.ureg.m


### PR DESCRIPTION
- [ ] Closes # (insert issue number)
- [x] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

Support `linalg.diagonal`, `linalg.matrix_transpose`, `diag`, `tril`, `triu`, `linalg.eigvals`, `linalg.eigvalsh`, `linalg.matrix_norm`, `linalg.vector_norm`

For `linalg.diagonal` and `linalg.matrix_transpose`, output has the same unit as input
For `diag`, `tril`, `triu`, `linalg.eigvals`, `linalg.eigvalsh`, `linalg.matrix_norm`, `linalg.vector_norm`, output has the same unit as input, and the unit have to be multiplicative