### PR TITLE
Format negative magnitudes in scientific notation with the pretty exponent

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.26.0 (unreleased)
 -------------------
 
+- Fix negative magnitudes in scientific notation not getting the pretty/HTML exponent formatting (e.g. `-1.5e-08 m` now renders as `-1.5×10⁻⁸ m`, matching the positive case) (#2350)
 - Fix offset (affine) unit conversion of `Decimal` magnitudes raising `TypeError` from mixing `Decimal` with the float scale/offset (e.g. `Quantity(Decimal(10), "degC").to("K")`), and the mirror case of a plain `float` magnitude in a `Decimal` registry (#2305)
 - Add `system` parameter to `to_base_units` and `ito_base_units` to allow converting to the base units of a specific unit system (#2297)
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)

--- a/pint/delegates/formatter/html.py
+++ b/pint/delegates/formatter/html.py
@@ -76,7 +76,7 @@ class HTMLFormatter(BaseFormatter):
                         + "</pre>"
                     )
 
-        m = _EXP_PATTERN.match(mstr)
+        m = _EXP_PATTERN.search(mstr)
         _exp_formatter = lambda s: f"<sup>{s}</sup>"
 
         if m:

--- a/pint/delegates/formatter/plain.py
+++ b/pint/delegates/formatter/plain.py
@@ -307,7 +307,7 @@ class PrettyFormatter(BaseFormatter):
             else:
                 mstr = format_number(magnitude)
 
-            m = _EXP_PATTERN.match(mstr)
+            m = _EXP_PATTERN.search(mstr)
 
             if m:
                 exp = int(m.group(2) + m.group(3))

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1477,6 +1477,19 @@ def test_issue2256_2():
     assert f"{q:^}" == "2.3e-06 kilogram ** -1 * meter ** 3 * second ** -2"
 
 
+def test_negative_magnitude_scientific_notation_formatting():
+    # A negative magnitude shown in scientific notation must get the same pretty
+    # (and HTML) exponent formatting as its positive counterpart. _EXP_PATTERN
+    # was applied with .match(), which anchors at the start and so failed on the
+    # leading "-", leaving negatives with raw e-notation.
+    ureg = UnitRegistry()
+
+    assert f"{2.3e-6 * ureg.m:~P}" == "2.3×10⁻⁶ m"
+    assert f"{-2.3e-6 * ureg.m:~P}" == "-2.3×10⁻⁶ m"
+    assert f"{2.3e-6 * ureg.m:~H}" == "2.3×10<sup>-6</sup> m"
+    assert f"{-2.3e-6 * ureg.m:~H}" == "-2.3×10<sup>-6</sup> m"
+
+
 def test_issue2305():
     # Offset (affine) conversion of a Decimal magnitude must not raise
     # TypeError from mixing Decimal with the float scale/offset.


### PR DESCRIPTION
The pretty (`~P`) and HTML (`~H`) formatters turn a magnitude's scientific notation into a nice `×10ⁿ` exponent, but only for positive magnitudes:

```python
>>> import pint
>>> u = pint.UnitRegistry()
>>> f"{2.3e-6 * u.m:~P}"
'2.3×10⁻⁶ m'
>>> f"{-2.3e-6 * u.m:~P}"
'-2.3e-06 m'      # raw e-notation, not formatted
```

The formatters detect the exponent with `_EXP_PATTERN.match(mstr)`. `re.match` anchors at the start of the string, and `_EXP_PATTERN` begins with `[0-9]`, so a negative magnitude (leading `-`) never matches and the `×10ⁿ` substitution is skipped. Positive magnitudes match at index 0 and are formatted.

## Fix

Use `_EXP_PATTERN.search(mstr)` in the plain and HTML formatters so the mantissa is found regardless of a leading sign. (The LaTeX formatter already calls `_EXP_PATTERN.sub(...)` directly and is unaffected.) After the fix:

```python
>>> f"{-2.3e-6 * u.m:~P}"
'-2.3×10⁻⁶ m'
>>> f"{-2.3e-6 * u.m:~H}"
'-2.3×10<sup>-6</sup> m'
```

Positive magnitudes are unchanged.

## Test

Added `test_negative_magnitude_scientific_notation_formatting` in `pint/testsuite/test_issues.py`, asserting matching `~P`/`~H` output for positive and negative magnitudes. It fails before this change (`'-2.3e-06 m' != '-2.3×10⁻⁶ m'`) and passes after. The existing formatter/formatting/measurement tests still pass.
