### PR TITLE
Fix definition of degree_Reaumur

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -206,7 +206,7 @@ planck_time = (hbar * gravitational_constant / c ** 5) ** 0.5
 degree_Celsius = kelvin; offset: 273.15 = °C = celsius = degC = degreeC
 degree_Rankine = 5 / 9 * kelvin; offset: 0 = °R = rankine = degR = degreeR
 degree_Fahrenheit = 5 / 9 * kelvin; offset: 233.15 + 200 / 9 = °F = fahrenheit = degF = degreeF
-degree_Reaumur = 4 / 5 * kelvin; offset: 273.15 = °Re = reaumur = degRe = degreeRe = degree_Réaumur = réaumur
+degree_Reaumur = 5 / 4 * kelvin; offset: 273.15 = °Re = reaumur = degRe = degreeRe = degree_Réaumur = réaumur
 atomic_unit_of_temperature = E_h / k = a_u_temp
 planck_temperature = (hbar * c ** 5 / gravitational_constant / k ** 2) ** 0.5
 


### PR DESCRIPTION
The previous definition of degree_Reaumur gave the incorrect result 80 °C = 100 °Re instead of 100 °C = 80 °Re.

Reference
- https://en.wikipedia.org/wiki/R%C3%A9aumur_scale