### PR TITLE
Fix parse_units cache never hit for symbol/prefixed spellings (#2320)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ Pint Changelog
 - Bump minimum numpy version to 2.0.0
 - Fix `Unit.__eq__` when comparing with strings using unit aliases (e.g. `Unit('metre') == 'meter'`) (#634)
 - Fix regression when using magnitude format specs in string formats (#2291)
+- Fix `parse_units` cache never being hit for symbol and prefixed spellings (e.g. `kg`, `kWh`, `ms`), making those very common lookups re-parse on every call (#2320)
 - Updated repr for various objects so that eval(repr(...))) works (#1495)
 
 0.25.3 (2026-03-19)

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -127,7 +127,9 @@ class RegistryCache:
         self.dimensionality: dict[UnitsContainer, UnitsContainer] = {}
 
         #: Cache the unit name associated to user input. ('mV' -> 'millivolt')
-        self.parse_unit: dict[str, UnitsContainer] = {}
+        #: Keyed on (input string, case_sensitive) because the same spelling can resolve
+        #: differently under each mode (e.g. "Meter" is undefined when case-sensitive).
+        self.parse_unit: dict[tuple[str, bool], UnitsContainer] = {}
 
         self.conversion_factor: dict[
             tuple[UnitsContainer, UnitsContainer], Scalar | DimensionalityError
@@ -1304,8 +1306,17 @@ class GenericPlainRegistry[QuantityT: PlainQuantity, UnitT: PlainUnit](
         # Issue #1097: it is possible, when a unit was defined while a different context
         # was active, that the unit is in self._cache.parse_unit but not in self._units.
         # If this is the case, force self._units to be repopulated.
-        if as_delta and input_string in cache and input_string in self._units:
-            return cache[input_string]
+        # Issue #2320: validate the cached result's canonical names rather than the raw
+        # input string. The input string can be a symbol ("kg") or prefixed form ("kWh",
+        # "ms") that is never a self._units key, so guarding on it left those (very common)
+        # spellings unable to ever hit the cache. The cached UnitsContainer always holds
+        # canonical names, which are self._units keys exactly while the definitions are live.
+        # The cache is keyed on (input, case_sensitive) so a case-insensitive result is not
+        # returned for a case-sensitive lookup of the same spelling.
+        if as_delta and (input_string, case_sensitive) in cache:
+            cached = cache[input_string, case_sensitive]
+            if all(name in self._units for name in cached):
+                return cached
 
         for p in self.preprocessors:
             input_string = p(input_string)
@@ -1334,7 +1345,7 @@ class GenericPlainRegistry[QuantityT: PlainQuantity, UnitT: PlainUnit](
             ret = ret.add(cname, value)
 
         if as_delta:
-            cache[input_string] = ret
+            cache[input_string, case_sensitive] = ret
 
         return ret
 

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -7,6 +7,7 @@ import math
 import pprint
 import subprocess
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -1475,3 +1476,25 @@ def test_issue2256_2():
     assert f"{q:~P}" == "2.3×10⁻⁶ m³/kg/s²"
     assert f"{q:~^P}" == "2.3×10⁻⁶ kg⁻¹·m³·s⁻²"
     assert f"{q:^}" == "2.3e-06 kilogram ** -1 * meter ** 3 * second ** -2"
+
+
+def test_issue2320():
+    # symbol ("kg") and prefixed ("kWh", "ms") spellings, plus the delta form of an
+    # offset unit, must be able to hit the parse_units cache. The previous cache-hit
+    # guard required the raw input to be a self._units key, which those spellings never
+    # are, so the populated cache entry was unreachable and every call re-parsed.
+    ureg = UnitRegistry()
+    for spelling in ("kg", "kWh", "ms", "degC**2"):
+        ureg.parse_units(spelling)  # prime the cache
+        with patch.object(
+            ParserHelper, "from_string", wraps=ParserHelper.from_string
+        ) as spy:
+            ureg.parse_units(spelling)
+        assert spy.call_count == 0, f"{spelling} re-parsed instead of hitting the cache"
+
+    # The cache must stay case-sensitivity aware: priming a case-insensitive lookup must
+    # not let the same spelling resolve under a case-sensitive lookup.
+    ureg = UnitRegistry()
+    assert ureg.parse_units("Meter", case_sensitive=False) == UnitsContainer(meter=1)
+    with pytest.raises(UndefinedUnitError):
+        ureg.parse_units("Meter", case_sensitive=True)


### PR DESCRIPTION
Fixes #2320.

### Problem

`PlainRegistry._parse_units_as_container` populates `self._cache.parse_unit` for every spelling, but the cache-hit guard required the raw input string to also be a `self._units` key:

```python
if as_delta and input_string in cache and input_string in self._units:
    return cache[input_string]
```

`self._units` holds canonical names and registered aliases, but **not** symbol forms (`kg` is the symbol of `kilogram`) nor prefixed forms (`kWh`, `ms`, `GB`). So for exactly the spellings most users write, the guard fails on every call and the full parse pipeline re-runs even though a cache entry exists. Since `ureg.kg` attribute access goes through the same path, every such access pays it. Reporter measured a ~20x penalty (≈0.7 µs cached vs ≈15 µs for `kg`).

### Fix

Validate the **cached result** instead of the raw input string. The cached `UnitsContainer` always holds canonical names, which are `self._units` keys exactly while the definitions are live, so this keeps the issue #1097 staleness protection (a unit removed after a context switch leaves its canonical name absent from `self._units`, so the cache correctly falls through and re-parses).

While doing so I found the cache was also not case-sensitivity aware: the key was the raw input only, and the old `input_string in self._units` guard had been incidentally masking that (a mis-cased spelling like `"Meter"` is never a `self._units` key). To keep `case_sensitive=True/False` correct, the cache is now keyed on `(input_string, case_sensitive)`.

### Verification

`kg`, `kWh`, `ms`, and `degC**2` now hit the cache (0 re-parses after priming, confirmed by spying on `ParserHelper.from_string`), dropping to ≈0.8 µs. New regression test `test_issue2320` covers both the cache-hit and the case-sensitivity behavior; it fails on `master` (`kg re-parsed instead of hitting the cache`) and passes here. Existing `test_issues`, `test_unit`, `test_contexts`, `test_quantity`, and `test_application_registry` suites stay green.