### PR TITLE
Allow pint.registry.Quantity to be used as a generic class

### DIFF
--- a/pint/facets/context/registry.py
+++ b/pint/facets/context/registry.py
@@ -427,7 +427,7 @@ class GenericContextRegistry(
 
 
 class ContextRegistry(
-    GenericContextRegistry[objects.ContextQuantity[Any], objects.ContextUnit]
+    GenericContextRegistry[objects.ContextQuantity, objects.ContextUnit]
 ):
-    Quantity: TypeAlias = objects.ContextQuantity[Any]
+    Quantity: TypeAlias = objects.ContextQuantity
     Unit: TypeAlias = objects.ContextUnit

--- a/pint/facets/dask/__init__.py
+++ b/pint/facets/dask/__init__.py
@@ -136,6 +136,6 @@ class GenericDaskRegistry(
     pass
 
 
-class DaskRegistry(GenericDaskRegistry[DaskQuantity[Any], DaskUnit]):
-    Quantity: TypeAlias = DaskQuantity[Any]
+class DaskRegistry(GenericDaskRegistry[DaskQuantity, DaskUnit]):
+    Quantity: TypeAlias = DaskQuantity
     Unit: TypeAlias = DaskUnit

--- a/pint/facets/measurement/registry.py
+++ b/pint/facets/measurement/registry.py
@@ -39,8 +39,8 @@ class GenericMeasurementRegistry(
 
 class MeasurementRegistry(
     GenericMeasurementRegistry[
-        objects.MeasurementQuantity[Any], objects.MeasurementUnit
+        objects.MeasurementQuantity, objects.MeasurementUnit
     ]
 ):
-    Quantity: TypeAlias = objects.MeasurementQuantity[Any]
+    Quantity: TypeAlias = objects.MeasurementQuantity
     Unit: TypeAlias = objects.MeasurementUnit

--- a/pint/facets/nonmultiplicative/registry.py
+++ b/pint/facets/nonmultiplicative/registry.py
@@ -302,8 +302,8 @@ class GenericNonMultiplicativeRegistry(
 
 class NonMultiplicativeRegistry(
     GenericNonMultiplicativeRegistry[
-        objects.NonMultiplicativeQuantity[Any], objects.NonMultiplicativeUnit
+        objects.NonMultiplicativeQuantity, objects.NonMultiplicativeUnit
     ]
 ):
-    Quantity: TypeAlias = objects.NonMultiplicativeQuantity[Any]
+    Quantity: TypeAlias = objects.NonMultiplicativeQuantity
     Unit: TypeAlias = objects.NonMultiplicativeUnit

--- a/pint/facets/numpy/registry.py
+++ b/pint/facets/numpy/registry.py
@@ -22,6 +22,6 @@ class GenericNumpyRegistry(
     pass
 
 
-class NumpyRegistry(GenericPlainRegistry[NumpyQuantity[Any], NumpyUnit]):
-    Quantity: TypeAlias = NumpyQuantity[Any]
+class NumpyRegistry(GenericPlainRegistry[NumpyQuantity, NumpyUnit]):
+    Quantity: TypeAlias = NumpyQuantity
     Unit: TypeAlias = NumpyUnit

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -160,7 +160,7 @@ class RegistryMeta(type):
 
 
 # Generic types used to mark types associated to Registries.
-QuantityT = TypeVar("QuantityT", bound=PlainQuantity[Any])
+QuantityT = TypeVar("QuantityT", bound=PlainQuantity)
 UnitT = TypeVar("UnitT", bound=PlainUnit)
 
 
@@ -1476,6 +1476,6 @@ class GenericPlainRegistry(Generic[QuantityT, UnitT], metaclass=RegistryMeta):
     __call__ = parse_expression
 
 
-class PlainRegistry(GenericPlainRegistry[PlainQuantity[Any], PlainUnit]):
-    Quantity: TypeAlias = PlainQuantity[Any]
+class PlainRegistry(GenericPlainRegistry[PlainQuantity, PlainUnit]):
+    Quantity: TypeAlias = PlainQuantity
     Unit: TypeAlias = PlainUnit

--- a/pint/facets/system/registry.py
+++ b/pint/facets/system/registry.py
@@ -259,7 +259,7 @@ class GenericSystemRegistry(
 
 
 class SystemRegistry(
-    GenericSystemRegistry[objects.SystemQuantity[Any], objects.SystemUnit]
+    GenericSystemRegistry[objects.SystemQuantity, objects.SystemUnit]
 ):
-    Quantity: TypeAlias = objects.SystemQuantity[Any]
+    Quantity: TypeAlias = objects.SystemQuantity
     Unit: TypeAlias = objects.SystemUnit

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -26,13 +26,14 @@ from .util import logger, pi_theorem
 
 
 class Quantity(
-    facets.SystemRegistry.Quantity,
-    facets.ContextRegistry.Quantity,
-    facets.DaskRegistry.Quantity,
-    facets.NumpyRegistry.Quantity,
-    facets.MeasurementRegistry.Quantity,
-    facets.NonMultiplicativeRegistry.Quantity,
-    facets.PlainRegistry.Quantity,
+    Generic[facets.MagnitudeT],
+    facets.SystemRegistry.Quantity[facets.MagnitudeT],
+    facets.ContextRegistry.Quantity[facets.MagnitudeT],
+    facets.DaskRegistry.Quantity[facets.MagnitudeT],
+    facets.NumpyRegistry.Quantity[facets.MagnitudeT],
+    facets.MeasurementRegistry.Quantity[facets.MagnitudeT],
+    facets.NonMultiplicativeRegistry.Quantity[facets.MagnitudeT],
+    facets.PlainRegistry.Quantity[facets.MagnitudeT],
 ):
     pass
 

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -2062,3 +2062,9 @@ class TestCompareNeutral(QuantityTestCase):
         assert isinstance(quantity.m, float)
 
         assert isinstance(self.ureg.m, self.ureg.Unit)
+
+
+class TestGenericQuantityTyping:
+    def test_generic_type_use(self):
+        from pint import Quantity
+        _ = Quantity[int]


### PR DESCRIPTION
- [x] Closes #1770
- [ ] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
