### PR TITLE
Fix KeyError('') when dimensionless is referenced by name

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.26.0 (unreleased)
 -------------------
 
+- Fix `KeyError('')` raised when the `dimensionless` unit is referenced by name, e.g. `get_dimensionality("dimensionless")`, `Quantity(5, "dimensionless").check("dimensionless")`, or a unit defined via `* dimensionless` (#1513, #1994)
 - Fix offset (affine) unit conversion of `Decimal` magnitudes raising `TypeError` from mixing `Decimal` with the float scale/offset (e.g. `Quantity(Decimal(10), "degC").to("K")`), and the mirror case of a plain `float` magnitude in a `Decimal` registry (#2305)
 - Add `system` parameter to `to_base_units` and `ito_base_units` to allow converting to the base units of a specific unit system (#2297)
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -760,9 +760,7 @@ class GenericPlainRegistry[QuantityT: PlainQuantity, UnitT: PlainUnit](
 
             else:
                 name = self.get_name(key)
-                if not name:
-                    # ``dimensionless`` referenced by name resolves to "", which is
-                    # the identity and contributes nothing to the dimensionality.
+                if name == "":
                     continue
                 reg = self._units[name]
                 if reg.reference is not None:
@@ -1010,9 +1008,7 @@ class GenericPlainRegistry[QuantityT: PlainQuantity, UnitT: PlainUnit](
         for key in ref:
             exp2 = exp * ref[key]
             key = self.get_name(key)
-            if not key:
-                # ``dimensionless`` referenced by name resolves to "", which is
-                # the identity and has no root units.
+            if key == "":
                 continue
             reg = self._units[key]
             if reg.is_base:

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -759,7 +759,12 @@ class GenericPlainRegistry[QuantityT: PlainQuantity, UnitT: PlainUnit](
                     accumulator[key] += exp2
 
             else:
-                reg = self._units[self.get_name(key)]
+                name = self.get_name(key)
+                if not name:
+                    # ``dimensionless`` referenced by name resolves to "", which is
+                    # the identity and contributes nothing to the dimensionality.
+                    continue
+                reg = self._units[name]
                 if reg.reference is not None:
                     self._get_dimensionality_recurse(reg.reference, exp2, accumulator)
 
@@ -1005,6 +1010,10 @@ class GenericPlainRegistry[QuantityT: PlainQuantity, UnitT: PlainUnit](
         for key in ref:
             exp2 = exp * ref[key]
             key = self.get_name(key)
+            if not key:
+                # ``dimensionless`` referenced by name resolves to "", which is
+                # the identity and has no root units.
+                continue
             reg = self._units[key]
             if reg.is_base:
                 accumulators[key] += exp2

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1508,3 +1508,26 @@ def test_issue2305():
     ureg_dec = UnitRegistry(non_int_type=Decimal)
     assert ureg_dec.Quantity(10.0, "degC").to("K").magnitude == 283.15
     assert ureg_dec.Quantity(Decimal(10), "degC").to("K").magnitude == Decimal("283.15")
+
+
+def test_issue1513():
+    # ``dimensionless`` referenced by name resolves to "", which is not a key in
+    # the unit registry; the recurse loops used to index it directly and raise
+    # KeyError(''). It is the identity and must behave like the empty unit.
+    ureg = UnitRegistry()
+
+    # #1513: get_dimensionality by name must not raise
+    assert ureg.get_dimensionality("dimensionless") == ureg.get_dimensionality("")
+
+    # #1994: check() by name must not raise
+    assert ureg.Quantity(5, "dimensionless").check("dimensionless")
+
+    # a fractional dimensionless unit defined via ``* dimensionless`` must match
+    # the same unit defined as a bare scalar
+    ureg.define("frac = 0.01 * dimensionless")
+    ureg.define("frac_bare = 0.01")
+    assert (
+        ureg.Quantity(50, "frac").to_base_units()
+        == ureg.Quantity(50, "frac_bare").to_base_units()
+    )
+    assert ureg.get_root_units("frac") == ureg.get_root_units("frac_bare")


### PR DESCRIPTION
Referencing `dimensionless` by name raised `KeyError('')`. `get_name("dimensionless")` returns `""` (the canonical dimensionless name), which is not a key in `self._units`, and both `_get_dimensionality_recurse` and `_get_root_units_recurse` indexed `self._units[self.get_name(key)]` directly.

This surfaced through several public-API paths:

```python
ureg.get_dimensionality("dimensionless")                     # KeyError: ''  (#1513)
ureg.Quantity(5, "dimensionless").check("dimensionless")     # KeyError: ''  (#1994)
ureg.define("frac = 0.01 * dimensionless")
ureg.Quantity(50, "frac").to_base_units()                    # KeyError: ''
```

The last case is why `percent = 0.01` works but `frac = 0.01 * dimensionless` did not: the explicit `* dimensionless` token stores `{'dimensionless': 1}` in the unit's reference, which the recurse loops then hit.

`dimensionless` is the identity — it contributes nothing to a dimensionality and has no root units — so both loops now skip the empty name. After the fix, `frac = 0.01 * dimensionless` behaves identically to a bare `frac = 0.01`.

- [x] Closes #1513, closes #1994
- [x] Executed `ruff check` and `ruff format` (the pre-commit lint hooks) with no errors
- [x] The change is fully covered by an automated unit test (`test_issue1513`, which fails with `KeyError('')` on `master` and passes with the fix)
- [ ] Documented in docs/ — not applicable (bug fix, no API change)
- [x] Added an entry to the CHANGES file

---

This contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the bug, reproduced it against the public API, wrote the fix and the regression test, and wrote this description; the human account holder reviews every change and is accountable for it. The verification is real and re-runnable from the diff — it was done by the AI, not a person. If this isn't the kind of contribution you want, say so and I'll close it.

