### PR TITLE
Fix CI by constraining dependencies and lint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,10 +109,11 @@ pythonpath = "."
 docstring-code-format = true
 
 [tool.ruff.lint]
-extend-select = ["I"]
+select = ["E4", "E7", "E9", "F", "I"]
 ignore = [
   "E402", # module level import not at top of file
   "E731", # do not assign a lambda expression, use a def
+  "E741", # ambiguous variable name
 ]
 
 [tool.pixi.workspace]
@@ -214,6 +215,7 @@ doctest = "sphinx-build -a -j auto -b doctest -d build/doctrees docs build/docte
 
 [tool.pixi.feature.docs.dependencies]
 pandoc = "*"
+graphviz = "*"
 
 [tool.pixi.feature.py312.dependencies]
 python = "3.12.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ docs = [
   "scipy",
   "currencyconverter",
   "matplotlib",
-  "numpy",
+  "numpy<2.5",
   "xarray",
   "dask[complete]<2025.3.0",
   "optype[numpy]",


### PR DESCRIPTION
## Summary

This builds on #2334 (constrain the `docs` extra's NumPy dependency to avoid resolving an old numba/llvmlite stack on Python 3.12), adding two additional CI fixes that were surfaced while checking that PR: `docbuild`/`doctest` and `lint` were both failing, but for reasons unrelated to the NumPy pin itself — they're pre-existing issues that also affect `master`.

- **docbuild/doctest**: the pixi `docs` environment installs the Python `graphviz` bindings (via the `docs` pypi extra) but never the `dot` binary those bindings shell out to, so any notebook rendering a graphviz diagram (e.g. `docs/user/numpy.ipynb`) fails with `ExecutableNotFound: failed to execute PosixPath('dot')`. `.readthedocs.yaml` works around this with `apt_packages: [graphviz]`, but the GitHub Actions `docs.yml` workflow (which uses pixi) never installed it. Added `graphviz = "*"` to `[tool.pixi.feature.docs.dependencies]`, matching how `pandoc` is already provided.
- **lint**: Ruff 0.16.0 expanded its default rule set from 59 rules to 413 (see the [0.16.0 release notes](https://astral.sh/blog/ruff-v0.16.0)). Since `ruff` is unpinned in `[tool.pixi.feature.lint.dependencies]` (`ruff = "*"`) and `pixi.lock` isn't committed, CI picked up 0.16.0 and started failing lint on ~365 pre-existing violations unrelated to whatever PR happens to trigger the run. Pinned `[tool.ruff.lint]` to `select = ["E4", "E7", "E9", "F", "I"]` (Ruff's pre-0.16 defaults plus the isort rules this project already opted into), and added `E741` to `ignore` to match prior behavior.

Filed #2356 to track what's needed to eventually adopt Ruff's new default rules deliberately, with a full breakdown of the ~365 violations by rule code.

## Verification

- `pixi run --environment docs docbuild`: `dot` now resolves and the graphviz-diagram cell no longer errors.
- `pixi run --environment lint lint --all-files`: passes cleanly again.

## Test plan

- [ ] CI: `docbuild`, `doctest`, and `lint` jobs pass