### PR TITLE
Fix alias name for mercury_density_32F constant

### DIFF
--- a/pint/constants_en.txt
+++ b/pint/constants_en.txt
@@ -69,7 +69,7 @@ angstrom_star = 1.00001495e-10 = Å_star                                        
 water_density_4C = 999.972 kg/m^3 = ρH2O_4C				# approximate
 water_density_60F = 999.001 kg/m^3 = ρH2O_60F			# approximate
 mercury_density_0C = 13595.1 kg/m^3 = ρHg_0C			# approximate
-mercury_density_32F = 13595.1 kg/m^3 = ρHg_4C			# approximate
+mercury_density_32F = 13595.1 kg/m^3 = ρHg_32F			# approximate
 mercury_density_60F = 13556.8 kg/m^3 = ρHg_60F			# approximate
 
 #### DERIVED CONSTANTS ####


### PR DESCRIPTION
Changed alias name from ρHg_4C to ρHg_32F.