### PR TITLE
Honor negative-power unit format flag

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Pint Changelog
 -------------------
 
 - Fix offset (affine) unit conversion of `Decimal` magnitudes raising `TypeError` from mixing `Decimal` with the float scale/offset (e.g. `Quantity(Decimal(10), "degC").to("K")`), and the mirror case of a plain `float` magnitude in a `Decimal` registry (#2305)
+- Fix `format_unit()` to honor the `^` unit-format modifier for standalone units with negative powers (#2313)
 - Add `system` parameter to `to_base_units` and `ito_base_units` to allow converting to the base units of a specific unit system (#2297)
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)
 - Drop support for Python 3.11 in favour of Python 3.14 (#2304)

--- a/pint/delegates/formatter/full.py
+++ b/pint/delegates/formatter/full.py
@@ -135,7 +135,11 @@ class FullFormatter(BaseFormatter):
         uspec = uspec or self.default_format
         sort_func = sort_func or self.default_sort_func
         return self.get_formatter(uspec).format_unit(
-            unit, uspec, sort_func=sort_func, **babel_kwds
+            unit,
+            uspec,
+            sort_func=sort_func,
+            as_ratio=False if "^" in uspec else True,
+            **babel_kwds,
         )
 
     def format_quantity[MagnitudeT: Magnitude](

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1477,6 +1477,16 @@ def test_issue2256_2():
     assert f"{q:^}" == "2.3e-06 kilogram ** -1 * meter ** 3 * second ** -2"
 
 
+def test_issue2313():
+    ureg = UnitRegistry()
+
+    inverse_second = ureg.Unit("second") ** -1
+
+    assert f"{inverse_second:~P}" == "1/s"
+    assert f"{inverse_second:~^P}" == "s⁻¹"
+    assert f"{inverse_second:^}" == "second ** -1"
+
+
 def test_issue2305():
     # Offset (affine) conversion of a Decimal magnitude must not raise
     # TypeError from mixing Decimal with the float scale/offset.


### PR DESCRIPTION
## Summary
- pass `as_ratio=False` from `FullFormatter.format_unit()` when the unit format spec contains `^`
- add a regression test for standalone inverse units
- add a changelog entry for #2313

Fixes #2313.

## Verification
- `.venv-pint-test/bin/python -m pytest pint/testsuite/test_issues.py::test_issue2313 pint/testsuite/test_formatter.py -q`
- `.venv-pint-test/bin/python -m pytest pint/testsuite/test_issues.py -q`
- `.venv-pint-test/bin/python -m ruff check pint/delegates/formatter/full.py pint/testsuite/test_issues.py`
- `.venv-pint-test/bin/python -m ruff format --check pint/delegates/formatter/full.py pint/testsuite/test_issues.py`
