### PR TITLE
Fix to_compact() crashing on units whose name is ambiguous with a prefix (dtex)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.26.0 (unreleased)
 -------------------
 
+- Fix `Quantity.to_compact()` raising `AssertionError` for units whose name is ambiguous with a prefixed unit (e.g. `dtex`) (#2246)
 - Fix offset (affine) unit conversion of `Decimal` magnitudes raising `TypeError` from mixing `Decimal` with the float scale/offset (e.g. `Quantity(Decimal(10), "degC").to("K")`), and the mirror case of a plain `float` magnitude in a `Decimal` registry (#2305)
 - Add `system` parameter to `to_base_units` and `ito_base_units` to allow converting to the base units of a specific unit system (#2297)
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)

--- a/pint/testsuite/test_infer_base_unit.py
+++ b/pint/testsuite/test_infer_base_unit.py
@@ -133,3 +133,13 @@ def test_volts(sess_registry):
     b = infer_base_unit(r)
     assert b == sess_registry.Quantity(1, "V").units
     helpers.assert_quantity_almost_equal(r, sess_registry.Quantity(1, "uV"))
+
+
+def test_infer_base_unit_ambiguous_prefixed_unit(sess_registry):
+    # "dtex" parses both as the registered unit dtex and as deci + tex, so
+    # parse_unit_name returns two candidates; infer_base_unit / to_compact must
+    # take the first (like Quantity._get_unprefixed) rather than assert and crash.
+    # See https://github.com/hgrecco/pint/issues/2246
+    q = sess_registry.Quantity(100, "dtex")
+    assert q.to_compact() == q
+    assert infer_base_unit(q) == sess_registry.Quantity(1, "dtex").units

--- a/pint/util.py
+++ b/pint/util.py
@@ -1086,7 +1086,10 @@ def infer_base_unit(
 
     for unit_name, power in original_units.items():
         candidates = registry.parse_unit_name(unit_name)
-        assert len(candidates) == 1
+        # A unit name can be parsed as more than one (prefix, unit, suffix)
+        # candidate when it collides with a prefixed unit (e.g. "dtex" is both
+        # the registered unit dtex and deci + tex); take the first, matching the
+        # sibling logic in Quantity._get_unprefixed (facets/plain/qto.py).
         _, base_unit, _ = candidates[0]
         d[base_unit] += power
 


### PR DESCRIPTION
## Summary

`Quantity.to_compact()` crashes with a bare `AssertionError` on a unit whose name is ambiguous with a prefixed unit:

```python
import pint
ureg = pint.UnitRegistry()
ureg.Quantity(100, "dtex").to_compact()
# AssertionError  (pint/util.py, infer_base_unit)
```

`to_compact()` calls `infer_base_unit`, which loops over the unit names and does `candidates = registry.parse_unit_name(unit_name); assert len(candidates) == 1`. For `dtex` the parser returns **two** candidates: `('', 'dtex', '')` (dtex is itself a registered unit, `dtex = decitex`) and `('deci', 'tex', '')`. `_dedup_candidates` cannot collapse them (it only drops a no-prefix name equal to the literal `prefix + unit` concatenation, and `deci` + `tex` = `decitex` != `dtex`), so `len(candidates) == 2` and the assert fires on a perfectly valid unit.

The sibling `Quantity._get_unprefixed` (`pint/facets/plain/qto.py`) handles the exact same `parse_unit_name` result by just taking `candidates[0]` with no assert, and a `TODO` there notes the two functions should be merged. This makes the assert an inconsistent oversight.

## Fix

Drop the assert and take `candidates[0]`, matching the sibling. `Quantity(100, "dtex").to_compact()` now returns `100 dtex`, and the documented `to_compact` examples are unchanged.

Fixes #2246.

## Test

`pint/testsuite/test_infer_base_unit.py::test_infer_base_unit_ambiguous_prefixed_unit` asserts `Quantity(100, "dtex").to_compact()` no longer raises and that `infer_base_unit` resolves it. Raises `AssertionError` before the fix, passes after. Added a `CHANGES` entry.