### PR TITLE
Handle NaN values in registry scale calculations

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ Pint Changelog
 - Add devcontainer.json to add GitHub Codespace support (#2208)
 - Add support for `numpy.geomspace` (#2206)
 - Add support for `linalg.diagonal`, `linalg.matrix_transpose`, `diag`, `tril`, `triu`, `linalg.eigvals`, `linalg.eigvalsh`, `linalg.matrix_norm` and `linalg.vector_norm` (#2210)
+- Fixed `nan`/`nan` to return `nan` rather than 1 in unit conversion (#2228)
 
 
 0.25.0 (2025-08-25)

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -33,6 +33,7 @@ from collections import defaultdict
 from collections.abc import Callable, Generator, Iterable, Iterator
 from decimal import Decimal
 from fractions import Fraction
+from math import isnan
 from token import NAME, NUMBER
 from tokenize import TokenInfo
 from typing import (
@@ -909,7 +910,10 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
         # Identify if terms appear in both numerator and denominator
         def terms_are_unique(fraction):
             for n_factor, n_exp in fraction["numerator"].items():
-                if n_factor in fraction["denominator"]:
+                if isnan(n_factor):
+                    # Ignore nans so that they correctly resolve in the factor calculations
+                    continue
+                elif n_factor in fraction["denominator"]:
                     return False
             return True
 
@@ -917,7 +921,10 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
         while not terms_are_unique(fraction):
             for n_factor, n_exponent in fraction["numerator"].items():
                 if n_factor in fraction["denominator"]:
-                    if n_exponent >= fraction["denominator"][n_factor]:
+                    if isnan(n_factor):
+                        # Ignore nans so that they correctly resolve in the factor calculations
+                        continue
+                    elif n_exponent >= fraction["denominator"][n_factor]:
                         fraction["numerator"][n_factor] -= fraction["denominator"][
                             n_factor
                         ]
@@ -925,6 +932,9 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
                         continue
             for d_factor, d_exponent in fraction["denominator"].items():
                 if d_factor in fraction["numerator"]:
+                    if isnan(d_factor):
+                        # ignore nans so that they correctly resolve in the factor calculations
+                        continue
                     if d_exponent >= fraction["numerator"][d_factor]:
                         fraction["denominator"][d_factor] -= fraction["numerator"][
                             d_factor

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1375,3 +1375,20 @@ def test_issue2199(func_registry):
     msg = "is not defined in the unit registry"
     with pytest.raises(UndefinedUnitError, match=msg):
         func_registry.Quantity.from_tuple((1, (("wrong", 1),)))
+
+
+def test_issue2228(func_registry):
+    func_registry.define("test2228A = nan meter")
+    func_registry.define("test2228B = nan meter")
+    # Behaviour before 2228 was fixed
+    nan_factor, _ = func_registry._get_root_units(
+        UnitsContainer({"test2228A": 1, "test2228B": -1})
+    )
+    assert nan_factor != 1
+    # Expected behaviour - return nan
+    assert math.isnan(nan_factor)
+
+    ok_factor, _ = func_registry._get_root_units(
+        UnitsContainer({"meter": 1, "centimeter": -1})
+    )
+    assert ok_factor == 100.0


### PR DESCRIPTION
Fix for https://github.com/hgrecco/pint/issues/2228

Adds a check if the scale factor is nan, and does not cancel `nan/nan` to 0.

- [x] Closes #2228 
- [x] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate _(not documented)_
- [x] Added an entry to the CHANGES file
