### PR TITLE
Add dimensionless unit strain to the registry

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -148,10 +148,11 @@ byte = 8 * bit = B = octet
 # byte = 8 * bit = _ = octet
 ## NOTE: B (byte) symbol can conflict with Bell
 
-# Ratios
+# Dimensionless ratios
 percent = 0.01 = %
-permille = 0.001 = ‰
+permille = 0.001 = ‰   # NOTE: ‰ = U+2030 (PER MILLE SIGN)
 ppm = 1e-6
+strain = 1 = ε = ϵ     # NOTE: ε = U+03B5 (GREEK SMALL LETTER EPSILON), ϵ = U+03F5 (GREEK LUNATE EPSILON SYMBOL)
 
 # Length
 angstrom = 1e-10 * meter = Å = ångström = Å


### PR DESCRIPTION
Strain is a dimensionless length ratio quantity with units of m/m = 1.

In practice, ε (strain) and µε (microstrain) are commonly used as units of the quantity strain and are equivalent to units of m/m and µm/m.

1 strain = 1 ε = 1 m/m = 1
1 microstrain = 1 µε = 1 µm/m = 1e-6

References
- https://link.springer.com/chapter/10.1007/978-3-662-04732-3_7
- https://www.me-systeme.de/en/support/unit-conversion/strain
- https://en.wikipedia.org/wiki/Strain_(mechanics)

