### PR TITLE
Let Context.redefine parse magnitudes with the registry's non_int_type

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.26.0 (unreleased)
 -------------------
 
+- Add a `non_int_type` parameter to `Context.redefine` so a context redefinition can be parsed with a registry's `non_int_type` (e.g. `decimal.Decimal`) instead of always `float`, which raised `TypeError` on conversion (#2301)
 - Fix offset (affine) unit conversion of `Decimal` magnitudes raising `TypeError` from mixing `Decimal` with the float scale/offset (e.g. `Quantity(Decimal(10), "degC").to("K")`), and the mirror case of a plain `float` magnitude in a `Decimal` registry (#2305)
 - Add `system` parameter to `to_base_units` and `ito_base_units` to allow converting to the base units of a specific unit system (#2297)
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)

--- a/docs/user/contexts.rst
+++ b/docs/user/contexts.rst
@@ -270,6 +270,11 @@ Programmatically:
     >>> q.to("J")
     1055.056 joule
 
+If the registry uses a non-default ``non_int_type`` (e.g. ``decimal.Decimal``), pass the
+same type to ``redefine`` (for example ``ctx.redefine("BTU = 1055 J",
+non_int_type=decimal.Decimal)``) so the redefinition is parsed compatibly with quantities
+created by that registry.
+
 Or with a definitions file::
 
     @context somecontract

--- a/pint/facets/context/objects.py
+++ b/pint/facets/context/objects.py
@@ -227,19 +227,21 @@ class Context:
         defaults.update(ctx_kwargs)
         return func(registry, value, **defaults)
 
-    def redefine(self, definition: str) -> None:
+    def redefine(self, definition: str, non_int_type: type = float) -> None:
         """Override the definition of a unit in the registry.
 
         Parameters
         ----------
         definition : str
             <unit> = <new definition>``, e.g. ``pound = 0.5 kg``
+        non_int_type : type
+            Numerical type used to parse the magnitudes in ``definition``. Pass the
+            registry's ``non_int_type`` (e.g. ``decimal.Decimal``) so the redefinition
+            is compatible with quantities created by that registry.
         """
         from ...delegates import ParserConfig, txt_defparser
 
-        # TODO: kept for backwards compatibility.
-        #       this is not a good idea as we have no way of known the correct non_int_type
-        cfg = ParserConfig(float)
+        cfg = ParserConfig(non_int_type)
         parser = txt_defparser.DefParser(cfg, None)
         pp = parser.parse_string(definition)
         for definition in parser.iter_parsed_project(pp):

--- a/pint/testsuite/test_contexts.py
+++ b/pint/testsuite/test_contexts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import decimal
 import itertools
 import logging
 import math
@@ -809,6 +810,23 @@ def test_redefine(subtests):
             assert asd.to("baz").magnitude == 4
 
         ureg.disable_contexts()
+
+
+def test_redefine_non_int_type():
+    # A redefinition parsed with the wrong numerical type crashes on conversion when
+    # the registry uses a non-float non_int_type, because the redefined unit's scale
+    # ends up mixing e.g. float and Decimal. See GH #2301.
+    ureg = UnitRegistry(non_int_type=decimal.Decimal)
+    ureg.define("CV = 2.6 L")
+
+    c = Context("columnvolume")
+    c.redefine("CV = 3.14 L", non_int_type=decimal.Decimal)
+    ureg.add_context(c)
+    ureg.enable_contexts("columnvolume")
+
+    converted = ureg.Quantity(decimal.Decimal("1.0"), "CV").to("L")
+    assert isinstance(converted.magnitude, decimal.Decimal)
+    assert converted.magnitude == decimal.Decimal("3.14")
 
 
 def test_define_nan():


### PR DESCRIPTION
Closes #2301

- [x] Executed `pre-commit run --all-files`
- [x] Covered by unit tests
- [x] Documented in docs/
- [x] Added a CHANGES entry

`Context.redefine` always parsed the definition with `ParserConfig(float)`, so redefining a unit on a `non_int_type=decimal.Decimal` registry produced a float scale and conversion blew up with `TypeError: unsupported operand type(s) for ** or pow(): 'float' and 'decimal.Decimal'`.

I added a `non_int_type` argument (default `float`) so the redefinition can be parsed with the registry's type — option 1 from the discussion, matching `Context.from_lines`.

One thing to note: it's opt-in, so the caller passes `non_int_type=decimal.Decimal`; it doesn't auto-inherit from the registry. If you'd rather it inherit, I can move the parsing into `add_context` instead — happy to switch.