### PR TITLE
[TYP] Fix `Magnitude` type alias and make magnitude type optional

### DIFF
--- a/pint/_typing.py
+++ b/pint/_typing.py
@@ -11,17 +11,23 @@ if TYPE_CHECKING:
     from .util import UnitsContainer
 
 
-HAS_NUMPY = False
-if TYPE_CHECKING:
-    from .compat import HAS_NUMPY
-
+# NOTE: There is no supported pattern for conditionally defining types
+#   based on the availability of external dependencies.
+#
+# The pattern used here allows type checkers to correctly infer types when numpy
+#   is available, but falls back to Any/Unknown (and not Never) in case of error
+#   (tested: pyright 1.1.411)
+#
+# See https://discuss.python.org/t/conditional-imports-in-stub-files/50326 for context
 type _BuiltinScalar = complex | float | int | Decimal | Fraction
-if HAS_NUMPY:
-    from .compat import np
+try:
+    import numpy as np
 
     type Scalar = _BuiltinScalar | np.number[Any]
     type Array = np.ndarray[Any, Any]
-else:
+except ModuleNotFoundError:
+    # NOTE: redefining type aliases is not supported and may lead to type checker misbehavior
+    assert not TYPE_CHECKING
     type Scalar = _BuiltinScalar
     type Array = Never
 

--- a/pint/_typing.py
+++ b/pint/_typing.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 #   (tested: pyright 1.1.411)
 #
 # See https://discuss.python.org/t/conditional-imports-in-stub-files/50326 for context
-type _BuiltinScalar = complex | float | int | Decimal | Fraction
+type _BuiltinScalar = complex | float | Decimal | Fraction
 try:
     import numpy as np
 

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -23,10 +23,11 @@ from typing import (
     Generic,
     Self,
     TypeAlias,
-    TypeVar,
     overload,
     override,
 )
+
+from typing_extensions import TypeVar
 
 from . import facets, registry_helpers
 from .util import logger, pi_theorem
@@ -46,7 +47,9 @@ if TYPE_CHECKING:
 # but
 
 
-MagnitudeT_co = TypeVar("MagnitudeT_co", covariant=True, bound="Magnitude")
+MagnitudeT_co = TypeVar(
+    "MagnitudeT_co", covariant=True, bound="Magnitude", default="Any"
+)
 
 
 class Quantity(


### PR DESCRIPTION
- [ ] Closes # (insert issue number)
- [x] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

There was a `HAS_NUMPY = False` definition in `_typing.py`, which made `Array` resolve to `Never` and therefore denied numpy arrays as type arguments to `Quantity`.

**Note**: Type checkers [do not officially support](https://discuss.python.org/t/conditional-imports-in-stub-files/50326) constant definitions that are conditional over the availability of a package/module.

**Edit**: I also made `Quantity`'s `MagnitudeT` type argument optional (defaults to `Any`).