### PR TITLE
Fix wraps raising errors with VAR_POSITIONAL (*args) parameters (#2254)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.26.0 (unreleased)
 -------------------
 
+- Fix `wraps` raising `KeyError` when calling a `*args` function with 0 arguments, and `DimensionalityError` when calling it with more than one `Quantity` argument (#2254)
 - Fix offset (affine) unit conversion of `Decimal` magnitudes raising `TypeError` from mixing `Decimal` with the float scale/offset (e.g. `Quantity(Decimal(10), "degC").to("K")`), and the mirror case of a plain `float` magnitude in a `Decimal` registry (#2305)
 - Add `system` parameter to `to_base_units` and `ito_base_units` to allow converting to the base units of a specific unit system (#2297)
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)

--- a/pint/registry_helpers.py
+++ b/pint/registry_helpers.py
@@ -120,34 +120,77 @@ def _parse_wrap_args(args, registry=None):
     def _converter(ureg, sig, values, kw, strict):
         len_initial_values = len(values)
 
-        # pack kwargs
+        # pack kwargs, skipping VAR_POSITIONAL/VAR_KEYWORD params since they
+        # collect positional/keyword args and don't appear in kw themselves
         for i, param_name in enumerate(sig.parameters):
-            if i >= len_initial_values:
+            param = sig.parameters[param_name]
+            if i >= len_initial_values and param.kind not in (
+                Parameter.VAR_POSITIONAL,
+                Parameter.VAR_KEYWORD,
+            ):
                 values.append(kw[param_name])
+
+        # For VAR_POSITIONAL parameters: expand unit specs to cover all actual
+        # positional args passed beyond the single spec defined for *args.
+        local_args_as_uc = args_as_uc
+        local_defs_ndx = defs_args_ndx
+        local_dep_ndx = dependent_args_ndx
+        local_unit_ndx = unit_args_ndx
+
+        if len(values) > len(args_as_uc):
+            var_pos_ndx = next(
+                (
+                    i
+                    for i, pname in enumerate(sig.parameters)
+                    if sig.parameters[pname].kind == Parameter.VAR_POSITIONAL
+                ),
+                None,
+            )
+            if var_pos_ndx is not None:
+                local_args_as_uc = list(args_as_uc)
+                local_defs_ndx = set(defs_args_ndx)
+                local_dep_ndx = set(dependent_args_ndx)
+                local_unit_ndx = set(unit_args_ndx)
+
+                var_uc, _ = args_as_uc[var_pos_ndx]
+                for ndx in range(len(args_as_uc), len(values)):
+                    if var_pos_ndx in defs_args_ndx:
+                        # The first *args value defined the reference unit;
+                        # subsequent ones are dependent on it.
+                        local_args_as_uc.append((UnitsContainer({var_uc: 1}), True))
+                        local_dep_ndx.add(ndx)
+                    elif var_pos_ndx in dependent_args_ndx:
+                        local_args_as_uc.append(args_as_uc[var_pos_ndx])
+                        local_dep_ndx.add(ndx)
+                    else:
+                        local_args_as_uc.append(args_as_uc[var_pos_ndx])
+                        local_unit_ndx.add(ndx)
 
         values_by_name = {}
 
         # first pass: Grab named values
-        for ndx in defs_args_ndx:
+        for ndx in local_defs_ndx:
+            if ndx >= len(values):
+                continue
             value = values[ndx]
-            values_by_name[args_as_uc[ndx][0]] = value
+            values_by_name[local_args_as_uc[ndx][0]] = value
             values[ndx] = getattr(value, "_magnitude", value)
 
         # second pass: calculate derived values based on named values
-        for ndx in dependent_args_ndx:
+        for ndx in local_dep_ndx:
             value = values[ndx]
-            assert _replace_units(args_as_uc[ndx][0], values_by_name) is not None
+            assert _replace_units(local_args_as_uc[ndx][0], values_by_name) is not None
             values[ndx] = ureg._convert(
                 getattr(value, "_magnitude", value),
                 getattr(value, "_units", UnitsContainer({})),
-                _replace_units(args_as_uc[ndx][0], values_by_name),
+                _replace_units(local_args_as_uc[ndx][0], values_by_name),
             )
 
         # third pass: convert other arguments
-        for ndx in unit_args_ndx:
+        for ndx in local_unit_ndx:
             if isinstance(values[ndx], ureg.Quantity):
                 values[ndx] = ureg._convert(
-                    values[ndx]._magnitude, values[ndx]._units, args_as_uc[ndx][0]
+                    values[ndx]._magnitude, values[ndx]._units, local_args_as_uc[ndx][0]
                 )
             else:
                 if strict:
@@ -155,20 +198,26 @@ def _parse_wrap_args(args, registry=None):
                         # if the value is a string, we try to parse it
                         tmp_value = ureg.parse_expression(values[ndx])
                         values[ndx] = ureg._convert(
-                            tmp_value._magnitude, tmp_value._units, args_as_uc[ndx][0]
+                            tmp_value._magnitude,
+                            tmp_value._units,
+                            local_args_as_uc[ndx][0],
                         )
                     else:
                         raise ValueError(
                             "A wrapped function using strict=True requires "
                             "quantity or a string for all arguments with not None units. "
                             "(error found for {}, {})".format(
-                                args_as_uc[ndx][0], values[ndx]
+                                local_args_as_uc[ndx][0], values[ndx]
                             )
                         )
 
-        # unpack kwargs
+        # unpack kwargs, skipping VAR_POSITIONAL/VAR_KEYWORD
         for i, param_name in enumerate(sig.parameters):
-            if i >= len_initial_values:
+            param = sig.parameters[param_name]
+            if i >= len_initial_values and param.kind not in (
+                Parameter.VAR_POSITIONAL,
+                Parameter.VAR_KEYWORD,
+            ):
                 kw[param_name] = values[i]
 
         return values[:len_initial_values], kw, values_by_name

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1508,3 +1508,36 @@ def test_issue2305():
     ureg_dec = UnitRegistry(non_int_type=Decimal)
     assert ureg_dec.Quantity(10.0, "degC").to("K").magnitude == 283.15
     assert ureg_dec.Quantity(Decimal(10), "degC").to("K").magnitude == Decimal("283.15")
+
+
+def test_issue2254():
+    # wraps must handle functions with a VAR_POSITIONAL (*args) parameter.
+    # Previously calling with 0 args raised KeyError and calling with more
+    # than one Quantity argument raised DimensionalityError because the single
+    # unit spec was only applied to the first argument.
+    ureg = UnitRegistry()
+    Q_ = ureg.Quantity
+
+    # Plain sum with reference units: all *args share the same unit.
+    @ureg.wraps("=A", "=A")
+    def vsum(*values):
+        return sum(values)
+
+    # Single arg: existing behaviour must be preserved.
+    assert vsum(Q_(3, "m")) == Q_(3, "m")
+
+    # Multiple Quantity args of the same dimension are converted to the first
+    # arg's unit before the call and the result carries that unit.
+    result = vsum(Q_(1, "m"), Q_(200, "cm"))
+    assert result.magnitude == pytest.approx(3.0)
+    assert result.units == ureg.meter
+
+    # Plain numbers (no units) still work and return a dimensionless Quantity.
+    assert vsum(3, 4) == 7
+
+    # Fixed unit spec: convert every *arg to metres, return raw magnitude.
+    @ureg.wraps(None, "m")
+    def vsum_raw(*values):
+        return sum(values)
+
+    assert vsum_raw(Q_(1, "m"), Q_(200, "cm")) == pytest.approx(3.0)


### PR DESCRIPTION
## Problem

`ureg.wraps` fails in two distinct ways when wrapping a function whose parameter list contains `*args` (`VAR_POSITIONAL`):

**Calling with 0 arguments raises `KeyError`:**
```python
@ureg.wraps("=A", "=A")
def f(*values):
    return sum(values)

f()  # KeyError: 'values'
```
`_converter` iterated over `sig.parameters` and, for any index `i ≥ len(positional_values)`, attempted `values.append(kw[param_name])`.  A `VAR_POSITIONAL` parameter never appears in `kw`, so the lookup failed.

**Calling with multiple `Quantity` arguments raises `DimensionalityError`:**
```python
f(1 * ureg.meter, 200 * ureg.cm)  # DimensionalityError
```
`_parse_wrap_args` produced exactly one entry in `args_as_uc` (one spec per declared parameter). Only `values[0]` was processed by the unit-conversion passes; `values[1]` was left as a raw `Quantity` and forwarded to the function unchanged, causing `sum(1, Quantity(200, 'cm'))` to raise.

## Fix

Two targeted changes inside `_converter` (the closure returned by `_parse_wrap_args`):

1. **Skip `VAR_POSITIONAL`/`VAR_KEYWORD` in the kwargs-packing and kwargs-unpacking loops.** Variadic positional args are collected as a tuple in `values`, not as individual keyword args, so attempting `kw[param_name]` is always wrong for them.

2. **Expand the unit-spec tables for extra `*args` values.** When `len(values) > len(args_as_uc)` and the function has a `VAR_POSITIONAL` parameter, copy the unit spec for that parameter to every additional index. When the original spec was a reference definition (e.g. `"=A"`), the first `*args` value continues to define the reference unit and the extras become dependent on it, so they are all converted to a consistent unit before being forwarded.

## Tests

Regression test added in `pint/testsuite/test_issues.py::test_issue2254` covering:
- single `Quantity` arg (pre-existing behaviour preserved)
- two `Quantity` args of the same dimension but different units (new)
- plain scalars without units (new)
- fixed-unit spec with two args (new)

All existing `test_wraps` and `test_wrap_referencing` cases still pass.

Closes #2254