### PR TITLE
Add system parameter to to_base_units and ito_base_units

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.26.0 (unreleased)
 -------------------
 
+- Add `system` parameter to `to_base_units` and `ito_base_units` to allow converting to the base units of a specific unit system (#2297)
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)
 - Bump minimum numpy version to 2.0.0
 - Fix regression when using magnitude format specs in string formats (#2291)

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -549,20 +549,34 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
 
         return self.__class__(magnitude, other)
 
-    def ito_base_units(self) -> None:
-        """Return PlainQuantity rescaled to plain units."""
+    def ito_base_units(self, system=None) -> None:
+        """Return PlainQuantity rescaled to plain units.
 
-        _, other = self._REGISTRY._get_base_units(self._units)
+        Parameters
+        ----------
+        system : str or System, optional
+            The unit system to convert to. If None, uses the registry's
+            default system.
+        """
+
+        _, other = self._REGISTRY._get_base_units(self._units, system=system)
 
         self._magnitude = self._convert_magnitude(other)
         self._units = other
 
         return None
 
-    def to_base_units(self) -> PlainQuantity[MagnitudeT]:
-        """Return PlainQuantity rescaled to plain units."""
+    def to_base_units(self, system=None) -> PlainQuantity[MagnitudeT]:
+        """Return PlainQuantity rescaled to plain units.
 
-        _, other = self._REGISTRY._get_base_units(self._units)
+        Parameters
+        ----------
+        system : str or System, optional
+            The unit system to convert to. If None, uses the registry's
+            default system.
+        """
+
+        _, other = self._REGISTRY._get_base_units(self._units, system=system)
 
         magnitude = self._convert_magnitude_not_inplace(other)
 

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -382,6 +382,20 @@ class TestQuantity(QuantityTestCase):
             x.to_base_units(), self.Q_(0.0254 / 60.0, "meter/second")
         )
 
+    @pytest.mark.parametrize(
+        "input_quantity, system, expected_quantity",
+        [
+            ("100 meter", "imperial", "109.36132983377078 yard"),
+            ("1 km", "mks", "1000 meter"),
+            ("1 inch", "mks", "0.0254 meter"),
+        ],
+    )
+    def test_to_base_units_with_system(self, input_quantity, system, expected_quantity):
+        helpers.assert_quantity_almost_equal(
+            self.Q_(input_quantity).to_base_units(system=system),
+            self.Q_(expected_quantity),
+        )
+
     def test_convert(self):
         helpers.assert_quantity_almost_equal(
             self.Q_("2 inch").to("meter"), self.Q_(2.0 * 0.0254, "meter")


### PR DESCRIPTION
## Summary

- Adds an optional `system` parameter to `to_base_units()` and `ito_base_units()` so callers can convert to the base units of a specific unit system
- The underlying `_get_base_units()` already supported a `system` argument — this just exposes it on the public API
- Closes #2297

## Example

```python
from pint import UnitRegistry

u = UnitRegistry(system='mks')
x = 0.1 * u.km

print(x.to_base_units())             # 100.0 meter
print(x.to_base_units('imperial'))   # 109.36 yard
```

## Test plan

- [x] Parametrized `test_to_base_units_with_system` covering imperial and mks conversions
- [x] Existing `test_to_base_units` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)