### PR TITLE
Add ureg.constants for accessing physical constants

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.26.0 (unreleased)
 -------------------
 
+- Add `ureg.constants` for accessing physical constants (#1078)
 - Add `system` parameter to `to_base_units` and `ito_base_units` to allow converting to the base units of a specific unit system (#2297)
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)
 - Bump minimum numpy version to 2.0.0

--- a/docs/getting/tutorial.rst
+++ b/docs/getting/tutorial.rst
@@ -225,6 +225,23 @@ preferred units when producing new quantities. This is disabled by default.
 Note when there are multiple good combinations of units to reduce to, to_preferred is not guaranteed to be repeatable.
 For example, ``(1 * ureg.lbf * ureg.m).to_preferred(preferred_units)`` may return ``W s`` or ``ft lbf``.
 
+Constants
+---------
+
+Pint includes a number of physical constants, which can be accessed as Quantities through the ``UnitRegistry``:
+
+.. doctest::
+
+   >>> ureg.constants.speed_of_light
+   Quantity(299792458.0, "meter / second")
+
+They are also provided as Units, so you can use them in calculations:
+
+.. doctest::
+
+   >>> speed.to(ureg.speed_of_light)
+   Quantity(1.0006922855944561e-08, "speed_of_light")
+
 String parsing
 --------------
 

--- a/pint/constants_en.txt
+++ b/pint/constants_en.txt
@@ -6,78 +6,82 @@
 #         https://physics.nist.gov/cuu/pdf/sp811.pdf
 # :copyright: 2013,2019 by Pint Authors, see AUTHORS for more details.
 
-#### MATHEMATICAL CONSTANTS ####
-# As computed by Maxima with fpprec:50
+@group constants
 
-pi     = 3.1415926535897932384626433832795028841971693993751 = π  # pi
-tansec = 4.8481368111333441675396429478852851658848753880815e-6   # tangent of 1 arc-second ~ arc_second/radian
-ln10   = 2.3025850929940456840179914546843642076011014886288      # natural logarithm of 10
-wien_x = 4.9651142317442763036987591313228939440555849867973      # solution to (x-5)*exp(x)+5 = 0 => x = W(5/exp(5))+5
-wien_u = 2.8214393721220788934031913302944851953458817440731      # solution to (u-3)*exp(u)+3 = 0 => u = W(3/exp(3))+3
-eulers_number = 2.71828182845904523536028747135266249775724709369995
+    #### MATHEMATICAL CONSTANTS ####
+    # As computed by Maxima with fpprec:50
 
-#### DEFINED EXACT CONSTANTS ####
+    pi     = 3.1415926535897932384626433832795028841971693993751 = π  # pi
+    tansec = 4.8481368111333441675396429478852851658848753880815e-6   # tangent of 1 arc-second ~ arc_second/radian
+    ln10   = 2.3025850929940456840179914546843642076011014886288      # natural logarithm of 10
+    wien_x = 4.9651142317442763036987591313228939440555849867973      # solution to (x-5)*exp(x)+5 = 0 => x = W(5/exp(5))+5
+    wien_u = 2.8214393721220788934031913302944851953458817440731      # solution to (u-3)*exp(u)+3 = 0 => u = W(3/exp(3))+3
+    eulers_number = 2.71828182845904523536028747135266249775724709369995
 
-speed_of_light = 299792458 m/s = c = c_0                      # since 1983
-planck_constant = 6.62607015e-34 J s = ℎ                      # since May 2019
-elementary_charge = 1.602176634e-19 C = e                     # since May 2019
-avogadro_number = 6.02214076e23                               # since May 2019
-boltzmann_constant = 1.380649e-23 J K^-1 = k = k_B            # since May 2019
-standard_gravity = 9.80665 m/s^2 = g_0 = g0 = g_n = gravity   # since 1901
-standard_atmosphere = 1.01325e5 Pa = atm = atmosphere         # since 1954
-conventional_josephson_constant = 4.835979e14 Hz / V = K_J90  # since Jan 1990
-conventional_von_klitzing_constant = 2.5812807e4 ohm = R_K90  # since Jan 1990
-conventional_water_density = 1000 kg/m^3 = ρH2O
-conventional_mercury_density = 13595.1 kg/m^3 = ρHg
+    #### DEFINED EXACT CONSTANTS ####
 
-#### DERIVED EXACT CONSTANTS ####
-# Floating-point conversion may introduce inaccuracies
+    speed_of_light = 299792458 m/s = c = c_0                      # since 1983
+    planck_constant = 6.62607015e-34 J s = ℎ                      # since May 2019
+    elementary_charge = 1.602176634e-19 C = e                     # since May 2019
+    avogadro_number = 6.02214076e23                               # since May 2019
+    boltzmann_constant = 1.380649e-23 J K^-1 = k = k_B            # since May 2019
+    standard_gravity = 9.80665 m/s^2 = g_0 = g0 = g_n = gravity   # since 1901
+    standard_atmosphere = 1.01325e5 Pa = atm = atmosphere         # since 1954
+    conventional_josephson_constant = 4.835979e14 Hz / V = K_J90  # since Jan 1990
+    conventional_von_klitzing_constant = 2.5812807e4 ohm = R_K90  # since Jan 1990
+    conventional_water_density = 1000 kg/m^3 = ρH2O
+    conventional_mercury_density = 13595.1 kg/m^3 = ρHg
 
-zeta = c / (cm/s) = ζ
-dirac_constant = ℎ / (2 * π) = ħ = hbar = atomic_unit_of_action = a_u_action
-avogadro_constant = avogadro_number * mol^-1 = N_A
-molar_gas_constant = k * N_A = R
-faraday_constant = e * N_A
-conductance_quantum = 2 * e ** 2 / ℎ = G_0
-magnetic_flux_quantum = ℎ / (2 * e) = Φ_0 = Phi_0
-josephson_constant = 2 * e / ℎ = K_J
-von_klitzing_constant = ℎ / e ** 2 = R_K
-stefan_boltzmann_constant = 2 / 15 * π ** 5 * k ** 4 / (ℎ ** 3 * c ** 2) = σ = sigma
-first_radiation_constant = 2 * π * ℎ * c ** 2 = c_1
-second_radiation_constant = ℎ * c / k = c_2
-wien_wavelength_displacement_law_constant = ℎ * c / (k * wien_x)
-wien_frequency_displacement_law_constant = wien_u * k / ℎ
+    #### DERIVED EXACT CONSTANTS ####
+    # Floating-point conversion may introduce inaccuracies
 
-#### MEASURED CONSTANTS ####
-# Recommended CODATA-2022 values
-# To some extent, what is measured and what is derived is a bit arbitrary.
-# The choice of measured constants is based on convenience and on available uncertainty.
-# The uncertainty in the last significant digits is given in parentheses as a comment.
+    zeta = c / (cm/s) = ζ
+    dirac_constant = ℎ / (2 * π) = ħ = hbar = atomic_unit_of_action = a_u_action
+    avogadro_constant = avogadro_number * mol^-1 = N_A
+    molar_gas_constant = k * N_A = R
+    faraday_constant = e * N_A
+    conductance_quantum = 2 * e ** 2 / ℎ = G_0
+    magnetic_flux_quantum = ℎ / (2 * e) = Φ_0 = Phi_0
+    josephson_constant = 2 * e / ℎ = K_J
+    von_klitzing_constant = ℎ / e ** 2 = R_K
+    stefan_boltzmann_constant = 2 / 15 * π ** 5 * k ** 4 / (ℎ ** 3 * c ** 2) = σ = sigma
+    first_radiation_constant = 2 * π * ℎ * c ** 2 = c_1
+    second_radiation_constant = ℎ * c / k = c_2
+    wien_wavelength_displacement_law_constant = ℎ * c / (k * wien_x)
+    wien_frequency_displacement_law_constant = wien_u * k / ℎ
 
-newtonian_constant_of_gravitation = 6.67430e-11 m^3/(kg s^2) = _ = gravitational_constant  # (15)
-rydberg_constant = 1.0973731568157e7 * m^-1 = R_∞ = R_inf                                  # (12)
-electron_g_factor = -2.00231930436092 = g_e                                                # (36)
-atomic_mass_constant = 1.66053906892e-27 kg = m_u                                          # (52)
-electron_mass = 9.1093837139e-31 kg = m_e = atomic_unit_of_mass = a_u_mass                 # (28)
-proton_mass = 1.67262192595e-27 kg = m_p                                                   # (52)
-neutron_mass = 1.67492750056e-27 kg = m_n                                                  # (85)
-x_unit_Cu = 1.00207697e-13 m = Xu_Cu                                                       # (28)
-x_unit_Mo = 1.00209952e-13 m = Xu_Mo                                                       # (53)
-angstrom_star = 1.00001495e-10 m = Å_star                                                  # (90)
+    #### MEASURED CONSTANTS ####
+    # Recommended CODATA-2022 values
+    # To some extent, what is measured and what is derived is a bit arbitrary.
+    # The choice of measured constants is based on convenience and on available uncertainty.
+    # The uncertainty in the last significant digits is given in parentheses as a comment.
 
-# Mass densities
-water_density_4C = 999.972 kg/m^3 = ρH2O_4C				# approximate
-water_density_60F = 999.001 kg/m^3 = ρH2O_60F			# approximate
-mercury_density_0C = 13595.1 kg/m^3 = ρHg_0C			# approximate
-mercury_density_32F = 13595.1 kg/m^3 = ρHg_32F			# approximate
-mercury_density_60F = 13556.8 kg/m^3 = ρHg_60F			# approximate
+    newtonian_constant_of_gravitation = 6.67430e-11 m^3/(kg s^2) = _ = gravitational_constant  # (15)
+    rydberg_constant = 1.0973731568157e7 * m^-1 = R_∞ = R_inf                                  # (12)
+    electron_g_factor = -2.00231930436092 = g_e                                                # (36)
+    atomic_mass_constant = 1.66053906892e-27 kg = m_u                                          # (52)
+    electron_mass = 9.1093837139e-31 kg = m_e = atomic_unit_of_mass = a_u_mass                 # (28)
+    proton_mass = 1.67262192595e-27 kg = m_p                                                   # (52)
+    neutron_mass = 1.67492750056e-27 kg = m_n                                                  # (85)
+    x_unit_Cu = 1.00207697e-13 m = Xu_Cu                                                       # (28)
+    x_unit_Mo = 1.00209952e-13 m = Xu_Mo                                                       # (53)
+    angstrom_star = 1.00001495e-10 m = Å_star                                                  # (90)
 
-#### DERIVED CONSTANTS ####
+    # Mass densities
+    water_density_4C = 999.972 kg/m^3 = ρH2O_4C				# approximate
+    water_density_60F = 999.001 kg/m^3 = ρH2O_60F			# approximate
+    mercury_density_0C = 13595.1 kg/m^3 = ρHg_0C			# approximate
+    mercury_density_32F = 13595.1 kg/m^3 = ρHg_32F			# approximate
+    mercury_density_60F = 13556.8 kg/m^3 = ρHg_60F			# approximate
 
-fine_structure_constant = (2 * ℎ * R_inf / (m_e * c)) ** 0.5 = α = alpha
-vacuum_permeability = 2 * α * ℎ / (e ** 2 * c) = µ_0 = mu_0 = mu0 = magnetic_constant
-vacuum_permittivity = e ** 2 / (2 * α * ℎ * c) = ε_0 = epsilon_0 = eps_0 = eps0 = electric_constant
-impedance_of_free_space = 2 * α * ℎ / e ** 2 = Z_0 = characteristic_impedance_of_vacuum
-coulomb_constant = α * hbar * c / e ** 2 = k_C
-classical_electron_radius = α * hbar / (m_e * c) = r_e
-thomson_cross_section = 8 / 3 * π * r_e ** 2 = σ_e = sigma_e
+    #### DERIVED CONSTANTS ####
+
+    fine_structure_constant = (2 * ℎ * R_inf / (m_e * c)) ** 0.5 = α = alpha
+    vacuum_permeability = 2 * α * ℎ / (e ** 2 * c) = µ_0 = mu_0 = mu0 = magnetic_constant
+    vacuum_permittivity = e ** 2 / (2 * α * ℎ * c) = ε_0 = epsilon_0 = eps_0 = eps0 = electric_constant
+    impedance_of_free_space = 2 * α * ℎ / e ** 2 = Z_0 = characteristic_impedance_of_vacuum
+    coulomb_constant = α * hbar * c / e ** 2 = k_C
+    classical_electron_radius = α * hbar / (m_e * c) = r_e
+    thomson_cross_section = 8 / 3 * π * r_e ** 2 = σ_e = sigma_e
+
+@end

--- a/pint/facets/group/objects.py
+++ b/pint/facets/group/objects.py
@@ -83,6 +83,9 @@ class Group(SharedRegistryObject):
         #: None indicates that the cache has been invalidated.
         self._computed_members: frozenset[str] | None = None
 
+    def __dir__(self) -> list[str]:
+        return sorted(self.members)
+
     @property
     def members(self) -> frozenset[str]:
         """Names of the units that are members of the group.

--- a/pint/facets/group/objects.py
+++ b/pint/facets/group/objects.py
@@ -228,5 +228,7 @@ class Group(SharedRegistryObject):
         if item in units_dict:
             canonical = units_dict[item].name
             if canonical in self._REGISTRY.constants.members:
-                return self._REGISTRY.Quantity(*self._REGISTRY.get_base_units(canonical))
+                return self._REGISTRY.Quantity(
+                    *self._REGISTRY.get_base_units(canonical)
+                )
         return getattr(self._REGISTRY, item)

--- a/pint/facets/group/objects.py
+++ b/pint/facets/group/objects.py
@@ -221,4 +221,6 @@ class Group(SharedRegistryObject):
 
     def __getattr__(self, item: str):
         getattr_maybe_raise(self, item)
-        return self._REGISTRY
+        if item in self._REGISTRY.constants.members:
+            return self._REGISTRY.Quantity(*self._REGISTRY.get_base_units(item))
+        return getattr(self._REGISTRY, item)

--- a/pint/facets/group/objects.py
+++ b/pint/facets/group/objects.py
@@ -224,6 +224,9 @@ class Group(SharedRegistryObject):
 
     def __getattr__(self, item: str):
         getattr_maybe_raise(self, item)
-        if item in self._REGISTRY.constants.members:
-            return self._REGISTRY.Quantity(*self._REGISTRY.get_base_units(item))
+        units_dict = self._REGISTRY._units
+        if item in units_dict:
+            canonical = units_dict[item].name
+            if canonical in self._REGISTRY.constants.members:
+                return self._REGISTRY.Quantity(*self._REGISTRY.get_base_units(canonical))
         return getattr(self._REGISTRY, item)

--- a/pint/facets/group/registry.py
+++ b/pint/facets/group/registry.py
@@ -96,6 +96,11 @@ class GenericGroupRegistry(
         except KeyError as e:
             raise errors.DefinitionSyntaxError(f"unknown dimension {e} in context")
 
+    @property
+    def constants(self) -> objects.Group:
+        """Return the constants group."""
+        return self.get_group("constants", create_if_needed=False)
+
     def get_group(self, name: str, create_if_needed: bool = True) -> objects.Group:
         """Return a Group.
 

--- a/pint/facets/system/objects.py
+++ b/pint/facets/system/objects.py
@@ -213,5 +213,3 @@ class Lister:
     def __getattr__(self, item: str) -> Any:
         getattr_maybe_raise(self, item)
         return self.d[item]
-
-

--- a/pint/facets/system/objects.py
+++ b/pint/facets/system/objects.py
@@ -75,12 +75,12 @@ class System(SharedRegistryObject):
     def __dir__(self):
         return list(self.members)
 
+    @property
+    def constants(self) -> "SystemConstantsAccessor":
+        return SystemConstantsAccessor(self._REGISTRY, self.name)
+
     def __getattr__(self, item: str) -> Any:
         getattr_maybe_raise(self, item)
-        if item in self._REGISTRY.get_group("constants").members:
-            return self._REGISTRY.Quantity(
-                *self._REGISTRY.get_base_units(item, system=self.name)
-            )
         u = getattr(self._REGISTRY, self.name + "_" + item, None)
         if u is not None:
             return u
@@ -217,3 +217,35 @@ class Lister:
     def __getattr__(self, item: str) -> Any:
         getattr_maybe_raise(self, item)
         return self.d[item]
+
+
+class SystemConstantsAccessor:
+    """Provides access to physical constants as Quantities in a specific system's base units.
+
+    Example::
+
+        ureg.sys.imperial.constants.speed_of_light  # <Quantity(327857018.8, 'yard / second')>
+    """
+
+    def __init__(self, registry, system_name: str):
+        object.__setattr__(self, "_registry", registry)
+        object.__setattr__(self, "_system_name", system_name)
+
+    def __dir__(self) -> list:
+        registry = object.__getattribute__(self, "_registry")
+        return sorted(registry.constants.members)
+
+    def __getattr__(self, item: str):
+        registry = object.__getattribute__(self, "_registry")
+        system_name = object.__getattribute__(self, "_system_name")
+
+        units_dict = registry._units
+        if item not in units_dict:
+            raise AttributeError(f"'{item}' is not a known constant")
+
+        canonical = units_dict[item].name
+        if canonical not in registry.constants.members:
+            raise AttributeError(f"'{item}' is not a physical constant")
+
+        factor, base_units = registry.get_base_units(canonical, system=system_name)
+        return registry.Quantity(factor, base_units)

--- a/pint/facets/system/objects.py
+++ b/pint/facets/system/objects.py
@@ -77,6 +77,8 @@ class System(SharedRegistryObject):
 
     def __getattr__(self, item: str) -> Any:
         getattr_maybe_raise(self, item)
+        if item in self._REGISTRY.get_group("constants").members:
+            return self._REGISTRY.Quantity(*self._REGISTRY.get_base_units(item, system=self.name))
         u = getattr(self._REGISTRY, self.name + "_" + item, None)
         if u is not None:
             return u

--- a/pint/facets/system/objects.py
+++ b/pint/facets/system/objects.py
@@ -75,10 +75,6 @@ class System(SharedRegistryObject):
     def __dir__(self):
         return list(self.members)
 
-    @property
-    def constants(self) -> "SystemConstantsAccessor":
-        return SystemConstantsAccessor(self._REGISTRY, self.name)
-
     def __getattr__(self, item: str) -> Any:
         getattr_maybe_raise(self, item)
         u = getattr(self._REGISTRY, self.name + "_" + item, None)
@@ -219,33 +215,3 @@ class Lister:
         return self.d[item]
 
 
-class SystemConstantsAccessor:
-    """Provides access to physical constants as Quantities in a specific system's base units.
-
-    Example::
-
-        ureg.sys.imperial.constants.speed_of_light  # <Quantity(327857018.8, 'yard / second')>
-    """
-
-    def __init__(self, registry, system_name: str):
-        object.__setattr__(self, "_registry", registry)
-        object.__setattr__(self, "_system_name", system_name)
-
-    def __dir__(self) -> list:
-        registry = object.__getattribute__(self, "_registry")
-        return sorted(registry.constants.members)
-
-    def __getattr__(self, item: str):
-        registry = object.__getattribute__(self, "_registry")
-        system_name = object.__getattribute__(self, "_system_name")
-
-        units_dict = registry._units
-        if item not in units_dict:
-            raise AttributeError(f"'{item}' is not a known constant")
-
-        canonical = units_dict[item].name
-        if canonical not in registry.constants.members:
-            raise AttributeError(f"'{item}' is not a physical constant")
-
-        factor, base_units = registry.get_base_units(canonical, system=system_name)
-        return registry.Quantity(factor, base_units)

--- a/pint/facets/system/objects.py
+++ b/pint/facets/system/objects.py
@@ -78,7 +78,9 @@ class System(SharedRegistryObject):
     def __getattr__(self, item: str) -> Any:
         getattr_maybe_raise(self, item)
         if item in self._REGISTRY.get_group("constants").members:
-            return self._REGISTRY.Quantity(*self._REGISTRY.get_base_units(item, system=self.name))
+            return self._REGISTRY.Quantity(
+                *self._REGISTRY.get_base_units(item, system=self.name)
+            )
         u = getattr(self._REGISTRY, self.name + "_" + item, None)
         if u is not None:
             return u

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1477,7 +1477,6 @@ def test_issue2256_2():
     assert f"{q:^}" == "2.3e-06 kilogram ** -1 * meter ** 3 * second ** -2"
 
 
-
 def test_issue1078():
     """ureg.constants.<name> returns a Quantity; ureg.<name> returns a Unit."""
     ureg = UnitRegistry()

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1475,3 +1475,12 @@ def test_issue2256_2():
     assert f"{q:~P}" == "2.3×10⁻⁶ m³/kg/s²"
     assert f"{q:~^P}" == "2.3×10⁻⁶ kg⁻¹·m³·s⁻²"
     assert f"{q:^}" == "2.3e-06 kilogram ** -1 * meter ** 3 * second ** -2"
+
+
+
+def test_issue1078():
+    """ureg.constants.<name> returns a Quantity; ureg.<name> returns a Unit."""
+    ureg = UnitRegistry()
+
+    assert isinstance(ureg.constants.speed_of_light, ureg.Quantity)
+    assert isinstance(ureg.speed_of_light, ureg.Unit)

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1477,9 +1477,10 @@ def test_issue2256_2():
     assert f"{q:^}" == "2.3e-06 kilogram ** -1 * meter ** 3 * second ** -2"
 
 
-def test_issue1078():
+@pytest.mark.parametrize("name", ["speed_of_light", "c"])
+def test_issue1078(name):
     """ureg.constants.<name> returns a Quantity; ureg.<name> returns a Unit."""
     ureg = UnitRegistry()
 
-    assert isinstance(ureg.constants.speed_of_light, ureg.Quantity)
-    assert isinstance(ureg.speed_of_light, ureg.Unit)
+    assert isinstance(getattr(ureg.constants, name), ureg.Quantity)
+    assert isinstance(getattr(ureg, name), ureg.Unit)


### PR DESCRIPTION
## Summary

- Adds `ureg.constants` accessor for convenient access to physical constants
- Adds `__dir__` to `Group` for autocomplete support

Closes #1078
