### PR TITLE
Updating `repr` for various objects

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Pint Changelog
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)
 - Bump minimum numpy version to 2.0.0
 - Fix regression when using magnitude format specs in string formats (#2291)
+- Updated repr for various objects so that eval(repr(...))) works (#1495)
 
 0.25.3 (2026-03-19)
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ It is extremely easy and natural to use:
     >>> import pint
     >>> ureg = pint.UnitRegistry()
     >>> 3 * ureg.meter + 4 * ureg.cm
-    <Quantity(3.04, 'meter')>
+    Quantity(3.04, "meter")
 
 and you can make good use of numpy if you want:
 
@@ -66,9 +66,9 @@ and you can make good use of numpy if you want:
 
     >>> import numpy as np
     >>> [3, 4] * ureg.meter + [4, 3] * ureg.cm
-    <Quantity([ 3.04  4.03], 'meter')>
+    Quantity([ 3.04  4.03], "meter")
     >>> np.sum(_)
-    <Quantity(7.07, 'meter')>
+    Quantity(7.07, "meter")
 
 
 Quick Installation

--- a/docs/advanced/serialization.rst
+++ b/docs/advanced/serialization.rst
@@ -14,7 +14,7 @@ The easiest way to do this is by converting the quantity to a string:
    >>> ureg = pint.UnitRegistry()
    >>> duration = 24.2 * ureg.years
    >>> duration
-   <Quantity(24.2, 'year')>
+   Quantity(24.2, "year")
    >>> serialized = str(duration)
    >>> print(serialized)
    24.2 year
@@ -83,7 +83,7 @@ To unpickle, just
 
     >>> loaded = pickle.loads(serialized)
     >>> ureg.Quantity.from_tuple(loaded)
-    <Quantity(24.2, 'year')>
+    Quantity(24.2, "year")
 
 (To pickle to and from a file just use the dump and load method as described in _Pickle)
 

--- a/docs/advanced/wrapping.rst
+++ b/docs/advanced/wrapping.rst
@@ -56,7 +56,7 @@ and:
 .. doctest::
 
     >>> mypp_caveman(100 * ureg.centimeter)
-    <Quantity(2.00640929, 'second')>
+    Quantity(2.0064092925890407, "second")
 
 Pint provides a more convenient way to do this:
 
@@ -72,7 +72,7 @@ Or in the decorator format:
     ... def mypp(length):
     ...     return pendulum_period(length)
     >>> mypp(100 * ureg.centimeter)
-    <Quantity(2.00640929, 'second')>
+    Quantity(2.0064092925890407, "second")
 
 
 `wraps` takes 3 input arguments:
@@ -95,7 +95,7 @@ the input arguments assigned to units must be a Quantities.
 .. doctest::
 
     >>> mypp(1. * ureg.meter)
-    <Quantity(2.00640929, 'second')>
+    Quantity(2.0064092925890407, "second")
     >>> mypp(1.)
     Traceback (most recent call last):
     ...
@@ -107,9 +107,9 @@ To enable using non-Quantity numerical values, set strict to False`.
 
     >>> mypp_ns = ureg.wraps(ureg.second, ureg.meter, False)(pendulum_period)
     >>> mypp_ns(1. * ureg.meter)
-    <Quantity(2.00640929, 'second')>
+    Quantity(2.0064092925890407, "second")
     >>> mypp_ns(1.)
-    <Quantity(2.00640929, 'second')>
+    Quantity(2.0064092925890407, "second")
 
 In this mode, the value is assumed to have the correct units.
 
@@ -176,10 +176,10 @@ arguments:
     >>> lunar_module_height = Q_(22, 'feet') + Q_(11, 'inches')
     >>> calculate_time_to_fall(lunar_module_height, verbose=True)
     1.1939473204801092 seconds to fall
-    <Quantity(1.19394732, 'second')>
+    Quantity(1.1939473204801092, "second")
     >>> moon_gravity = Q_(1.625, 'm/s^2')
     >>> calculate_time_to_fall(lunar_module_height, gravity=moon_gravity)
-    <Quantity(2.932051, 'second')>
+    Quantity(2.932051001760214, "second")
 
 
 Specifying relations between arguments
@@ -216,9 +216,9 @@ With optional arguments
     ...     return time * rate
     ...
     >>> get_displacement(Q_(2, 's'))
-    <Quantity(2, 'meter')>
+    Quantity(2, "meter")
     >>> get_displacement(Q_(2, 's'), Q_(1, 'deg/s'))
-    <Quantity(2, 'degree')>
+    Quantity(2, "degree")
 
 
 Ignoring an argument or return value

--- a/docs/getting/overview.rst
+++ b/docs/getting/overview.rst
@@ -24,7 +24,7 @@ It is extremely easy and natural to use:
     >>> import pint
     >>> ureg = pint.UnitRegistry()
     >>> 3 * ureg.meter + 4 * ureg.cm
-    <Quantity(3.04, 'meter')>
+    Quantity(3.04, "meter")
 
 and you can make good use of numpy if you want:
 
@@ -32,9 +32,9 @@ and you can make good use of numpy if you want:
 
     >>> import numpy as np
     >>> [3, 4] * ureg.meter + [4, 3] * ureg.cm
-    <Quantity([ 3.04  4.03], 'meter')>
+    Quantity([ 3.04  4.03], "meter")
     >>> np.sum(_)
-    <Quantity(7.07, 'meter')>
+    Quantity(7.07, "meter")
 
 See the :ref:`Tutorial` for more help getting started.
 

--- a/docs/getting/tutorial.rst
+++ b/docs/getting/tutorial.rst
@@ -319,7 +319,7 @@ Pint's physical quantities can be easily printed:
    The str is 1.3 meter / second ** 2
    >>> # The standard representation formatting code
    >>> print('The repr is {!r}'.format(accel))
-   The repr is <Quantity(1.3, 'meter / second ** 2')>
+   The repr is Quantity(1.3, "meter / second ** 2")
    >>> # Accessing useful attributes
    >>> print('The magnitude is {0.magnitude} with units {0.units}'.format(accel))
    The magnitude is 1.3 with units meter / second ** 2

--- a/docs/getting/tutorial.rst
+++ b/docs/getting/tutorial.rst
@@ -29,7 +29,7 @@ Once you've initialized your ``UnitRegistry``, you can define quantities easily:
 
    >>> distance = 24.0 * ureg.meter
    >>> distance
-   <Quantity(24.0, 'meter')>
+   Quantity(24.0, "meter")
    >>> print(distance)
    24.0 meter
 
@@ -42,7 +42,7 @@ magnitude, units, and dimensionality:
    >>> distance.magnitude
    24.0
    >>> distance.units
-   <Unit('meter')>
+   Unit("meter")
    >>> print(distance.dimensionality)
    [length]
 
@@ -56,7 +56,7 @@ and can correctly handle many mathematical operations, including with other
    8.0 second
    >>> speed = distance / time
    >>> speed
-   <Quantity(3.0, 'meter / second')>
+   Quantity(3.0, "meter / second")
    >>> print(speed)
    3.0 meter / second
    >>> print(speed.dimensionality)
@@ -101,11 +101,11 @@ the ``to()`` method, which accepts a string or a :class:`Unit() <pint.unit.Unit>
 .. doctest::
 
    >>> speed.to('inch/minute')
-   <Quantity(7086.61417, 'inch / minute')>
+   Quantity(7086.614173228347, "inch / minute")
    >>> ureg.inch / ureg.minute
-   <Unit('inch / minute')>
+   Unit("inch / minute")
    >>> speed.to(ureg.inch / ureg.minute)
-   <Quantity(7086.61417, 'inch / minute')>
+   Quantity(7086.614173228347, "inch / minute")
 
 This method returns a new object leaving the original intact as can be seen by:
 
@@ -121,7 +121,7 @@ use the ``ito()`` method:
 
    >>> speed.ito(ureg.inch / ureg.minute)
    >>> speed
-   <Quantity(7086.61417, 'inch / minute')>
+   Quantity(7086.614173228347, "inch / minute")
    >>> print(speed)
    7086.6141... inch / minute
 
@@ -234,7 +234,7 @@ many cases, units can be defined as strings:
 .. doctest::
 
    >>> 2.54 * ureg('centimeter')
-   <Quantity(2.54, 'centimeter')>
+   Quantity(2.54, "centimeter")
 
 or using the ``Quantity`` constructor:
 
@@ -242,23 +242,23 @@ or using the ``Quantity`` constructor:
 
    >>> Q_ = ureg.Quantity
    >>> Q_(2.54, 'centimeter')
-   <Quantity(2.54, 'centimeter')>
+   Quantity(2.54, "centimeter")
 
 Numbers are also parsed, so you can use an expression:
 
 .. doctest::
 
    >>> ureg('2.54 * centimeter')
-   <Quantity(2.54, 'centimeter')>
+   Quantity(2.54, "centimeter")
    >>> Q_('2.54 * centimeter')
-   <Quantity(2.54, 'centimeter')>
+   Quantity(2.54, "centimeter")
 
 or leave out the `*` altogether:
 
 .. doctest::
 
    >>> Q_('2.54cm')
-   <Quantity(2.54, 'centimeter')>
+   Quantity(2.54, "centimeter")
 
 This enables you to build a simple unit converter in 3 lines:
 
@@ -267,7 +267,7 @@ This enables you to build a simple unit converter in 3 lines:
    >>> user_input = '2.54 * centimeter to inch'
    >>> src, dst = user_input.split(' to ')
    >>> Q_(src).to(dst)
-   <Quantity(1.0, 'inch')>
+   Quantity(1.0, "inch")
 
 Strings containing values can be parsed using the ``ureg.parse_pattern()`` function.
 A ``format``-like string with the units defined in it is used as the pattern:
@@ -277,7 +277,7 @@ A ``format``-like string with the units defined in it is used as the pattern:
    >>> input_string = '10 feet 10 inches'
    >>> pattern = '{feet} feet {inch} inches'
    >>> ureg.parse_pattern(input_string, pattern)
-   [<Quantity(10.0, 'foot')>, <Quantity(10.0, 'inch')>]
+   [Quantity(10.0, "foot"), Quantity(10.0, "inch")]
 
 To search for multiple matches, set the ``many`` parameter to ``True``. The following
 example also demonstrates how the parser is able to find matches in amongst filler characters:
@@ -287,7 +287,7 @@ example also demonstrates how the parser is able to find matches in amongst fill
    >>> input_string = '10 feet - 20 feet ! 30 feet.'
    >>> pattern = '{feet} feet'
    >>> ureg.parse_pattern(input_string, pattern, many=True)
-   [[<Quantity(10.0, 'foot')>], [<Quantity(20.0, 'foot')>], [<Quantity(30.0, 'foot')>]]
+   [[Quantity(10.0, "foot")], [Quantity(20.0, "foot")], [Quantity(30.0, "foot")]]
 
 The full power of regex can also be employed when writing patterns:
 
@@ -296,7 +296,7 @@ The full power of regex can also be employed when writing patterns:
    >>> input_string = "10` - 20 feet ! 30 ft."
    >>> pattern = r"{feet}(`| feet| ft)"
    >>> ureg.parse_pattern(input_string, pattern, many=True)
-   [[<Quantity(10.0, 'foot')>], [<Quantity(20.0, 'foot')>], [<Quantity(30.0, 'foot')>]]
+   [[Quantity(10.0, "foot")], [Quantity(20.0, "foot")], [Quantity(30.0, "foot")]]
 
 *Note that the curly brackets (``{}``) are converted to a float-matching pattern by the parser.*
 

--- a/docs/user/angular_frequency.rst
+++ b/docs/user/angular_frequency.rst
@@ -45,7 +45,7 @@ Since pint treats angle quantities as `dimensionless`, it allows conversions bet
     >>> ureg = UnitRegistry()
     >>> angular_frequency = ureg('60rpm')
     >>> angular_frequency.to('Hz')
-    <Quantity(6.28318531, 'hertz')>
+    Quantity(6.28318531, "hertz")
 
 The SI BIPM Brochure (Bureau International des Poids et Mesures) states:
 

--- a/docs/user/contexts.rst
+++ b/docs/user/contexts.rst
@@ -24,7 +24,7 @@ You probably want to use the relation `frequency = speed_of_light / wavelength`:
 .. doctest::
 
     >>> (ureg.speed_of_light / q).to('Hz')
-    <Quantity(5.99584916e+14, 'hertz')>
+    Quantity(599584915999999.9, "hertz")
 
 
 To make this task easy, Pint has the concept of `contexts` which provides
@@ -36,14 +36,14 @@ different units.
 .. doctest::
 
     >>> q.to('Hz', 'spectroscopy')
-    <Quantity(5.99584916e+14, 'hertz')>
+    Quantity(599584915999999.9, "hertz")
 
 or with the abbreviated form:
 
 .. doctest::
 
     >>> q.to('Hz', 'sp')
-    <Quantity(5.99584916e+14, 'hertz')>
+    Quantity(599584915999999.9, "hertz")
 
 Contexts can be also enabled for blocks of code using the `with` statement:
 
@@ -51,7 +51,7 @@ Contexts can be also enabled for blocks of code using the `with` statement:
 
     >>> with ureg.context('sp'):
     ...     q.to('Hz')
-    <Quantity(5.99584916e+14, 'hertz')>
+    Quantity(599584915999999.9, "hertz")
 
 If you need a particular context in all your code, you can enable it for all
 operations with the registry
@@ -75,7 +75,7 @@ You can enable multiple contexts:
 .. doctest::
 
     >>> q.to('Hz', 'sp', 'boltzmann')
-    <Quantity(5.99584916e+14, 'hertz')>
+    Quantity(599584915999999.9, "hertz")
 
 This works also using the `with` statement:
 
@@ -83,7 +83,7 @@ This works also using the `with` statement:
 
     >>> with ureg.context('sp', 'boltzmann'):
     ...     q.to('Hz')
-    <Quantity(5.99584916e+14, 'hertz')>
+    Quantity(599584915999999.9, "hertz")
 
 or in the registry:
 
@@ -91,7 +91,7 @@ or in the registry:
 
     >>> ureg.enable_contexts('sp', 'boltzmann')
     >>> q.to('Hz')
-    <Quantity(5.99584916e+14, 'hertz')>
+    Quantity(599584915999999.9, "hertz")
 
 If a conversion rule between two dimensions appears in more than one context,
 the one in the last context has precedence. This is easy to remember if you
@@ -102,7 +102,7 @@ think that the previous syntax is equivalent to nest contexts:
     >>> with ureg.context('sp'):
     ...     with ureg.context('boltzmann') :
     ...         q.to('Hz')
-    <Quantity(5.99584916e+14, 'hertz')>
+    Quantity(599584915999999.9, "hertz")
 
 
 Parameterized contexts
@@ -117,7 +117,7 @@ calculate, for example, the wavelength in water of a laser which on air is 530 n
     >>> wl = 530. * ureg.nm
     >>> f = wl.to('Hz', 'sp')
     >>> f.to('nm', 'sp', n=1.33)
-    <Quantity(398.4962..., 'nanometer')>
+    Quantity(398.4962..., "nanometer")
 
 Contexts can also accept Pint Quantity objects as parameters. For example, the
 'chemistry' context accepts the molecular weight of a substance (as a Quantity
@@ -128,7 +128,7 @@ mass.
 
     >>> substance = 95 * ureg('g')
     >>> substance.to('moles', 'chemistry', mw = 5 * ureg('g/mol'))
-    <Quantity(19.0, 'mole')>
+    Quantity(19.0, "mole")
 
 
 Ensuring context when calling a function
@@ -205,7 +205,7 @@ functions. For example:
     ...                      lambda ureg, x: x * ureg.speed_of_light)
     >>> ureg.add_context(c)
     >>> ureg("1 s").to("km", "ab")
-    <Quantity(299792.458, 'kilometer')>
+    Quantity(299792.458, "kilometer")
 
 It is also possible to create anonymous contexts without invoking add_context:
 
@@ -214,7 +214,7 @@ It is also possible to create anonymous contexts without invoking add_context:
    >>> c = pint.Context()
    >>> c.add_transformation('[time]', '[length]', lambda ureg, x: x * ureg.speed_of_light)
    >>> ureg("1 s").to("km", c)
-   <Quantity(299792.458, 'kilometer')>
+   Quantity(299792.458, "kilometer")
 
 Using contexts for unit redefinition
 ------------------------------------

--- a/docs/user/defining-quantities.rst
+++ b/docs/user/defining-quantities.rst
@@ -19,16 +19,16 @@ quantity by multiplying a ``Unit()`` and a scalar:
     >>> from pint import UnitRegistry
     >>> ureg = UnitRegistry()
     >>> ureg.meter
-    <Unit('meter')>
+    Unit("meter")
     >>> 30.0 * ureg.meter
-    <Quantity(30.0, 'meter')>
+    Quantity(30.0, "meter")
 
 This works to build up complex units as well:
 
 .. doctest::
 
     >>> 9.8 * ureg.meter / ureg.second**2
-    <Quantity(9.8, 'meter / second ** 2')>
+    Quantity(9.8, "meter / second ** 2")
 
 
 Using the constructor
@@ -44,7 +44,7 @@ We typically abbreviate that constructor as `Q_` to make it's usage less verbose
 
     >>> Q_ = ureg.Quantity
     >>> Q_(1.78, ureg.meter)
-    <Quantity(1.78, 'meter')>
+    Quantity(1.78, "meter")
 
 As you can see below, the multiplication and constructor methods should produce
 the same results:
@@ -54,7 +54,7 @@ the same results:
     >>> Q_(30.0, ureg.meter) == 30.0 * ureg.meter
     True
     >>> Q_(9.8, ureg.meter / ureg.second**2)
-    <Quantity(9.8, 'meter / second ** 2')>
+    Quantity(9.8, "meter / second ** 2")
 
 Quantity can be created with itself, if units is specified ``pint`` will try to convert it to the desired units.
 If not, pint will just copy the quantity.
@@ -63,9 +63,9 @@ If not, pint will just copy the quantity.
 
     >>> length = Q_(30.0, ureg.meter)
     >>> Q_(length, 'cm')
-    <Quantity(3000.0, 'centimeter')>
+    Quantity(3000.0, "centimeter")
     >>> Q_(length)
-    <Quantity(30.0, 'meter')>
+    Quantity(30.0, "meter")
 
 Using string parsing
 --------------------
@@ -77,11 +77,11 @@ invokes the parsing function ``UnitRegistry.parse_expression``:
 .. doctest::
 
     >>> 30.0 * ureg('meter')
-    <Quantity(30.0, 'meter')>
+    Quantity(30.0, "meter")
     >>> ureg('30.0 meters')
-    <Quantity(30.0, 'meter')>
+    Quantity(30.0, "meter")
     >>> ureg('3000cm').to('meters')
-    <Quantity(30.0, 'meter')>
+    Quantity(30.0, "meter")
 
 The parsing function is also available to the ``Quantity()`` constructor and
 the various ``.to()`` methods:
@@ -89,18 +89,18 @@ the various ``.to()`` methods:
 .. doctest::
 
     >>> Q_('30.0 meters')
-    <Quantity(30.0, 'meter')>
+    Quantity(30.0, "meter")
     >>> Q_(30.0, 'meter')
-    <Quantity(30.0, 'meter')>
+    Quantity(30.0, "meter")
     >>> Q_('3000.0cm').to('meter')
-    <Quantity(30.0, 'meter')>
+    Quantity(30.0, "meter")
 
 Or as a standalone method on the ``UnitRegistry``:
 
 .. doctest::
 
    >>> 2.54 * ureg.parse_expression('centimeter')
-   <Quantity(2.54, 'centimeter')>
+   Quantity(2.54, "centimeter")
 
 It is fairly good at detecting compound units:
 
@@ -108,9 +108,9 @@ It is fairly good at detecting compound units:
 
     >>> g = ureg('9.8 meters/second**2')
     >>> g
-    <Quantity(9.8, 'meter / second ** 2')>
+    Quantity(9.8, "meter / second ** 2")
     >>> g.to('furlongs/fortnight**2')
-    <Quantity(7.12770743e+10, 'furlong / fortnight ** 2')>
+    Quantity(71277074338.9091, "furlong / fortnight ** 2")
 
 And behaves well when given dimensionless quantities, which are parsed into
 dimensionless ``Quantity`` objects:
@@ -118,11 +118,11 @@ dimensionless ``Quantity`` objects:
 .. doctest::
 
    >>> ureg('2.54')
-   <Quantity(2.54, 'dimensionless')>
+   Quantity(2.54, "dimensionless")
    >>> type(ureg('2.54'))
    <class 'pint.Quantity'>
    >>> Q_('2.54')
-   <Quantity(2.54, 'dimensionless')>
+   Quantity(2.54, "dimensionless")
    >>> type(Q_('2.54'))
    <class 'pint.Quantity'>
 
@@ -134,7 +134,7 @@ For example, the units of
 .. doctest::
 
    >>> Q_('3 l / 100 km')
-   <Quantity(0.03, 'liter * kilometer')>
+   Quantity(0.03, "liter * kilometer")
 
 may be unexpected at first but, are a consequence of applying this rule. Use
 brackets to get the expected result:
@@ -142,7 +142,7 @@ brackets to get the expected result:
 .. doctest::
 
    >>> Q_('3 l / (100 km)')
-   <Quantity(0.03, 'liter / kilometer')>
+   Quantity(0.03, "liter / kilometer")
 
 Special strings for NaN (Not a Number) and inf(inity) are also handled in a case-insensitive fashion.
 Note that, as usual, NaN != NaN.
@@ -150,13 +150,13 @@ Note that, as usual, NaN != NaN.
 .. doctest::
 
    >>> Q_('inf m')
-   <Quantity(inf, 'meter')>
+   Quantity(inf, "meter")
    >>> Q_('-INFINITY m')
-   <Quantity(-inf, 'meter')>
+   Quantity(-inf, "meter")
    >>> Q_('nan m')
-   <Quantity(nan, 'meter')>
+   Quantity(nan, "meter")
    >>> Q_('NaN m')
-   <Quantity(nan, 'meter')>
+   Quantity(nan, "meter")
 
 .. note:: Since version 0.7, Pint **does not** use eval_ under the hood.
    This change removes the `serious security problems`_ that the system is

--- a/docs/user/log_units.rst
+++ b/docs/user/log_units.rst
@@ -44,11 +44,11 @@ you can define simple logarithmic quantities like most others:
 .. doctest::
 
     >>> 20.0 * ureg.dBm
-    <Quantity(20.0, 'decibelmilliwatt')>
+    Quantity(20.0, "decibelmilliwatt")
     >>> ureg('20.0 dBm')
-    <Quantity(20.0, 'decibelmilliwatt')>
+    Quantity(20.0, "decibelmilliwatt")
     >>> ureg('20 dB')
-    <Quantity(20, 'decibel')>
+    Quantity(20, "decibel")
 
 
 Converting to and from base units
@@ -60,9 +60,9 @@ Get a sense of how logarithmic units are handled by using the `.to()` and
 .. doctest::
 
     >>> ureg('20 dBm').to('mW')
-    <Quantity(100.0, 'milliwatt')>
+    Quantity(np.float64(100.00000000000004), "milliwatt")
     >>> ureg('20 dB').to_base_units()
-    <Quantity(100.0, 'dimensionless')>
+    Quantity(np.float64(100.00000000000004), "dimensionless")
 
 .. note::
 
@@ -76,12 +76,12 @@ Convert back from a base unit to a logarithmic unit using the `.to()` method:
 .. doctest::
 
     >>> (100.0 * ureg('mW')).to('dBm')
-    <Quantity(20.0, 'decibelmilliwatt')>
+    Quantity(np.float64(20.0), "decibelmilliwatt")
     >>> shift = Q_(4, '')
     >>> shift
-    <Quantity(4, 'dimensionless')>
+    Quantity(4, "dimensionless")
     >>> shift.to('octave')
-    <Quantity(2.0, 'octave')>
+    Quantity(np.float64(2.0), "octave")
 
 Compound log units
 ------------------
@@ -101,9 +101,9 @@ example of computing RMS noise from a noise density and a bandwidth:
     >>> bandwidth = 10.0 * ureg.kHz
     >>> noise_power = noise_density * bandwidth
     >>> noise_power.to('dBm')
-    <Quantity(-121.0, 'decibelmilliwatt')>
+    Quantity(np.float64(-121.00000000000003), "decibelmilliwatt")
     >>> noise_power.to('mW')
-    <Quantity(7.94328235e-13, 'milliwatt')>
+    Quantity(np.float64(7.943282347242739e-13), "milliwatt")
 
 There are still issues with parsing compound units, so for now the following
 will not work:

--- a/docs/user/nonmult.rst
+++ b/docs/user/nonmult.rst
@@ -53,7 +53,7 @@ Subtraction of two temperatures given in offset units yields a *delta* unit:
 .. doctest::
 
     >>> Q_(25.4, ureg.degC) - Q_(10., ureg.degC)
-    <Quantity(15.4, 'delta_degree_Celsius')>
+    Quantity(15.399999999999999, "delta_degree_Celsius")
 
 You can add or subtract a quantity with *delta* unit and a quantity with
 offset unit:
@@ -61,9 +61,9 @@ offset unit:
 .. doctest::
 
     >>> Q_(25.4, ureg.degC) + Q_(10., ureg.delta_degC)
-    <Quantity(35.4, 'degree_Celsius')>
+    Quantity(35.4, "degree_Celsius")
     >>> Q_(25.4, ureg.degC) - Q_(10., ureg.delta_degC)
-    <Quantity(15.4, 'degree_Celsius')>
+    Quantity(15.399999999999999, "degree_Celsius")
 
 If you want to add a quantity with absolute unit to one with offset unit, like here
 
@@ -81,14 +81,14 @@ absolute unit before addition
 .. doctest::
 
     >>> Q_(10., ureg.degC).to(ureg.kelvin) + heating_rate * Q_(30, ureg.min)
-    <Quantity(298.15, 'kelvin')>
+    Quantity(298.15, "kelvin")
 
 or convert the absolute unit to a *delta* unit:
 
 .. doctest::
 
     >>> Q_(10., ureg.degC) + heating_rate.to('delta_degC/min') * Q_(30, ureg.min)
-    <Quantity(25.0, 'degree_Celsius')>
+    Quantity(25.0, "degree_Celsius")
 
 In contrast to subtraction, the addition of quantities with offset units
 is ambiguous, e.g. for *10 degC + 100 degC* two different result are reasonable
@@ -119,7 +119,7 @@ to be explicitly created:
         ...
     OffsetUnitCalculusError: Ambiguous operation with offset unit (degC).
     >>> Q_(25.4, ureg.degC)
-    <Quantity(25.4, 'degree_Celsius')>
+    Quantity(25.4, "degree_Celsius")
 
 As an alternative to raising an error, pint can be configured to work more
 relaxed via setting the UnitRegistry parameter *autoconvert_offset_to_baseunit*
@@ -133,7 +133,7 @@ to true. In this mode, pint behaves differently:
     >>> ureg = UnitRegistry(autoconvert_offset_to_baseunit = True)
     >>> T = 25.4 * ureg.degC
     >>> T
-    <Quantity(25.4, 'degree_Celsius')>
+    Quantity(25.4, "degree_Celsius")
 
 * Before all other multiplications, all divisions and in case of
   exponentiation [#f1]_ involving quantities with offset-units, pint
@@ -143,9 +143,9 @@ to true. In this mode, pint behaves differently:
 .. doctest::
 
     >>> 1/T
-    <Quantity(0.0033495..., '1 / kelvin')>
+    Quantity(0.0033495..., "1 / kelvin")
     >>> T * 10 * ureg.meter
-    <Quantity(527.15, 'kelvin * meter')>
+    Quantity(527.15, "kelvin * meter")
 
 You can change the behaviour at any time:
 
@@ -184,7 +184,7 @@ Note that the magnitude is left unchanged:
 .. doctest::
 
     >>> Q_(10, 'degC/meter')
-    <Quantity(10, 'delta_degree_Celsius / meter')>
+    Quantity(10, "delta_degree_Celsius / meter")
 
 To define a new temperature, you need to specify the offset. For example,
 this is the definition of the celsius and fahrenheit::

--- a/docs/user/systems.rst
+++ b/docs/user/systems.rst
@@ -18,7 +18,7 @@ This has an effect in the base units. For example:
 
     >>> q = 3600. * ureg.meter / ureg.hour
     >>> q.to_base_units()
-    <Quantity(1.0, 'meter / second')>
+    Quantity(1.0, "meter / second")
 
 But if you change to cgs:
 
@@ -26,7 +26,7 @@ But if you change to cgs:
 
     >>> ureg.default_system = 'cgs'
     >>> q.to_base_units()
-    <Quantity(100.0, 'centimeter / second')>
+    Quantity(100.0, "centimeter / second")
 
 or more drastically to:
 
@@ -60,8 +60,8 @@ Notice that this give you the opportunity to choose within units with colliding 
 .. doctest::
 
     >>> (1 * ureg.sys.imperial.pint).to('liter')
-    <Quantity(0.568261..., 'liter')>
+    Quantity(0.568261..., "liter")
     >>> (1 * ureg.sys.US.pint).to('liter')
-    <Quantity(0.473176..., 'liter')>
+    Quantity(0.473176..., "liter")
     >>> (1 * ureg.sys.US.pint).to(ureg.sys.imperial.pint)
-    <Quantity(0.832674..., 'imperial_pint')>
+    Quantity(0.832674..., "imperial_pint")

--- a/pint/facets/measurement/objects.py
+++ b/pint/facets/measurement/objects.py
@@ -98,9 +98,7 @@ class Measurement(PlainQuantity):
         return _unpickle_measurement, (Measurement, self.magnitude, self._units)
 
     def __repr__(self):
-        return "<Measurement({}, {}, {})>".format(
-            self.magnitude.nominal_value, self.magnitude.std_dev, self.units
-        )
+        return f"Measurement({repr(self.magnitude.nominal_value)}, {repr(self.magnitude.std_dev)}, {self.units})"
 
     def __str__(self):
         return f"{self}"

--- a/pint/facets/measurement/objects.py
+++ b/pint/facets/measurement/objects.py
@@ -98,7 +98,7 @@ class Measurement(PlainQuantity):
         return _unpickle_measurement, (Measurement, self.magnitude, self._units)
 
     def __repr__(self):
-        return f"Measurement({repr(self.magnitude.nominal_value)}, {repr(self.magnitude.std_dev)}, {self.units})"
+        return f"Measurement({repr(self.magnitude.nominal_value)}, {repr(self.magnitude.std_dev)}, \"{self.units}\")"
 
     def __str__(self):
         return f"{self}"

--- a/pint/facets/measurement/objects.py
+++ b/pint/facets/measurement/objects.py
@@ -98,7 +98,7 @@ class Measurement(PlainQuantity):
         return _unpickle_measurement, (Measurement, self.magnitude, self._units)
 
     def __repr__(self):
-        return f"Measurement({repr(self.magnitude.nominal_value)}, {repr(self.magnitude.std_dev)}, \"{self.units}\")"
+        return f'Measurement({repr(self.magnitude.nominal_value)}, {repr(self.magnitude.std_dev)}, "{self.units}")'
 
     def __str__(self):
         return f"{self}"

--- a/pint/facets/plain/qto.py
+++ b/pint/facets/plain/qto.py
@@ -87,9 +87,9 @@ def to_compact(
     >>> import pint
     >>> ureg = pint.UnitRegistry()
     >>> (200e-9 * ureg.s).to_compact()
-    <Quantity(200.0, 'nanosecond')>
+    Quantity(199.99999999999997, "nanosecond")
     >>> (1e-2 * ureg("kg m/s^2")).to_compact("N")
-    <Quantity(10.0, 'millinewton')>
+    Quantity(10.0, "millinewton")
     """
 
     if not isinstance(quantity.magnitude, numbers.Number) and not hasattr(
@@ -207,9 +207,9 @@ def to_preferred(
     >>> import pint
     >>> ureg = pint.UnitRegistry()
     >>> (1 * ureg.acre).to_preferred([ureg.meters])
-    <Quantity(4046.87261, 'meter ** 2')>
+    Quantity(4046.8726098742513, "meter ** 2")
     >>> (1 * (ureg.force_pound * ureg.m)).to_preferred([ureg.W])
-    <Quantity(4.44822162, 'watt * second')>
+    Quantity(4.4482216152605005, "watt * second")
     """
 
     units = _get_preferred(quantity, preferred_units)
@@ -227,9 +227,9 @@ def ito_preferred(
     >>> import pint
     >>> ureg = pint.UnitRegistry()
     >>> (1 * ureg.acre).to_preferred([ureg.meters])
-    <Quantity(4046.87261, 'meter ** 2')>
+    Quantity(4046.8726098742513, "meter ** 2")
     >>> (1 * (ureg.force_pound * ureg.m)).to_preferred([ureg.W])
-    <Quantity(4.44822162, 'watt * second')>
+    Quantity(4.4482216152605005, "watt * second")
     """
 
     units = _get_preferred(quantity, preferred_units)

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -270,7 +270,7 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
     def __bytes__(self) -> bytes:
         return str(self).encode(locale.getpreferredencoding())
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         if HAS_UNCERTAINTIES:
             if isinstance(self._magnitude, UFloat):
                 return f"<Quantity({self._magnitude:.6}, '{self._units}')>"
@@ -280,6 +280,9 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
             return f"<Quantity({self._magnitude:.9}, '{self._units}')>"
 
         return f"<Quantity({self._magnitude}, '{self._units}')>"
+
+    def __repr__(self) -> str:
+        return f"Quantity({repr(self._magnitude)}, \"{self._units}\")"
 
     def __hash__(self) -> int:
         self_base = self.to_base_units()

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -270,17 +270,6 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
     def __bytes__(self) -> bytes:
         return str(self).encode(locale.getpreferredencoding())
 
-    def __str__(self) -> str:
-        if HAS_UNCERTAINTIES:
-            if isinstance(self._magnitude, UFloat):
-                return f"<Quantity({self._magnitude:.6}, '{self._units}')>"
-            else:
-                return f"<Quantity({self._magnitude}, '{self._units}')>"
-        elif isinstance(self._magnitude, float):
-            return f"<Quantity({self._magnitude:.9}, '{self._units}')>"
-
-        return f"<Quantity({self._magnitude}, '{self._units}')>"
-
     def __repr__(self) -> str:
         return f"Quantity({repr(self._magnitude)}, \"{self._units}\")"
 

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 
 try:
     import uncertainties.unumpy as unp
-    from uncertainties import UFloat, ufloat
+    from uncertainties import ufloat
 
     HAS_UNCERTAINTIES = True
 except ImportError:
@@ -271,7 +271,7 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
         return str(self).encode(locale.getpreferredencoding())
 
     def __repr__(self) -> str:
-        return f"Quantity({repr(self._magnitude)}, \"{self._units}\")"
+        return f'Quantity({repr(self._magnitude)}, "{self._units}")'
 
     def __hash__(self) -> int:
         self_base = self.to_base_units()

--- a/pint/facets/plain/unit.py
+++ b/pint/facets/plain/unit.py
@@ -73,7 +73,7 @@ class PlainUnit(PrettyIPython, SharedRegistryObject):
         return str(self).encode(locale.getpreferredencoding())
 
     def __repr__(self) -> str:
-        return f"<Unit('{self._units}')>"
+        return f"Unit('{self._units}')"
 
     @property
     def dimensionless(self) -> bool:

--- a/pint/facets/plain/unit.py
+++ b/pint/facets/plain/unit.py
@@ -73,7 +73,7 @@ class PlainUnit(PrettyIPython, SharedRegistryObject):
         return str(self).encode(locale.getpreferredencoding())
 
     def __repr__(self) -> str:
-        return f"Unit('{self._units}')"
+        return f"Unit(\"{self._units}\")"
 
     @property
     def dimensionless(self) -> bool:

--- a/pint/facets/plain/unit.py
+++ b/pint/facets/plain/unit.py
@@ -73,7 +73,7 @@ class PlainUnit(PrettyIPython, SharedRegistryObject):
         return str(self).encode(locale.getpreferredencoding())
 
     def __repr__(self) -> str:
-        return f"Unit(\"{self._units}\")"
+        return f'Unit("{self._units}")'
 
     @property
     def dimensionless(self) -> bool:

--- a/pint/testsuite/helpers.py
+++ b/pint/testsuite/helpers.py
@@ -22,13 +22,13 @@ from ..compat import (
 
 _number_re = r"([-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)"
 _q_re = re.compile(
-    r"<Quantity\("
+    r"Quantity\("
     + r"\s*"
     + r"(?P<magnitude>%s)" % _number_re
     + r"\s*,\s*"
-    + r"'(?P<unit>.*)'"
+    + r"\"(?P<unit>.*)\""
     + r"\s*"
-    + r"\)>"
+    + r"\)"
 )
 
 _sq_re = re.compile(

--- a/pint/testsuite/test_measurement.py
+++ b/pint/testsuite/test_measurement.py
@@ -21,7 +21,7 @@ class TestMeasurement(QuantityTestCase):
     def test_simple(self):
         M_ = self.ureg.Measurement
         m = M_(4.0, 0.1, "s * s")
-        assert repr(m) == "<Measurement(4.0, 0.1, second ** 2)>"
+        assert repr(m) == "Measurement(4.0, 0.1, \"second ** 2\")"
 
     def test_build(self):
         M_ = self.ureg.Measurement

--- a/pint/testsuite/test_measurement.py
+++ b/pint/testsuite/test_measurement.py
@@ -23,6 +23,9 @@ class TestMeasurement(QuantityTestCase):
         m = M_(4.0, 0.1, "s * s")
         assert repr(m) == "Measurement(4.0, 0.1, \"second ** 2\")"
 
+        # Just check that we can eval this, as we can't __eq__ Measurements
+        eval(repr(m).replace("Measurement","M_"))
+
     def test_build(self):
         M_ = self.ureg.Measurement
         v, u = self.Q_(4.0, "s"), self.Q_(0.1, "s")

--- a/pint/testsuite/test_measurement.py
+++ b/pint/testsuite/test_measurement.py
@@ -21,10 +21,10 @@ class TestMeasurement(QuantityTestCase):
     def test_simple(self):
         M_ = self.ureg.Measurement
         m = M_(4.0, 0.1, "s * s")
-        assert repr(m) == "Measurement(4.0, 0.1, \"second ** 2\")"
+        assert repr(m) == 'Measurement(4.0, 0.1, "second ** 2")'
 
         # Just check that we can eval this, as we can't __eq__ Measurements
-        eval(repr(m).replace("Measurement","M_"))
+        eval(repr(m).replace("Measurement", "M_"))
 
     def test_build(self):
         M_ = self.ureg.Measurement

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -138,6 +138,10 @@ class TestQuantity(QuantityTestCase):
         assert repr(x_arr) == 'Quantity(array([1., 2., 3.]), "meter ** 2")'
 
         # Imports needed for the eval
+        from numpy import array  # noqa: F401
+
+        from pint import Quantity  # noqa: F401
+
         assert eval(repr(x)) == x
         assert np.all(eval(repr(x_arr)) == x_arr)
 

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -130,13 +130,10 @@ class TestQuantity(QuantityTestCase):
         assert self.Q_(1000, "millimeter") == self.Q_(1, "meter")
         assert self.Q_(1000, "millimeter/min") == self.Q_(1000 / 60, "millimeter/s")
 
-    @helpers.requires_numpy
     def test_quantity_repr(self):
         x = self.Q_(4.2, UnitsContainer(meter=1))
-        x_arr = self.Q_(np.array([1.0, 2.0, 3.0]), UnitsContainer(meter=2))
         assert str(x) == "4.2 meter"
         assert repr(x) == 'Quantity(4.2, "meter")'
-        assert repr(x_arr) == 'Quantity(array([1., 2., 3.]), "meter ** 2")'
 
         # Imports needed for the eval
         from numpy import array  # noqa: F401
@@ -144,6 +141,17 @@ class TestQuantity(QuantityTestCase):
         from pint import Quantity  # noqa: F401
 
         assert eval(repr(x)) == x
+
+    @helpers.requires_numpy
+    def test_quantity_repr_numpy(self):
+        x_arr = self.Q_(np.array([1.0, 2.0, 3.0]), UnitsContainer(meter=2))
+        assert repr(x_arr) == 'Quantity(array([1., 2., 3.]), "meter ** 2")'
+
+        # Imports needed for the eval
+        from numpy import array  # noqa: F401
+
+        from pint import Quantity  # noqa: F401
+
         assert np.all(eval(repr(x_arr)) == x_arr)
 
     def test_quantity_hash(self):

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -136,8 +136,6 @@ class TestQuantity(QuantityTestCase):
         assert repr(x) == 'Quantity(4.2, "meter")'
 
         # Imports needed for the eval
-        from numpy import array  # noqa: F401
-
         from pint import Quantity  # noqa: F401
 
         assert eval(repr(x)) == x

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -133,7 +133,7 @@ class TestQuantity(QuantityTestCase):
     def test_quantity_repr(self):
         x = self.Q_(4.2, UnitsContainer(meter=1))
         assert str(x) == "4.2 meter"
-        assert repr(x) == "<Quantity(4.2, 'meter')>"
+        assert repr(x) == "Quantity(4.2, \"meter\")"
 
     def test_quantity_hash(self):
         x = self.Q_(4.2, "meter")

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -134,12 +134,10 @@ class TestQuantity(QuantityTestCase):
         x = self.Q_(4.2, UnitsContainer(meter=1))
         x_arr = self.Q_(np.array([1.0, 2.0, 3.0]), UnitsContainer(meter=2))
         assert str(x) == "4.2 meter"
-        assert repr(x) == "Quantity(4.2, \"meter\")"
-        assert repr(x_arr) == "Quantity(array([1., 2., 3.]), \"meter ** 2\")"
+        assert repr(x) == 'Quantity(4.2, "meter")'
+        assert repr(x_arr) == 'Quantity(array([1., 2., 3.]), "meter ** 2")'
 
         # Imports needed for the eval
-        from pint import Quantity
-        from numpy import array
         assert eval(repr(x)) == x
         assert np.all(eval(repr(x_arr)) == x_arr)
 

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -132,8 +132,16 @@ class TestQuantity(QuantityTestCase):
 
     def test_quantity_repr(self):
         x = self.Q_(4.2, UnitsContainer(meter=1))
+        x_arr = self.Q_(np.array([1.0, 2.0, 3.0]), UnitsContainer(meter=2))
         assert str(x) == "4.2 meter"
         assert repr(x) == "Quantity(4.2, \"meter\")"
+        assert repr(x_arr) == "Quantity(array([1., 2., 3.]), \"meter ** 2\")"
+
+        # Imports needed for the eval
+        from pint import Quantity
+        from numpy import array
+        assert eval(repr(x)) == x
+        assert np.all(eval(repr(x_arr)) == x_arr)
 
     def test_quantity_hash(self):
         x = self.Q_(4.2, "meter")

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -130,6 +130,7 @@ class TestQuantity(QuantityTestCase):
         assert self.Q_(1000, "millimeter") == self.Q_(1, "meter")
         assert self.Q_(1000, "millimeter/min") == self.Q_(1000 / 60, "millimeter/s")
 
+    @helpers.requires_numpy
     def test_quantity_repr(self):
         x = self.Q_(4.2, UnitsContainer(meter=1))
         x_arr = self.Q_(np.array([1.0, 2.0, 3.0]), UnitsContainer(meter=2))

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -34,8 +34,8 @@ class TestUnit(QuantityTestCase):
     def test_unit_repr(self):
         x = self.U_(UnitsContainer(meter=1))
         assert str(x) == "meter"
-        assert repr(x) == "Unit(\"meter\")"
-        assert eval(repr(x).replace("Unit","self.U_")) == x
+        assert repr(x) == 'Unit("meter")'
+        assert eval(repr(x).replace("Unit", "self.U_")) == x
 
     def test_unit_formatting(self, subtests):
         x = self.U_(UnitsContainer(meter=2, kilogram=1, second=-1))

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -35,6 +35,7 @@ class TestUnit(QuantityTestCase):
         x = self.U_(UnitsContainer(meter=1))
         assert str(x) == "meter"
         assert repr(x) == "Unit(\"meter\")"
+        assert eval(repr(x).replace("Unit","self.U_")) == x
 
     def test_unit_formatting(self, subtests):
         x = self.U_(UnitsContainer(meter=2, kilogram=1, second=-1))

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -34,7 +34,7 @@ class TestUnit(QuantityTestCase):
     def test_unit_repr(self):
         x = self.U_(UnitsContainer(meter=1))
         assert str(x) == "meter"
-        assert repr(x) == "<Unit('meter')>"
+        assert repr(x) == "Unit(\"meter\")"
 
     def test_unit_formatting(self, subtests):
         x = self.U_(UnitsContainer(meter=2, kilogram=1, second=-1))

--- a/pint/testsuite/test_util.py
+++ b/pint/testsuite/test_util.py
@@ -67,13 +67,13 @@ class TestUnitsContainer:
     def test_unitcontainer_repr(self):
         x = UnitsContainer()
         assert str(x) == "dimensionless"
-        assert repr(x) == "<UnitsContainer({})>"
+        assert repr(x) == "UnitsContainer({})"
         x = UnitsContainer(meter=1, second=2)
         assert str(x) == "meter * second ** 2"
-        assert repr(x) == "<UnitsContainer({'meter': 1, 'second': 2})>"
+        assert repr(x) == "UnitsContainer({'meter': 1, 'second': 2})"
         x = UnitsContainer(meter=1, second=2.5)
         assert str(x) == "meter * second ** 2.5"
-        assert repr(x) == "<UnitsContainer({'meter': 1, 'second': 2.5})>"
+        assert repr(x) == "UnitsContainer({'meter': 1, 'second': 2.5})"
 
     def test_unitcontainer_bool(self):
         assert UnitsContainer(meter=1, second=2)
@@ -166,7 +166,7 @@ class TestParseHelper:
         assert x() == xp()
         assert x() != y()
         assert ParserHelper.from_string("") == ParserHelper()
-        assert repr(x()) == "<ParserHelper(1, {'meter': 2})>"
+        assert repr(x()) == "ParserHelper(1, {'meter': 2})"
 
         assert ParserHelper(2) == 2
 

--- a/pint/util.py
+++ b/pint/util.py
@@ -590,6 +590,9 @@ class UnitsContainer(Mapping[str, Scalar]):
         return self.__format__("")
 
     def __repr__(self) -> str:
+        return f"UnitsContainer({repr(self._d)})"
+
+    def __str__(self) -> str:
         tmp = "{%s}" % ", ".join(
             [f"'{key}': {value}" for key, value in sorted(self._d.items())]
         )
@@ -840,6 +843,12 @@ class ParserHelper(UnitsContainer):
         return f"{self.scale} {tmp}"
 
     def __repr__(self):
+        tmp = "{%s}" % ", ".join(
+            [f"'{key}': {value}" for key, value in sorted(self._d.items())]
+        )
+        return f"ParserHelper({repr(self.scale)}, {repr(self._d)})"
+
+    def __str__(self):
         tmp = "{%s}" % ", ".join(
             [f"'{key}': {value}" for key, value in sorted(self._d.items())]
         )

--- a/pint/util.py
+++ b/pint/util.py
@@ -592,12 +592,6 @@ class UnitsContainer(Mapping[str, Scalar]):
     def __repr__(self) -> str:
         return f"UnitsContainer({repr(self._d)})"
 
-    def __str__(self) -> str:
-        tmp = "{%s}" % ", ".join(
-            [f"'{key}': {value}" for key, value in sorted(self._d.items())]
-        )
-        return f"<UnitsContainer({tmp})>"
-
     def __format__(self, spec: str) -> str:
         # TODO: provisional
         from .formatting import format_unit

--- a/pint/util.py
+++ b/pint/util.py
@@ -839,12 +839,6 @@ class ParserHelper(UnitsContainer):
     def __repr__(self):
         return f"ParserHelper({repr(self.scale)}, {repr(self._d)})"
 
-    def __str__(self):
-        tmp = "{%s}" % ", ".join(
-            [f"'{key}': {value}" for key, value in sorted(self._d.items())]
-        )
-        return f"<ParserHelper({self.scale}, {tmp})>"
-
     def __mul__(self, other):
         if isinstance(other, str):
             new = self.add(other, self._one)

--- a/pint/util.py
+++ b/pint/util.py
@@ -837,9 +837,6 @@ class ParserHelper(UnitsContainer):
         return f"{self.scale} {tmp}"
 
     def __repr__(self):
-        tmp = "{%s}" % ", ".join(
-            [f"'{key}': {value}" for key, value in sorted(self._d.items())]
-        )
         return f"ParserHelper({repr(self.scale)}, {repr(self._d)})"
 
     def __str__(self):


### PR DESCRIPTION
- [x] Closes #1495
- [x] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

This updates the `repr` values to use `repr(magnitude)` rather than printing the `magnitude` with a formatter. This also means that `repr` values are valid Python statements, so `eval(repr(...))` works; I've added unit tests that do this to confirm. These changes also make it so they work with things like `pybind11-stubgen`. See #1495 for more details.
