### PR TITLE
feat: Add Noether (Nn) as a unit of momentum

### DIFF
--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -300,6 +300,8 @@ conventional_watt_90 = K_J90 ** 2 * R_K90 / (K_J ** 2 * R_K) * watt = W_90
 
 # Momentum
 [momentum] = [length] * [mass] / [time]
+# Proposed unit of momentum, in honor of Emmy Noether's theorem linking symmetry and conservation laws.
+noether = kilogram * meter / second = Nn
 
 # Density
 [density] = [mass] / [volume]

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -801,6 +801,25 @@ class TestQuantity(QuantityTestCase):
         q = self.Q_(1, unit_str)
         assert q._units == UnitsContainer(expected_unit)
 
+    def test_noether_unit_conversion(self):
+        """Test the conversion of the new Noether unit for momentum."""
+        # Test forward conversion from Nn to base SI units
+        q_nn = self.ureg.Quantity(1, "Nn")
+        q_si = q_nn.to("kilogram * meter / second")
+        assert q_si.magnitude == 1
+        assert q_si.units == self.ureg.Unit("kilogram * meter / second")
+
+        # Test reverse conversion from base SI units to Nn
+        q_si_rev = self.ureg.Quantity(1, "kilogram * meter / second")
+        q_nn_rev = q_si_rev.to("Nn")
+        assert q_nn_rev.magnitude == 1
+        assert q_nn_rev.units == self.ureg.Unit("Nn")
+
+        # Test with a different magnitude
+        q_nn_10 = self.ureg.Quantity(10, "Nn")
+        q_si_10 = q_nn_10.to("kg*m/s")
+        assert q_si_10.magnitude == 10
+
 
 # TODO: do not subclass from QuantityTestCase
 class TestQuantityToCompact(QuantityTestCase):


### PR DESCRIPTION
This pull request introduces the 'Noether' (symbol: Nn) as a named unit for momentum, defined as 1 kg·m/s.

This proposal is formally discussed and advocated for in the American Journal of Physics article: 'It is time to honor Emmy Noether with a momentum unit' (https://pubs.aip.org/aapt/ajp/article/92/9/647/3309134/It-is-time-to-honor-Emmy-Noether-with-a-momentum). This gives the initiative strong academic backing.

- The unit 'noether = kilogram * meter / second = Nn' has been added to 'pint/default_en.txt'.
- A corresponding test case, 'test_noether_unit_conversion', has been added to 'pint/testsuite/test_quantity.py' to ensure the conversion works as expected.

This PR is meant as a grassroots initiative to get the unit more widely accepted. And also to settle on `Nn`. Both SciPy and Astropy refer to the SI and CODATA datasets, while the SI and official datasets won't include new units that are not widely used, presenting us with a catch-22.