### PR TITLE
Parse string magnitudes with registry numeric type

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Pint Changelog
 -------------------
 
 - Fix offset (affine) unit conversion of `Decimal` magnitudes raising `TypeError` from mixing `Decimal` with the float scale/offset (e.g. `Quantity(Decimal(10), "degC").to("K")`), and the mirror case of a plain `float` magnitude in a `Decimal` registry (#2305)
+- Parse string magnitudes passed with explicit units using the registry's `non_int_type` (#2068)
 - Add `system` parameter to `to_base_units` and `ito_base_units` to allow converting to the base units of a specific unit system (#2297)
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)
 - Drop support for Python 3.11 in favour of Python 3.14 (#2304)

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -39,6 +39,7 @@ from ...compat import (
 )
 from ...errors import DimensionalityError, OffsetUnitCalculusError, PintTypeError
 from ...util import (
+    ParserHelper,
     PrettyIPython,
     SharedRegistryObject,
     UnitsContainer,
@@ -233,6 +234,15 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
                 )
         if isinstance(value, cls):
             magnitude = value.to(units)._magnitude
+        elif isinstance(value, str):
+            if value == "":
+                raise ValueError("Quantity magnitude cannot be an empty string.")
+            parsed = ParserHelper.from_string(value, inst._REGISTRY.non_int_type)
+            magnitude = (
+                _to_magnitude(value, inst.force_ndarray, inst.force_ndarray_like)
+                if parsed
+                else parsed.scale
+            )
         else:
             magnitude = _to_magnitude(
                 value, inst.force_ndarray, inst.force_ndarray_like

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1193,6 +1193,16 @@ def test_issue1505():
     )  # unexpected fail (magnitude should be a decimal)
 
 
+def test_issue2068():
+    ur = UnitRegistry(non_int_type=decimal.Decimal)
+
+    q = ur.Quantity("1.2345", "m")
+
+    assert q.magnitude == decimal.Decimal("1.2345")
+    assert isinstance(q.magnitude, decimal.Decimal)
+    assert q.to("cm").magnitude == decimal.Decimal("123.45")
+
+
 def test_issue_1845():
     ur = UnitRegistry(auto_reduce_dimensions=True, non_int_type=decimal.Decimal)
     # before issue 1845 these inputs would have resulted in a TypeError


### PR DESCRIPTION
## Summary

- parse numeric string magnitudes passed with explicit units through `ParserHelper`
- respect the registry's `non_int_type`, so Decimal registries build Decimal magnitudes
- preserve existing non-numeric string magnitude behavior
- add regression coverage for Decimal string magnitude conversion

Fixes #2068

## Testing

- `.venv-pint-test/bin/python -m pytest pint/testsuite/test_issues.py::TestIssues::test_issue61 pint/testsuite/test_issues.py::test_issue2068 -q`
- `.venv-pint-test/bin/python -m pytest pint/testsuite/test_issues.py -q`
- `.venv-pint-test/bin/python -m pytest pint/testsuite/test_quantity.py -q`
- `.venv-pint-test/bin/python -m ruff check pint/facets/plain/quantity.py pint/testsuite/test_issues.py`
- `.venv-pint-test/bin/python -m ruff format --check pint/facets/plain/quantity.py pint/testsuite/test_issues.py`
