### PR TITLE
fix: match passed values case insensitively in parse_expression

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,6 +42,8 @@ Pint Changelog
 - `Quantity` now converts  `datetime.timedelta` objects to seconds or specified units when
   initializing a `Quantity` with a `datetime.timedelta` value.  (#1978)
 - Prefer the Greek mu `μ` (U+03BC) over the micro sign `µ` (U+00B5) as the default symbol for the `micro-` prefix and `micron`, matching the Unicode standard's recommendation (#2177)
+- Updated repr for various objects so that eval(repr(...))) works (#1495)
+- Fix `parse_expression` not matching passed values case insensitively when `case_sensitive=False` (#800)
 
 0.25.3 (2026-03-19)
 -------------------

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -1393,6 +1393,13 @@ class GenericPlainRegistry[QuantityT: PlainQuantity, UnitT: PlainUnit](
             elif token_text in values:
                 return self.Quantity(values[token_text])
             else:
+                case_insensitive = case_sensitive is False or (
+                    case_sensitive is None and not self.case_sensitive
+                )
+                if case_insensitive:
+                    for name, value in values.items():
+                        if name.lower() == token_text.lower():
+                            return self.Quantity(value)
                 return self.Quantity(
                     1,
                     self.UnitsContainer(

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1666,3 +1666,15 @@ def test_issue2182():
     assert q != np.float64(5.0)
     assert np.float64(5.0) != q  # used to raise DimensionalityError
     assert np.array(5.0) != q  # used to raise DimensionalityError
+
+
+def test_issue800():
+    ureg = UnitRegistry()
+    assert ureg.parse_expression(
+        "Constant", case_sensitive=False, constant=95
+    ) == ureg.Quantity(95)
+    assert ureg.parse_expression(
+        "constant", case_sensitive=False, constant=95
+    ) == ureg.Quantity(95)
+    with pytest.raises(UndefinedUnitError):
+        ureg.parse_expression("Constant", constant=95)


### PR DESCRIPTION
- [x] Closes #800
- [x] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

When `case_sensitive=False`, `parse_expression` looked up `**values` keys with an exact-case match, so a token like `Constant` would fall through to a unit lookup and raise `UndefinedUnitError`. It now also matches the passed value names case insensitively.