### PR TITLE
Fix Unit.__eq__ with strings by parsing via registry

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Pint Changelog
 
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)
 - Bump minimum numpy version to 2.0.0
+- Fix `Unit.__eq__` when comparing with strings using unit aliases (e.g. `Unit('metre') == 'meter'`) (#634)
 
 0.25.3 (2026-03-19)
 -----------------

--- a/pint/facets/plain/unit.py
+++ b/pint/facets/plain/unit.py
@@ -195,6 +195,12 @@ class PlainUnit(PrettyIPython, SharedRegistryObject):
     def __eq__(self, other) -> bool:
         # We compare to the plain class of PlainUnit because each PlainUnit class is
         # unique.
+        if isinstance(other, str):
+            try:
+                other = self._REGISTRY.Unit(other)
+            except Exception:
+                return False
+
         if self._check(other):
             if isinstance(other, self.__class__):
                 return self._units == other._units

--- a/pint/facets/plain/unit.py
+++ b/pint/facets/plain/unit.py
@@ -196,6 +196,8 @@ class PlainUnit(PrettyIPython, SharedRegistryObject):
         # We compare to the plain class of PlainUnit because each PlainUnit class is
         # unique.
         if isinstance(other, str):
+            if str(self) == other:
+                return True
             try:
                 other = self._REGISTRY.Unit(other)
             except Exception:

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -252,6 +252,22 @@ class TestUnit(QuantityTestCase):
         assert self.U_("byte") == self.U_("byte")
         assert not (self.U_("byte") != self.U_("byte"))
 
+    @pytest.mark.parametrize(
+        ("unit", "string", "expected"),
+        [
+            ("meter", "meter", True),
+            ("meter", "m", True),
+            ("m", "meter", True),
+            ("dimensionless", "dimensionless", True),
+            ("", "dimensionless", True),
+            ("meter", "second", False),
+            ("meter", "not_a_unit_xyz", False),
+        ],
+    )
+    def test_unit_eq_string(self, unit, string, expected):
+        # gh-634: Unit equality with strings, including dimensionless
+        assert (self.U_(unit) == string) is expected
+
     def test_unit_cmp(self):
         x = self.U_("m")
         assert x < self.U_("km")

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -262,6 +262,8 @@ class TestUnit(QuantityTestCase):
             ("", "dimensionless", True),
             ("meter", "second", False),
             ("meter", "not_a_unit_xyz", False),
+            ("metre", "meter", True),
+            ("metre", "metre", True),
         ],
     )
     def test_unit_eq_string(self, unit, string, expected):


### PR DESCRIPTION
Fixes #634.

## Summary

- In `Unit.__eq__`, when `other` is a `str`, parse it into a `Unit` via the registry before comparing (option 2 from the issue discussion).
- This fixes `Unit('dimensionless') == 'dimensionless'` returning `False`, and as a bonus also handles alternate spellings and abbreviated forms (`Unit('meter') == 'm'`, `Unit('m') == 'meter'`, etc.).
- Invalid strings return `False`.

## Test plan

- Added `test_unit_eq_string` as a parametrized test covering canonical names, abbreviated forms, `dimensionless`, mismatched units, and invalid strings.
- All existing `test_unit.py` tests pass (132 passed, 5 skipped).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)