### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -30,3 +30,4 @@ jobs:
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: pytest . --codspeed
+          mode: walltime

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,8 +14,8 @@ jobs:
   benchmarks:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
 
@@ -26,7 +26,7 @@ jobs:
         run: pip install .[codspeed]
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v2
+        uses: CodSpeedHQ/action@v4.11.1
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: pytest . --codspeed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.8.10
+      - uses: actions/checkout@v6.0.2
+      - uses: prefix-dev/setup-pixi@v0.9.4
         with:
           environments: lint
       - run: pixi run --environment lint lint --all-files --show-diff-on-failure
@@ -36,8 +36,8 @@ jobs:
             uncertainties: null
             extras: "babel==2.15 matplotlib==3.9.0"
     steps:
-      - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.8.10
+      - uses: actions/checkout@v6.0.2
+      - uses: prefix-dev/setup-pixi@v0.9.4
         with:
           environments: ${{ matrix.environment }}
           log-level: vvv
@@ -82,8 +82,8 @@ jobs:
           - test-py313
         numpy: [null, "numpy>=1.25,<2.0.0", "numpy>=2.0.0rc1"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.8.10
+      - uses: actions/checkout@v6.0.2
+      - uses: prefix-dev/setup-pixi@v0.9.4
         with:
           environments: ${{ matrix.environment }}
           log-level: vvv
@@ -102,8 +102,8 @@ jobs:
           - test-py313
         numpy: [null, "numpy>=1.25,<2.0.0", "numpy>=2.0.0rc1"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.8.10
+      - uses: actions/checkout@v6.0.2
+      - uses: prefix-dev/setup-pixi@v0.9.4
         with:
           environments: ${{ matrix.environment }}
           log-level: vvv
@@ -124,8 +124,8 @@ jobs:
       id-token: write  # for trusted publising to PyPI
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.8.10
+      - uses: actions/checkout@v6.0.2
+      - uses: prefix-dev/setup-pixi@v0.9.4
         with:
           environments: build
       - name: Build the package

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,16 +6,16 @@ jobs:
   docbuild:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.8.10
+      - uses: actions/checkout@v6.0.2
+      - uses: prefix-dev/setup-pixi@v0.9.4
         with:
           environments: docs
       - run: pixi run --environment docs docbuild
   doctest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.8.10
+      - uses: actions/checkout@v6.0.2
+      - uses: prefix-dev/setup-pixi@v0.9.4
         with:
           environments: docs
       - name: Install locales

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,12 @@
 Pint Changelog
 ==============
 
-0.25.3 (unreleased)
+0.26.0 (unreleased)
+-------------------
+
+- Nothing yet.
+
+0.25.3 (2026-03-19)
 -----------------
 
 - `GenericPlainRegistry.parse_expression` now correctly returns a dimensionless Quantity when taking a float, int, or NaN (#2259)


### PR DESCRIPTION
## Summary

- `actions/checkout`: v4 → v6.0.2
- `actions/setup-python`: v3 → v6.2.0
- `prefix-dev/setup-pixi`: v0.8.10 → v0.9.4
- `CodSpeedHQ/action`: v2 → v4.11.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)