### PR TITLE
[DOCS, CI] Remove all references to now unsupported Python versions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,7 +15,7 @@ Pint Changelog
 - Improve type annotations for `Quantity` (#2302, #2303)
 
 0.25.3 (2026-03-19)
------------------
+-------------------
 
 - `GenericPlainRegistry.parse_expression` now correctly returns a dimensionless Quantity when taking a float, int, or NaN (#2259)
 - Replace MIP with scipy in `Quantity.to_preferred` (#2264)

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ and constants. Due to its modular design, you can extend (or even rewrite!)
 the complete list without changing the source code. It supports a lot of
 numpy mathematical operations **without monkey patching or wrapping numpy**.
 
-It has a complete test coverage. It runs in Python 3.12+ with no other dependency.
+It has a complete test coverage. It runs in Python 3.12+ with minimal dependencies.
 It is licensed under BSD.
 
 It is extremely easy and natural to use:
@@ -139,8 +139,9 @@ package`_.
 **Handle temperature**: conversion between units with different reference
 points, like positions on a map or absolute temperature scales.
 
-**Dependency free**: it depends only on Python and its standard library. It interacts with other packages
-like numpy and uncertainties if they are installed
+**Minimal dependencies**: it depends only on Python, its standard library and a couple small packages that
+implement essential features (e.g. parsing unit definition files and caching).
+It only interacts with other external packages, like numpy and uncertainties, if they are installed.
 
 **Pandas integration**: Thanks to `Pandas Extension Types`_ it is now possible to use Pint with Pandas. Operations on DataFrames and between columns are units aware, providing even more convenience for users of Pandas DataFrames. For full details, see the `pint-pandas Jupyter notebook`_.
 

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ and constants. Due to its modular design, you can extend (or even rewrite!)
 the complete list without changing the source code. It supports a lot of
 numpy mathematical operations **without monkey patching or wrapping numpy**.
 
-It has a complete test coverage. It runs in Python 3.9+ with no other dependency.
+It has a complete test coverage. It runs in Python 3.12+ with no other dependency.
 It is licensed under BSD.
 
 It is extremely easy and natural to use:

--- a/docs/advanced/currencies.rst
+++ b/docs/advanced/currencies.rst
@@ -99,7 +99,7 @@ Many common currency symbols are not supported by the pint parser. A preprocesso
    1 euro
 
 Example using Currency Converter
--------------------------------
+--------------------------------
 
 The following example demonstrates how to use `currency_converter`_ with Pint to perform currency conversions with historical rates.
 

--- a/docs/advanced/custom-registry-class.rst
+++ b/docs/advanced/custom-registry-class.rst
@@ -95,8 +95,7 @@ can specify the types of
 
 .. doctest::
 
-    >>> from typing_extensions import TypeAlias # Python 3.9
-    >>> # from typing import TypeAlias # Python 3.10+
+    >>> from typing import TypeAlias
     >>> class MyRegistry(pint.registry.GenericUnitRegistry[MyQuantity, pint.Unit]):
     ...
     ...     Quantity: TypeAlias = MyQuantity

--- a/docs/advanced/serialization.rst
+++ b/docs/advanced/serialization.rst
@@ -110,7 +110,7 @@ Using the serialize_ package you can load and read from multiple formats:
 .. _Pickle: http://docs.python.org/3/library/pickle.html
 .. _json: http://docs.python.org/3/library/json.html
 .. _yaml: http://pyyaml.org/
-.. _shelve: http://docs.python.org/3.6/library/shelve.html
+.. _shelve: http://docs.python.org/3/library/shelve.html
 .. _hdf5: http://www.h5py.org/
 .. _PyTables: http://www.pytables.org
 .. _dill: https://pypi.python.org/pypi/dill

--- a/docs/getting/index.rst
+++ b/docs/getting/index.rst
@@ -8,7 +8,14 @@ The getting started guide aims to get you using pint productively as quickly as 
 Installation
 ------------
 
-Pint has no dependencies except Python itself. It runs on Python 3.12+.
+Pint runs on Python 3.12+.
+It only depends on a couple small packages for its core functionality:
+- :code:`flexparser` and :code:`flexcache` for parsing unit definition files
+- :code:`typing_extensions` for better compatibility with all supported Python versions
+- :code:`platformdirs` for finding platform-dependent cache paths
+
+Beyond this minimal setup, pint supports interoperability with other libraries, such as
+numpy and uncertainties, that are considered optional dependencies.
 
 .. grid:: 2
 

--- a/docs/getting/index.rst
+++ b/docs/getting/index.rst
@@ -8,7 +8,7 @@ The getting started guide aims to get you using pint productively as quickly as 
 Installation
 ------------
 
-Pint has no dependencies except Python itself. It runs on Python 3.9+.
+Pint has no dependencies except Python itself. It runs on Python 3.12+.
 
 .. grid:: 2
 

--- a/docs/getting/overview.rst
+++ b/docs/getting/overview.rst
@@ -14,7 +14,7 @@ Due to its modular design, you can extend (or even rewrite!) the complete list
 without changing the source code. It supports a lot of numpy mathematical
 operations **without monkey patching or wrapping numpy**.
 
-It has a complete test coverage. It runs in Python 3.12+ with no other
+It has a complete test coverage. It runs in Python 3.12+ with minimal
 dependencies. It is licensed under a `BSD 3-clause style license`_.
 
 It is extremely easy and natural to use:
@@ -78,8 +78,9 @@ package`_.
 **Handle temperature**: conversion between units with different reference
 points, like positions on a map or absolute temperature scales.
 
-**Dependency free**: it depends only on Python and its standard library. It interacts with other packages
-like numpy and uncertainties if they are installed
+**Minimal dependencies**: it depends only on Python, its standard library and a couple small packages that
+implement essential features (e.g. parsing unit definition files and caching).
+It only interacts with other external packages, like numpy and uncertainties, if they are installed.
 
 **Pandas integration**: The `pint-pandas`_ package makes it possible to use Pint with Pandas.
 Operations on DataFrames and between columns are units aware, providing even more convenience for users

--- a/docs/getting/overview.rst
+++ b/docs/getting/overview.rst
@@ -14,7 +14,7 @@ Due to its modular design, you can extend (or even rewrite!) the complete list
 without changing the source code. It supports a lot of numpy mathematical
 operations **without monkey patching or wrapping numpy**.
 
-It has a complete test coverage. It runs in Python 3.9+ with no other
+It has a complete test coverage. It runs in Python 3.12+ with no other
 dependencies. It is licensed under a `BSD 3-clause style license`_.
 
 It is extremely easy and natural to use:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,7 @@ docbuild = "sphinx-build -n -j auto -b html -d build/doctrees docs build/html"
 doctest = "sphinx-build -a -j auto -b doctest -d build/doctrees docs build/doctest"
 
 [tool.pixi.feature.docs.dependencies]
+python-graphviz = "*" # depends on `graphviz`, which installs the binary
 pandoc = "*"
 
 [tool.pixi.feature.py312.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,6 @@ docbuild = "sphinx-build -n -j auto -b html -d build/doctrees docs build/html"
 doctest = "sphinx-build -a -j auto -b doctest -d build/doctrees docs build/doctest"
 
 [tool.pixi.feature.docs.dependencies]
-python-graphviz = "*" # depends on `graphviz`, which installs the binary
 pandoc = "*"
 
 [tool.pixi.feature.py312.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ docs = [
   "graphviz",
   "pooch",
   "sparse",
+  "numba>=0.59",              # for sparse
   "Serialize",
   "pygments>=2.4",
   "sphinx-book-theme>=1.1.0",


### PR DESCRIPTION
- [x] Closes #2352
- [x] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

---

**Edit**: Other changes:
- Also fixed the failing docs-related GitHub workflows by installing `python-graphviz` from conda-forge instead of pypi (because the conda package depends on `graphviz`, which provides the missing binary automatically);
- Also fixed the failing ReadTheDocs build by helping pypi to solve dependencies (apparently it was trying to build from source an old numba version that was incompatible with Python 3.12).