### PR TITLE
Apply preprocessors in dimensionality parsing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Pint Changelog
 -------------------
 
 - Fix offset (affine) unit conversion of `Decimal` magnitudes raising `TypeError` from mixing `Decimal` with the float scale/offset (e.g. `Quantity(Decimal(10), "degC").to("K")`), and the mirror case of a plain `float` magnitude in a `Decimal` registry (#2305)
+- Apply registry preprocessors when getting dimensionality from text input (#2153)
 - Add `system` parameter to `to_base_units` and `ito_base_units` to allow converting to the base units of a specific unit system (#2297)
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)
 - Drop support for Python 3.11 in favour of Python 3.14 (#2304)

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -712,6 +712,9 @@ class GenericPlainRegistry[QuantityT: PlainQuantity, UnitT: PlainUnit](
 
         # TODO: This should be to_units_container(input_units, self)
         # but this tries to reparse and fail for dimensions.
+        if isinstance(input_units, str):
+            for p in self.preprocessors:
+                input_units = p(input_units)
         input_units = to_units_container(input_units)
 
         return self._get_dimensionality(input_units)

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1193,6 +1193,12 @@ def test_issue1505():
     )  # unexpected fail (magnitude should be a decimal)
 
 
+def test_issue2153():
+    q = get_application_registry().Quantity(1, "%")
+
+    assert q.check("%")
+
+
 def test_issue_1845():
     ur = UnitRegistry(auto_reduce_dimensions=True, non_int_type=decimal.Decimal)
     # before issue 1845 these inputs would have resulted in a TypeError

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -1311,6 +1311,8 @@ class TestDimensions(QuantityTestCase):
         assert get(UnitsContainer({"[time]": 1})) == UnitsContainer({"[time]": 1})
         assert get("seconds") == UnitsContainer({"[time]": 1})
         assert get(UnitsContainer({"seconds": 1})) == UnitsContainer({"[time]": 1})
+        assert get("%") == UnitsContainer({})
+        assert get("‰") == UnitsContainer({})
         assert get("[velocity]") == UnitsContainer({"[length]": 1, "[time]": -1})
         assert get("[acceleration]") == UnitsContainer({"[length]": 1, "[time]": -2})
 


### PR DESCRIPTION
## Summary

- apply registry preprocessors before `get_dimensionality()` parses text input
- allow preprocessed unit spellings such as `%` and `‰` to be checked as dimensionless
- keep direct dimension strings such as `[length]` on the existing non-registry parsing path

Fixes #2153

## Testing

- `.venv-pint-test/bin/python -m pytest pint/testsuite/test_issues.py::test_issue2153 pint/testsuite/test_quantity.py::TestDimensions::test_get_dimensionality -q`
- `.venv-pint-test/bin/python -m pytest pint/testsuite/test_quantity.py -q`
- `.venv-pint-test/bin/python -m pytest pint/testsuite/test_issues.py -q`
- `.venv-pint-test/bin/python -m ruff check pint/facets/plain/registry.py pint/testsuite/test_quantity.py pint/testsuite/test_issues.py`
- `.venv-pint-test/bin/python -m ruff format --check pint/facets/plain/registry.py pint/testsuite/test_quantity.py pint/testsuite/test_issues.py`
