### PR TITLE
Improve type annotations for `PlainQuantity`

### DIFF
--- a/pint/delegates/formatter/_compound_unit_helpers.py
+++ b/pint/delegates/formatter/_compound_unit_helpers.py
@@ -46,7 +46,7 @@ SortFunc: TypeAlias = Callable[
 ]
 
 
-class BabelKwds(TypedDict):
+class BabelKwds(TypedDict, total=False):
     """Babel related keywords used in formatters."""
 
     use_plural: bool

--- a/pint/errors.py
+++ b/pint/errors.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 
 import typing as ty
 
+if ty.TYPE_CHECKING:
+    from .facets.plain.unit import UnitsContainer as UnitsContainerT
+
 OFFSET_ERROR_DOCS_HTML = "https://pint.readthedocs.io/en/stable/user/nonmult.html"
 LOG_ERROR_DOCS_HTML = "https://pint.readthedocs.io/en/stable/user/log_units.html"
 
@@ -166,16 +169,16 @@ class DimensionalityError(PintTypeError):
 
     units1: ty.Any
     units2: ty.Any
-    dim1: str = ""
-    dim2: str = ""
+    dim1: "str | UnitsContainerT" = ""
+    dim2: "str | UnitsContainerT" = ""
     extra_msg: str = ""
 
     def __init__(
         self,
         units1: ty.Any,
         units2: ty.Any,
-        dim1: str = "",
-        dim2: str = "",
+        dim1: "str | UnitsContainerT" = "",
+        dim2: "str | UnitsContainerT" = "",
         extra_msg: str = "",
     ) -> None:
         self.units1 = units1

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -18,6 +18,9 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Generic,
+    SupportsComplex,
+    SupportsFloat,
+    SupportsInt,
     TypeVar,
     overload,
 )
@@ -560,7 +563,7 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
 
         return None
 
-    def to_base_units(self, system=None) -> PlainQuantity[MagnitudeT]:
+    def to_base_units(self, system=None) -> Self:
         """Return PlainQuantity rescaled to plain units.
 
         Parameters
@@ -588,17 +591,17 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
     ito_unprefixed = qto.ito_unprefixed
 
     # Mathematical operations
-    def __int__(self) -> int:
+    def __int__(self: PlainQuantity[SupportsInt]) -> int:
         if self.dimensionless:
             return int(self._convert_magnitude_not_inplace(UnitsContainer()))
         raise DimensionalityError(self._units, "dimensionless")
 
-    def __float__(self) -> float:
+    def __float__(self: PlainQuantity[SupportsFloat]) -> float:
         if self.dimensionless:
             return float(self._convert_magnitude_not_inplace(UnitsContainer()))
         raise DimensionalityError(self._units, "dimensionless")
 
-    def __complex__(self) -> complex:
+    def __complex__(self: PlainQuantity[SupportsComplex]) -> complex:
         if self.dimensionless:
             return complex(self._convert_magnitude_not_inplace(UnitsContainer()))
         raise DimensionalityError(self._units, "dimensionless")
@@ -1310,16 +1313,16 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
             new_self = self.to_root_units()
             return other**new_self._magnitude
 
-    def __abs__(self) -> PlainQuantity[MagnitudeT]:
+    def __abs__(self) -> Self:
         return self.__class__(abs(self._magnitude), self._units)
 
     def __round__(self, ndigits: int | None = None) -> PlainQuantity[int]:
         return self.__class__(round(self._magnitude, ndigits), self._units)
 
-    def __pos__(self) -> PlainQuantity[MagnitudeT]:
+    def __pos__(self) -> Self:
         return self.__class__(operator.pos(self._magnitude), self._units)
 
-    def __neg__(self) -> PlainQuantity[MagnitudeT]:
+    def __neg__(self) -> Self:
         return self.__class__(operator.neg(self._magnitude), self._units)
 
     @check_implemented

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -164,24 +164,18 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
         return _unpickle_quantity, (PlainQuantity, self.magnitude, self._units)
 
     @overload
-    def __new__(
-        cls, value: MagnitudeT, units: UnitLike | None = None
-    ) -> PlainQuantity[MagnitudeT]: ...
+    def __new__(cls, value: MagnitudeT, units: UnitLike | None = None) -> Self: ...
 
     @overload
-    def __new__(
-        cls, value: str, units: UnitLike | None = None
-    ) -> PlainQuantity[Any]: ...
+    def __new__(cls, value: str, units: UnitLike | None = None) -> Self: ...
 
     @overload
     def __new__(  # type: ignore[misc]
         cls, value: Sequence[ScalarT], units: UnitLike | None = None
-    ) -> PlainQuantity[Any]: ...
+    ) -> Self: ...
 
     @overload
-    def __new__(
-        cls, value: PlainQuantity[Any], units: UnitLike | None = None
-    ) -> PlainQuantity[Any]: ...
+    def __new__(cls, value: Self, units: UnitLike | None = None) -> Self: ...
 
     def __new__(cls, value, units=None):
         if is_upcast_type(type(value)):
@@ -244,11 +238,11 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
 
         return it_outer()
 
-    def __copy__(self) -> PlainQuantity[MagnitudeT]:
+    def __copy__(self) -> Self:
         ret = self.__class__(copy.copy(self._magnitude), self._units)
         return ret
 
-    def __deepcopy__(self, memo) -> PlainQuantity[MagnitudeT]:
+    def __deepcopy__(self, memo) -> Self:
         ret = self.__class__(
             copy.deepcopy(self._magnitude, memo), copy.deepcopy(self._units, memo)
         )
@@ -411,7 +405,7 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
         return cls(a, units)
 
     @classmethod
-    def from_tuple(cls, tup):
+    def from_tuple(cls, tup) -> Self:
         for units_tup in tup[1]:
             cls._REGISTRY.get_name(units_tup[0])
         return cls(tup[0], cls._REGISTRY.UnitsContainer(tup[1]))

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -14,10 +14,12 @@ import locale
 import numbers
 import operator
 from collections.abc import Callable, Iterable, Iterator, Sequence
+from types import NotImplementedType
 from typing import (
     TYPE_CHECKING,
     Any,
     Generic,
+    Self,
     SupportsComplex,
     SupportsFloat,
     SupportsInt,
@@ -28,7 +30,6 @@ from typing import (
 from ..._typing import Magnitude, QuantityOrUnitLike, Scalar, UnitLike
 from ...compat import (
     HAS_NUMPY,
-    Self,
     _to_magnitude,
     deprecated,
     eq,
@@ -180,7 +181,7 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
     @overload
     def __new__(cls, value: Self, units: UnitLike | None = None) -> Self: ...
 
-    def __new__(cls, value, units=None):
+    def __new__(cls, value, units: UnitLike | None = None) -> Self:
         if is_upcast_type(type(value)):
             raise TypeError(f"PlainQuantity cannot wrap upcast type {type(value)}")
 
@@ -229,7 +230,7 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
 
         return inst
 
-    def __iter__(self: PlainQuantity[MagnitudeT]) -> Iterator[Any]:
+    def __iter__(self: PlainQuantity[Iterable]) -> Iterator[PlainQuantity[Any]]:
         # Make sure that, if self.magnitude is not iterable, we raise TypeError as soon
         # as one calls iter(self) without waiting for the first element to be drawn from
         # the iterator
@@ -287,7 +288,7 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
         """PlainQuantity's magnitude. Short form for `magnitude`"""
         return self._magnitude
 
-    def m_as(self, units) -> MagnitudeT:
+    def m_as(self, units: QuantityOrUnitLike | None) -> MagnitudeT:
         """PlainQuantity's magnitude expressed in particular units.
 
         Parameters
@@ -413,7 +414,7 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
             cls._REGISTRY.get_name(units_tup[0])
         return cls(tup[0], cls._REGISTRY.UnitsContainer(tup[1]))
 
-    def to_tuple(self) -> tuple[MagnitudeT, tuple[tuple[str, ...]]]:
+    def to_tuple(self) -> tuple[MagnitudeT, tuple[tuple[str, Scalar], ...]]:
         return self.m, tuple(self._units.items())
 
     def compatible_units(self, *contexts):
@@ -607,7 +608,9 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
         raise DimensionalityError(self._units, "dimensionless")
 
     @check_implemented
-    def _iadd_sub(self, other, op):
+    def _iadd_sub(
+        self, other: PlainQuantity | list | tuple | Magnitude, op
+    ) -> Self | NotImplementedType:
         """Perform addition or subtraction operation in-place and return the result.
 
         Parameters
@@ -619,7 +622,7 @@ class PlainQuantity(Generic[MagnitudeT], PrettyIPython, SharedRegistryObject):
 
         """
         if not self._check(other):
-            # other not from same Registry or not a PlainQuantity
+            # other not a PlainQuantity
             try:
                 other_magnitude = _to_magnitude(
                     other, self.force_ndarray, self.force_ndarray_like

--- a/pint/util.py
+++ b/pint/util.py
@@ -38,6 +38,8 @@ from .errors import DefinitionSyntaxError
 from .pint_eval import build_eval_tree
 
 if TYPE_CHECKING:
+    from typing_extensions import TypeIs
+
     from ._typing import QuantityOrUnitLike
     from .registry import UnitRegistry
 
@@ -960,7 +962,7 @@ class SharedRegistryObject:
             inst._REGISTRY = application_registry.get()
         return inst
 
-    def _check(self, other: Any) -> bool:
+    def _check(self, other: Any) -> "TypeIs[SharedRegistryObject]":
         """Check if the other object use a registry and if so that it is the
         same registry.
 


### PR DESCRIPTION
Closes #2281.

If `PlainQuantity`'s methods return `PlainQuantity`, subclass information is lost. To improve the status quo, two options are available:
1. When the return type matches the instance type (i.e. `PlainQuantity[MagnitudeT]`), just return `Self`;
2. When this is not possible, the only route I see is to copy method signatures in the relevant subclasses (e.g. `Quantity`).

For now, I have chosen to restrict myself to type methods that allow for option 1 to be used.

---
_**Edit**_: Other improvements:
- Marked the `BabelKwds` `TypedDict` non-total, because those keyword arguments are optional (`TypedDict`s are total by default, see the examples [in the spec](https://typing.python.org/en/latest/spec/typeddict.html))
- Changed annotations for the `DimensionalityError.dim*` attributes because inside of `PlainQuantity._iadd_sub(...)` they were assigned a `UnitsContainer` (i.e. `PlainQuantity.dimensionality`) instead of a `str` 