### PR TITLE
Change return type of from_list, from_sequence to PlainQuantity[Array[MagnitudeT]]

### DIFF
--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -34,7 +34,7 @@ from ...compat import (
     np,
     zero_or_nan,
 )
-from ...errors import DimensionalityError, OffsetUnitCalculusError, PintTypeError
+from ...errors import Array, DimensionalityError, OffsetUnitCalculusError, PintTypeError
 from ...util import (
     PrettyIPython,
     SharedRegistryObject,
@@ -360,7 +360,7 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
     @classmethod
     def from_list(
         cls, quant_list: list[PlainQuantity[MagnitudeT]], units=None
-    ) -> PlainQuantity[MagnitudeT]:
+    ) -> PlainQuantity[Array[MagnitudeT]]:
         """Transforms a list of Quantities into an numpy.array quantity.
         If no units are specified, the unit of the first element will be used.
         Same as from_sequence.
@@ -384,7 +384,7 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
     @classmethod
     def from_sequence(
         cls, seq: Sequence[PlainQuantity[MagnitudeT]], units=None
-    ) -> PlainQuantity[MagnitudeT]:
+    ) -> PlainQuantity[Array[MagnitudeT]]:
         """Transforms a sequence of Quantities into an numpy.array quantity.
         If no units are specified, the unit of the first element will be used.
 

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -22,7 +22,7 @@ from typing import (
     overload,
 )
 
-from ..._typing import Magnitude, QuantityOrUnitLike, Scalar, UnitLike
+from ..._typing import Array, Magnitude, QuantityOrUnitLike, Scalar, UnitLike
 from ...compat import (
     HAS_NUMPY,
     Self,
@@ -34,7 +34,7 @@ from ...compat import (
     np,
     zero_or_nan,
 )
-from ...errors import Array, DimensionalityError, OffsetUnitCalculusError, PintTypeError
+from ...errors import DimensionalityError, OffsetUnitCalculusError, PintTypeError
 from ...util import (
     PrettyIPython,
     SharedRegistryObject,


### PR DESCRIPTION
Updated return type of from_list and from_sequence methods to support numpy arrays.

- [x] Closes #2257 
- [ ] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
