### PR TITLE
Support matmul for non numpy matrices

### DIFF
--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -1043,7 +1043,7 @@ class PlainQuantity[MagnitudeT: Magnitude](PrettyIPython, SharedRegistryObject):
     __rmul__ = __mul__
 
     def __matmul__(self, other):
-        return np.matmul(self, other)
+        return self._mul_div(other, operator.matmul, operator.mul)
 
     __rmatmul__ = __matmul__
 


### PR DESCRIPTION
Replace np.matmul with common _mul_div, using matmul for the numbers and mul for the units.  
Allows eg scipy.sparse matrix @ vector.

- [X] Related: #859, #2157
- [X] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors
- [ ] The change is fully covered by automated unit tests  - *Should it be tested with eg a sparse matrix?*
- [ ] ~~Documented in docs/ as appropriate~~ - *not a new feature really*
- [ ] ~~Added an entry to the CHANGES file~~ - *not a new feature plus #859 was not mentioned to begin with*
