### PR TITLE
Remove redundant numba pin from docs extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ docs = [
   "graphviz",
   "pooch",
   "sparse",
-  "numba>=0.59",              # for sparse
   "Serialize",
   "pygments>=2.4",
   "sphinx-book-theme>=1.1.0",


### PR DESCRIPTION
## Summary

- Remove the `numba>=0.59` floor from the `docs` optional-dependency group, added in #2353 to stop pip from resolving an old numba incompatible with Python 3.12.

## Why it's redundant now

#2334 / #2357 already constrain `numpy<2.5` for the `docs` extra. With that constraint in place, pip/uv's resolver picks a modern numba on its own, without needing an explicit floor — presumably because the old numba/llvmlite stack was only being reached in the first place through a numpy resolution that no longer happens.

## Verification

```
pixi update --environment docs
pixi list --environment docs | grep -i "numba\|llvmlite\|numpy "
```

resolves:

```
llvmlite   0.48.0
numba      0.66.0
numpy      2.4.6
```

— matching the versions #2334 originally verified as working, with no explicit numba pin needed.

## Test plan

- [ ] CI: `docbuild`/`doctest`/ReadTheDocs still resolve and build successfully without the numba pin