### PR TITLE
Fix offset (affine) unit conversion of Decimal magnitudes (#2305)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.26.0 (unreleased)
 -------------------
 
+- Fix offset (affine) unit conversion of `Decimal` magnitudes raising `TypeError` from mixing `Decimal` with the float scale/offset (e.g. `Quantity(Decimal(10), "degC").to("K")`), and the mirror case of a plain `float` magnitude in a `Decimal` registry (#2305)
 - Add `system` parameter to `to_base_units` and `ito_base_units` to allow converting to the base units of a specific unit system (#2297)
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)
 - Drop support for Python 3.11 in favour of Python 3.14 (#2304)

--- a/pint/compat.py
+++ b/pint/compat.py
@@ -14,6 +14,7 @@ import math
 import sys
 from collections.abc import Callable, Iterable, Mapping
 from decimal import Decimal
+from fractions import Fraction
 from importlib import import_module
 from importlib.util import find_spec
 from numbers import Number
@@ -29,6 +30,27 @@ if sys.version_info >= (3, 13):
     from warnings import deprecated  # noqa
 else:
     from typing_extensions import deprecated  # noqa
+
+
+def coerce_scalar(value, scalar):
+    """Coerce a scalar (a conversion scale or offset) to be arithmetically
+    compatible with value (magnitude).
+
+    Decimal refuses arithmetic with float (both directions raise TypeError);
+    Fraction loses its type when combined with float. Promote the scalar to
+    match a Decimal/Fraction magnitude, and demote a Decimal scalar to float
+    when value is a plain float (the only case where float OP Decimal fails).
+    int OP Decimal works fine and is left unchanged.
+    """
+    if isinstance(value, Decimal):
+        if not isinstance(scalar, Decimal):
+            return Decimal(str(scalar))
+    elif isinstance(value, Fraction):
+        if not isinstance(scalar, Fraction):
+            return Fraction(str(scalar))
+    elif isinstance(value, float) and isinstance(scalar, Decimal):
+        return float(scalar)
+    return scalar
 
 
 def missing_dependency(

--- a/pint/facets/nonmultiplicative/definitions.py
+++ b/pint/facets/nonmultiplicative/definitions.py
@@ -9,10 +9,30 @@ pint.facets.nonmultiplicative.definitions
 from __future__ import annotations
 
 from dataclasses import dataclass
+from decimal import Decimal
 
 from ..._typing import Magnitude
 from ...compat import HAS_NUMPY, exp, log
 from ..plain import ScaleConverter
+
+
+def _matching_scalar(value: Magnitude, scalar):
+    """Coerce a scale/offset scalar to a type that can be combined with ``value``.
+
+    ``Decimal`` does not support arithmetic with ``float``, so an affine
+    conversion of a ``Decimal`` magnitude with float scale/offset (or of a
+    plain ``float`` magnitude in a ``Decimal`` registry) raises ``TypeError``.
+    Match the scalar to the magnitude: promote it to ``Decimal`` for a
+    ``Decimal`` magnitude, and demote a ``Decimal`` scalar to ``float`` for any
+    other magnitude. Other numeric types (float, complex, Fraction, numpy
+    arrays) already interoperate, so they are returned unchanged.
+    """
+    if isinstance(value, Decimal):
+        if not isinstance(scalar, Decimal):
+            return Decimal(str(scalar))
+    elif isinstance(scalar, Decimal):
+        return float(scalar)
+    return scalar
 
 
 @dataclass(frozen=True)
@@ -26,20 +46,24 @@ class OffsetConverter(ScaleConverter):
         return self.offset == 0
 
     def to_reference(self, value: Magnitude, inplace: bool = False) -> Magnitude:
+        scale = _matching_scalar(value, self.scale)
+        offset = _matching_scalar(value, self.offset)
         if inplace:
-            value *= self.scale
-            value += self.offset
+            value *= scale
+            value += offset
         else:
-            value = value * self.scale + self.offset
+            value = value * scale + offset
 
         return value
 
     def from_reference(self, value: Magnitude, inplace: bool = False) -> Magnitude:
+        scale = _matching_scalar(value, self.scale)
+        offset = _matching_scalar(value, self.offset)
         if inplace:
-            value -= self.offset
-            value /= self.scale
+            value -= offset
+            value /= scale
         else:
-            value = (value - self.offset) / self.scale
+            value = (value - offset) / scale
 
         return value
 

--- a/pint/facets/nonmultiplicative/definitions.py
+++ b/pint/facets/nonmultiplicative/definitions.py
@@ -9,30 +9,10 @@ pint.facets.nonmultiplicative.definitions
 from __future__ import annotations
 
 from dataclasses import dataclass
-from decimal import Decimal
 
 from ..._typing import Magnitude
-from ...compat import HAS_NUMPY, exp, log
+from ...compat import HAS_NUMPY, coerce_scalar, exp, log
 from ..plain import ScaleConverter
-
-
-def _matching_scalar(value: Magnitude, scalar):
-    """Coerce a scale/offset scalar to a type that can be combined with ``value``.
-
-    ``Decimal`` does not support arithmetic with ``float``, so an affine
-    conversion of a ``Decimal`` magnitude with float scale/offset (or of a
-    plain ``float`` magnitude in a ``Decimal`` registry) raises ``TypeError``.
-    Match the scalar to the magnitude: promote it to ``Decimal`` for a
-    ``Decimal`` magnitude, and demote a ``Decimal`` scalar to ``float`` for any
-    other magnitude. Other numeric types (float, complex, Fraction, numpy
-    arrays) already interoperate, so they are returned unchanged.
-    """
-    if isinstance(value, Decimal):
-        if not isinstance(scalar, Decimal):
-            return Decimal(str(scalar))
-    elif isinstance(scalar, Decimal):
-        return float(scalar)
-    return scalar
 
 
 @dataclass(frozen=True)
@@ -46,8 +26,9 @@ class OffsetConverter(ScaleConverter):
         return self.offset == 0
 
     def to_reference(self, value: Magnitude, inplace: bool = False) -> Magnitude:
-        scale = _matching_scalar(value, self.scale)
-        offset = _matching_scalar(value, self.offset)
+        # Decimal magnitudes can't mix with float scale/offset — promote to match.
+        scale = coerce_scalar(value, self.scale)
+        offset = coerce_scalar(value, self.offset)
         if inplace:
             value *= scale
             value += offset
@@ -57,8 +38,9 @@ class OffsetConverter(ScaleConverter):
         return value
 
     def from_reference(self, value: Magnitude, inplace: bool = False) -> Magnitude:
-        scale = _matching_scalar(value, self.scale)
-        offset = _matching_scalar(value, self.offset)
+        # Decimal magnitudes can't mix with float scale/offset — promote to match.
+        scale = coerce_scalar(value, self.scale)
+        offset = coerce_scalar(value, self.offset)
         if inplace:
             value -= offset
             value /= scale

--- a/pint/facets/nonmultiplicative/definitions.py
+++ b/pint/facets/nonmultiplicative/definitions.py
@@ -26,7 +26,7 @@ class OffsetConverter(ScaleConverter):
         return self.offset == 0
 
     def to_reference(self, value: Magnitude, inplace: bool = False) -> Magnitude:
-        # Decimal magnitudes can't mix with float scale/offset — promote to match.
+        # Decimal magnitudes can't mix with float scale/offset — coerce to match.
         scale = coerce_scalar(value, self.scale)
         offset = coerce_scalar(value, self.offset)
         if inplace:
@@ -38,7 +38,7 @@ class OffsetConverter(ScaleConverter):
         return value
 
     def from_reference(self, value: Magnitude, inplace: bool = False) -> Magnitude:
-        # Decimal magnitudes can't mix with float scale/offset — promote to match.
+        # Decimal magnitudes can't mix with float scale/offset — coerce to match.
         scale = coerce_scalar(value, self.scale)
         offset = coerce_scalar(value, self.offset)
         if inplace:

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -59,7 +59,7 @@ from ..._typing import (
     Scalar,
     UnitLike,
 )
-from ...compat import deprecated
+from ...compat import coerce_scalar, deprecated
 from ...errors import (
     DimensionalityError,
     OffsetUnitCalculusError,
@@ -1149,12 +1149,8 @@ class GenericPlainRegistry[QuantityT: PlainQuantity, UnitT: PlainUnit](
         if isinstance(factor, DimensionalityError):
             raise factor
 
-        # factor is type float and if our magnitude is type Decimal then
-        # must first convert to Decimal before we can '*' the values
-        if isinstance(value, Decimal):
-            factor = Decimal(str(factor))
-        elif isinstance(value, Fraction):
-            factor = Fraction(str(factor))
+        # Decimal/Fraction magnitudes can't mix with float — coerce to match.
+        factor = coerce_scalar(value, factor)
 
         if inplace:
             value *= factor

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1475,3 +1475,36 @@ def test_issue2256_2():
     assert f"{q:~P}" == "2.3×10⁻⁶ m³/kg/s²"
     assert f"{q:~^P}" == "2.3×10⁻⁶ kg⁻¹·m³·s⁻²"
     assert f"{q:^}" == "2.3e-06 kilogram ** -1 * meter ** 3 * second ** -2"
+
+
+def test_issue2305():
+    # Offset (affine) conversion of a Decimal magnitude must not raise
+    # TypeError from mixing Decimal with the float scale/offset.
+    from decimal import Decimal
+
+    ureg = UnitRegistry()
+
+    # to_reference (degC -> K): adds the offset
+    q = ureg.Quantity(Decimal(10), "degC").to("K")
+    assert q.magnitude == Decimal("283.15")
+    assert isinstance(q.magnitude, Decimal)
+
+    # from_reference (K -> degC): subtracts the offset
+    q = ureg.Quantity(Decimal(300), "kelvin").to("degC")
+    assert q.magnitude == Decimal("26.85")
+    assert isinstance(q.magnitude, Decimal)
+
+    # scale and offset together (degF): the Decimal result tracks the float
+    # scale (5/9), so compare with a tolerance like the float path does
+    degf = ureg.Quantity(Decimal(32), "degF").to("K").magnitude
+    assert isinstance(degf, Decimal)
+    assert abs(float(degf) - 273.15) < 1e-9
+
+    # float magnitudes are unaffected
+    assert ureg.Quantity(10.0, "degC").to("K").magnitude == 273.15 + 10.0
+
+    # and in a Decimal registry, float magnitudes still convert (no longer
+    # the "problem just moves around" reported in the issue)
+    ureg_dec = UnitRegistry(non_int_type=Decimal)
+    assert ureg_dec.Quantity(10.0, "degC").to("K").magnitude == 283.15
+    assert ureg_dec.Quantity(Decimal(10), "degC").to("K").magnitude == Decimal("283.15")


### PR DESCRIPTION
Fixes #2305.

## Problem

Converting a `Quantity` with a `Decimal` magnitude across an affine (offset) unit raises `TypeError`:

```python
from pint import UnitRegistry
from decimal import Decimal

ureg = UnitRegistry()
ureg.Quantity(Decimal(10), "degC").to("K")
# TypeError: unsupported operand type(s) for +: 'decimal.Decimal' and 'float'
```

`OffsetConverter.to_reference` / `from_reference` combine the magnitude with `self.scale` and `self.offset` directly:

```python
value = value * self.scale + self.offset
```

The scale and offset are parsed as `float`, and `Decimal` does not support arithmetic with `float`, so the conversion fails (`*` for units with a non-unit scale like `degF`, `+`/`-` for the offset, in both directions).

Setting `non_int_type=Decimal` (as suggested in the issue) only moves the problem: scale/offset then become `Decimal`, so `Decimal` magnitudes work but plain `float` magnitudes fail instead.

## Fix

Coerce the scale/offset to a type compatible with the magnitude before the arithmetic (`_matching_scalar`): promote to `Decimal` for a `Decimal` magnitude, and demote a `Decimal` scale/offset to `float` for any other magnitude. Other numeric types (`float`, `complex`, `Fraction`, numpy arrays) already interoperate and are untouched, so this is a no-op for the common case. `Decimal` magnitudes now keep their type through the conversion, and the mirror `float`-in-a-`Decimal`-registry case works too.

## Tests

Added `test_issue2305` covering `degC`/`degF`/`K` conversions of `Decimal` magnitudes in both directions, the float-in-Decimal-registry case, and that float magnitudes are unaffected. Fails on `master` (TypeError), passes here.

`test_issues.py`, `test_converters.py`, `test_non_int.py`, `test_numpy.py`, `test_quantity.py` all pass (no regressions). `ruff check` and `ruff format` clean.