### PR TITLE
Add electronvolt as an alias for electron_volt

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -268,7 +268,7 @@ atomic_unit_of_force = E_h / a_0 = a_u_force
 joule = newton * meter = J
 erg = dyne * centimeter
 watt_hour = watt * hour = Wh = watthour
-electron_volt = e * volt = eV
+electron_volt = e * volt = eV = electronvolt
 rydberg = ℎ * c * R_inf = Ry
 hartree = 2 * rydberg = E_h = Eh = hartree_energy = atomic_unit_of_energy = a_u_energy
 calorie = 4.184 * joule = cal = thermochemical_calorie = cal_th


### PR DESCRIPTION
Note: electronvolt should be the canonical name but changing the canonical name may be a breaking change for some users and so for now I've only added an alias.

References
- https://si-digital-framework.org/SI/units/electronvolt
- https://www.electropedia.org/iev/iev.nsf/display?openform&ievref=113-03-47
- https://en.wikipedia.org/wiki/Electronvolt