### PR TITLE
Remove alias karat for the unit of mass carat

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -170,7 +170,7 @@ unified_atomic_mass_unit = atomic_mass_constant = u = amu
 dalton = atomic_mass_constant = Da
 grain = 64.79891 * milligram = gr
 gamma_mass = microgram
-carat = 200 * milligram = ct = karat
+carat = 200 * milligram = ct
 planck_mass = (hbar * c / gravitational_constant) ** 0.5
 
 # Time


### PR DESCRIPTION
Karat is a fractional measure of gold purity not a unit of mass.

Reference
- https://en.wikipedia.org/wiki/Carat_(mass)
- https://en.wikipedia.org/wiki/Fineness#Karat
- https://www.merriam-webster.com/grammar/usage-carat-vs-karat