### PR TITLE
Handle public units in quantity muldiv

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Pint Changelog
 -------------------
 
 - Fix offset (affine) unit conversion of `Decimal` magnitudes raising `TypeError` from mixing `Decimal` with the float scale/offset (e.g. `Quantity(Decimal(10), "degC").to("K")`), and the mirror case of a plain `float` magnitude in a `Decimal` registry (#2305)
+- Allow multiplying and dividing quantities by public `Unit` objects from the same registry (#2046)
 - Add `system` parameter to `to_base_units` and `ito_base_units` to allow converting to the base units of a specific unit system (#2297)
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)
 - Drop support for Python 3.11 in favour of Python 3.14 (#2304)

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -978,6 +978,13 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
         return -self._add_sub(other, operator.sub)
 
+    def _is_same_registry_unit(self, other) -> bool:
+        from .unit import PlainUnit
+
+        return isinstance(other, self._REGISTRY.Unit) or (
+            isinstance(other, PlainUnit) and other._REGISTRY is self._REGISTRY
+        )
+
     @check_implemented
     @ireduce_dimensions
     def _imul_div(self, other, magnitude_op, units_op=None):
@@ -1028,7 +1035,7 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
             self._units = units_op(self._units, self.UnitsContainer())
             return self
 
-        if isinstance(other, self._REGISTRY.Unit):
+        if self._is_same_registry_unit(other):
             other = 1 * other
 
         if not self._ok_for_muldiv(no_offset_units_self):
@@ -1099,7 +1106,7 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
             return self.__class__(magnitude, units)
 
-        if isinstance(other, self._REGISTRY.Unit):
+        if self._is_same_registry_unit(other):
             other = 1 * other
 
         new_self = self

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -15,6 +15,7 @@ import pytest
 from pint import (
     DimensionalityError,
     OffsetUnitCalculusError,
+    Unit,
     UnitRegistry,
     get_application_registry,
 )
@@ -1685,6 +1686,23 @@ class TestOffsetUnitMath(QuantityTestCase):
             helpers.assert_quantity_almost_equal(
                 op.itruediv(q1_cp, q2), Q_(*expected), atol=0.01
             )
+
+    def test_division_by_plain_unit_from_same_registry(self):
+        ureg = get_application_registry()
+
+        result = ureg.Quantity(2, "L") * Unit("mL")
+        helpers.assert_quantity_equal(result, ureg.Quantity(2, "L * mL"))
+
+        quantity = ureg.Quantity(2, "L")
+        quantity *= Unit("mL")
+        helpers.assert_quantity_equal(quantity, ureg.Quantity(2, "L * mL"))
+
+        result = ureg.Quantity(1, "L").units / Unit("mL")
+        helpers.assert_quantity_equal(result, ureg.Quantity(1000, ""))
+
+        quantity = ureg.Quantity(1, "L")
+        quantity /= Unit("mL")
+        helpers.assert_quantity_equal(quantity, ureg.Quantity(1000, ""))
 
     multiplications_with_autoconvert_to_baseunit = [
         (((100, "kelvin"), (10, "degC")), (28315.0, "kelvin**2")),


### PR DESCRIPTION
## Summary

- recognize public `Unit` objects attached to the same registry during quantity multiplication and division
- convert those units to unity quantities before offset-unit checks, matching registry inner `Unit` handling
- add regression coverage for `*`, `*=`, `/`, and `/=` with public `Unit` objects

Fixes #2046

## Testing

- `.venv-pint-test/bin/python -m pytest pint/testsuite/test_quantity.py -k plain_unit_from_same_registry -q`
- `.venv-pint-test/bin/python -m pytest pint/testsuite/test_quantity.py -q`
- `.venv-pint-test/bin/python -m ruff check pint/facets/plain/quantity.py pint/testsuite/test_quantity.py`
- `.venv-pint-test/bin/python -m ruff format --check pint/facets/plain/quantity.py pint/testsuite/test_quantity.py`
