### PR TITLE
Add alias kn for knot

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -238,7 +238,7 @@ reciprocal_centimeter = 1 / cm = cm_1 = kayser
 # Velocity
 [velocity] = [length] / [time]
 [speed] = [velocity]
-knot = nautical_mile / hour = kt = knot_international = international_knot
+knot = nautical_mile / hour = kt = kn = knot_international = international_knot
 mile_per_hour = mile / hour = mph = MPH
 kilometer_per_hour = kilometer / hour = kph = KPH
 kilometer_per_second = kilometer / second = kps

--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -238,7 +238,7 @@ reciprocal_centimeter = 1 / cm = cm_1 = kayser
 # Velocity
 [velocity] = [length] / [time]
 [speed] = [velocity]
-knot = nautical_mile / hour = kt = kn = knot_international = international_knot
+knot = nautical_mile / hour = kn = kt = knot_international = international_knot
 mile_per_hour = mile / hour = mph = MPH
 kilometer_per_hour = kilometer / hour = kph = KPH
 kilometer_per_second = kilometer / second = kps


### PR DESCRIPTION
The IEEE & ISO 80000 preferred unit symbol for the knot is kn.

Reference
- https://journals.ieeeauthorcenter.ieee.org/wp-content/uploads/sites/7/IEEE-Editorial-Style-Manual-for-Authors.pdf
- https://en.wikipedia.org/wiki/Knot_(unit)