### PR TITLE
Fix alias for decibelmicrowatt

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -528,7 +528,7 @@ LMH = L / m**2 / h
 
 decibelwatt = watt; logbase: 10; logfactor: 10 = dBW
 decibelmilliwatt = 1e-3 watt; logbase: 10; logfactor: 10 = dBm
-decibelmicrowatt = 1e-6 watt; logbase: 10; logfactor: 10 = dBuW
+decibelmicrowatt = 1e-6 watt; logbase: 10; logfactor: 10 = dBuW = dBµW = dBμW  # NOTE: µ = U+00B5, μ = U+03BC
 
 decibel = 1 ; logbase: 10; logfactor: 10 = dB
 # bell = 1 ; logbase: 10; logfactor: = B

--- a/pint/testsuite/test_log_units.py
+++ b/pint/testsuite/test_log_units.py
@@ -95,6 +95,8 @@ log_unit_names = [
     "dBm",
     "decibelmicrowatt",
     "dBuW",
+    "dBµW",
+    "dBμW",
     "decibel",
     "dB",
     "decade",


### PR DESCRIPTION
dBu is a voltage level not a power level.

0 dBu is defined as the RMS voltage that would
dissipate 0 dBm (1 mW) in a 600 ohm load.

dBuW is an alias which is used for decibelmicrowatt.

References
- (dBu) https://en.wikipedia.org/wiki/Decibel#List_of_suffixes
- (dBuW) https://spectrumcompact.com/uploads/2024/05/Spectrum_Compact_v2_03-43_GHz__User_Manual_v43.pdf