### PR TITLE
Constrain docs NumPy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ docs = [
   "scipy",
   "currencyconverter",
   "matplotlib",
-  "numpy",
+  "numpy<2.5",
   "xarray",
   "dask[complete]<2025.3.0",
   "optype[numpy]",


### PR DESCRIPTION
## Summary
- constrain the docs extra to `numpy<2.5`
- avoid resolving `sparse` through an old `numba`/`llvmlite` stack on Python 3.12

## Verification
- `env UV_CACHE_DIR=/tmp/uv-cache VIRTUAL_ENV=$PWD/.venv-rtd-check uv pip install --dry-run -e '.[docs]'` resolved `numpy==2.4.6`, `numba==0.66.0`, and `llvmlite==0.48.0`
- `env UV_CACHE_DIR=/tmp/uv-cache VIRTUAL_ENV=$PWD/.venv-rtd-check uv pip install -e '.[docs]'` completed successfully on Python 3.12.13
- `.venv-rtd-check/bin/python -c 'import tomllib; tomllib.load(open("pyproject.toml", "rb")); print("pyproject ok")'`

Note: a local Sphinx build progressed past dependency installation and notebook startup, but stopped because this machine does not have the Graphviz `dot` executable. ReadTheDocs installs Graphviz through `.readthedocs.yaml`.
