### PR TITLE
Add `complex` to the union of the `Scalar` alias

### DIFF
--- a/pint/_typing.py
+++ b/pint/_typing.py
@@ -19,10 +19,10 @@ if TYPE_CHECKING:
 if HAS_NUMPY:
     from .compat import np
 
-    Scalar: TypeAlias = Union[float, int, Decimal, Fraction, np.number[Any]]
+    Scalar: TypeAlias = Union[complex, float, int, Decimal, Fraction, np.number[Any]]
     Array = np.ndarray[Any, Any]
 else:
-    Scalar: TypeAlias = Union[float, int, Decimal, Fraction]
+    Scalar: TypeAlias = Union[complex, float, int, Decimal, Fraction]
     Array: TypeAlias = Never
 
 # TODO: Change when Python 3.10 becomes minimal version.


### PR DESCRIPTION
- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

`complex` is a valid scalar type but it is not included in the scalar types union. This causes pyright to show errors on quantities with complex magnitudes. This PR adds `complex` to the union of scalars used in the upper bound of the magnitude type variable of quantities.