### PR TITLE
Fix regression #2290

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Pint Changelog
 
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)
 - Bump minimum numpy version to 2.0.0
+- Fix regression when using magnitude format specs in string formats (#2291)
 
 0.25.3 (2026-03-19)
 -----------------

--- a/pint/delegates/formatter/full.py
+++ b/pint/delegates/formatter/full.py
@@ -104,9 +104,10 @@ class FullFormatter(BaseFormatter):
             if k in spec:
                 return v
 
-        clean_spec = re.sub(r"\~|\^", "", spec)
-        if clean_spec in REGISTERED_FORMATTERS:
-            orphan_fmt = REGISTERED_FORMATTERS[clean_spec]
+        for k, v in REGISTERED_FORMATTERS.items():
+            if k in spec:
+                orphan_fmt = REGISTERED_FORMATTERS[k]
+                break
         else:
             return self._formatters["D"]
 

--- a/pint/delegates/formatter/full.py
+++ b/pint/delegates/formatter/full.py
@@ -12,7 +12,6 @@ Implements:
 from __future__ import annotations
 
 import locale
-import re
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Literal
 

--- a/pint/testsuite/test_formatting.py
+++ b/pint/testsuite/test_formatting.py
@@ -64,6 +64,7 @@ def test_register_unit_format(func_registry):
         return "<formatted unit>"
 
     quantity = 1.0 * func_registry.meter
+    assert f"{quantity:g#~custom}" == "1 <formatted unit>"
     assert f"{quantity:custom}" == "1.0 <formatted unit>"
 
     with pytest.raises(ValueError, match="format 'custom' already exists"):

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1276,7 +1276,7 @@ def test_issue2017():
 
     from pint import formatting as fmt
 
-    @fmt.register_unit_format("test")
+    @fmt.register_unit_format("test2017")
     def _test_format(unit, registry, **options):
         proc = {u.replace("µ", "u"): e for u, e in unit.items()}
         return fmt.formatter(
@@ -1291,8 +1291,8 @@ def test_issue2017():
         )
 
     base_unit = ureg.microsecond
-    assert f"{base_unit:~test}" == "us"
-    assert f"{base_unit:test}" == "microsecond"
+    assert f"{base_unit:~test2017}" == "us"
+    assert f"{base_unit:test2017}" == "microsecond"
 
 
 def test_issue2007():


### PR DESCRIPTION
Reverts a small change introduced in #2268: The hardcoded list of modifiers is too restrictive and does not capture magnitude modifiers.

- [x] Closes #2290
- [x] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
  --> Already documented in user/formatting under "Magnitude modifiers"
- [x] Added an entry to the CHANGES file
