### PR TITLE
Fix wraps referenced units with integer arrays

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Pint Changelog
 -------------------
 
 - Fix offset (affine) unit conversion of `Decimal` magnitudes raising `TypeError` from mixing `Decimal` with the float scale/offset (e.g. `Quantity(Decimal(10), "degC").to("K")`), and the mirror case of a plain `float` magnitude in a `Decimal` registry (#2305)
+- Fix `UnitRegistry.wraps()` referenced return units with negative powers for integer NumPy array inputs (#2109)
 - Add `system` parameter to `to_base_units` and `ito_base_units` to allow converting to the base units of a specific unit system (#2297)
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)
 - Drop support for Python 3.11 in favour of Python 3.14 (#2304)

--- a/pint/registry_helpers.py
+++ b/pint/registry_helpers.py
@@ -39,11 +39,11 @@ def _replace_units(original_units, values_by_name):
     -------
 
     """
-    q = 1
+    q = UnitsContainer({})
     for arg_name, exponent in original_units.items():
-        q = q * values_by_name[arg_name] ** exponent
+        q *= getattr(values_by_name[arg_name], "_units", UnitsContainer({})) ** exponent
 
-    return getattr(q, "_units", UnitsContainer({}))
+    return q
 
 
 def _to_units_container(a, registry=None):

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -678,6 +678,15 @@ class TestRegistry(QuantityTestCase):
         assert g4(3.0 * ureg.meter, 2.0) == ureg("(3*meter)**2 * 2")
         assert g4(3.0, 2.0 * ureg.second) == ureg("3**2 * 2 * second")
 
+        def gfunc4(x, y):
+            return x / y
+
+        g5 = ureg.wraps("=A/B", ["=A", "=B"])(gfunc4)
+        helpers.assert_quantity_equal(
+            g5(np.array([1]) * ureg.angstrom, np.array([2]) * ureg.second),
+            np.array([0.5]) * ureg.angstrom / ureg.second,
+        )
+
     def test_check(self):
         def func(x):
             return x


### PR DESCRIPTION
## Summary

- derive referenced `wraps()` return units from argument units only
- avoid applying negative powers to integer NumPy array magnitudes while resolving units such as `=A/B`
- add regression coverage for integer array quantities in referenced return units

Fixes #2109

## Testing

- `.venv-pint-test/bin/python -m pytest pint/testsuite/test_unit.py -k test_wrap -q`
- `.venv-pint-test/bin/python -m pytest pint/testsuite/test_unit.py -q`
- `.venv-pint-test/bin/python -m ruff check pint/registry_helpers.py pint/testsuite/test_unit.py`
- `.venv-pint-test/bin/python -m ruff format --check pint/registry_helpers.py pint/testsuite/test_unit.py`
