### PR TITLE
Handle public Unit/Quantity objects in muldiv, from_, and wraps

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Pint Changelog
 -------------------
 
 - Fix offset (affine) unit conversion of `Decimal` magnitudes raising `TypeError` from mixing `Decimal` with the float scale/offset (e.g. `Quantity(Decimal(10), "degC").to("K")`), and the mirror case of a plain `float` magnitude in a `Decimal` registry (#2305)
+- Allow multiplying and dividing quantities by public `Unit` objects from the same registry (#2046)
 - Add `system` parameter to `to_base_units` and `ito_base_units` to allow converting to the base units of a specific unit system (#2297)
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)
 - Drop support for Python 3.11 in favour of Python 3.14 (#2304)

--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,7 @@ Pint Changelog
 -------------------
 
 - Fix offset (affine) unit conversion of `Decimal` magnitudes raising `TypeError` from mixing `Decimal` with the float scale/offset (e.g. `Quantity(Decimal(10), "degC").to("K")`), and the mirror case of a plain `float` magnitude in a `Decimal` registry (#2305)
-- Allow multiplying and dividing quantities by public `Unit` objects from the same registry (#2046)
+- Allow multiplying and dividing quantities by public `Unit` objects from the same registry, and fix the same class of bug in `Unit.from_` and `wraps` (#2046)
 - Add `system` parameter to `to_base_units` and `ito_base_units` to allow converting to the base units of a specific unit system (#2297)
 - Add beats per minute (`beats_per_minute`, `bpm`) (#2286)
 - Drop support for Python 3.11 in favour of Python 3.14 (#2304)

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -978,6 +978,13 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
         return -self._add_sub(other, operator.sub)
 
+    def _is_same_registry_unit(self, other) -> bool:
+        from .unit import PlainUnit
+
+        return isinstance(other, self._REGISTRY.Unit) or (
+            isinstance(other, PlainUnit) and other._REGISTRY is self._REGISTRY
+        )
+
     @check_implemented
     @ireduce_dimensions
     def _imul_div(self, other, magnitude_op, units_op=None):
@@ -1028,7 +1035,7 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
             self._units = units_op(self._units, self.UnitsContainer())
             return self
 
-        if isinstance(other, self._REGISTRY.Unit):
+        if self._is_same_registry_unit(other):
             other = 1 * other
 
         if not self._ok_for_muldiv(no_offset_units_self):
@@ -1099,7 +1106,7 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
             return self.__class__(magnitude, units)
 
-        if isinstance(other, self._REGISTRY.Unit):
+        if self._is_same_registry_unit(other):
             other = 1 * other
 
         new_self = self

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -978,13 +978,6 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
         return -self._add_sub(other, operator.sub)
 
-    def _is_same_registry_unit(self, other) -> bool:
-        from .unit import PlainUnit
-
-        return isinstance(other, self._REGISTRY.Unit) or (
-            isinstance(other, PlainUnit) and other._REGISTRY is self._REGISTRY
-        )
-
     @check_implemented
     @ireduce_dimensions
     def _imul_div(self, other, magnitude_op, units_op=None):
@@ -1035,7 +1028,9 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
             self._units = units_op(self._units, self.UnitsContainer())
             return self
 
-        if self._is_same_registry_unit(other):
+        from .unit import PlainUnit
+
+        if isinstance(other, PlainUnit):
             other = 1 * other
 
         if not self._ok_for_muldiv(no_offset_units_self):
@@ -1106,7 +1101,9 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
             return self.__class__(magnitude, units)
 
-        if self._is_same_registry_unit(other):
+        from .unit import PlainUnit
+
+        if isinstance(other, PlainUnit):
             other = 1 * other
 
         new_self = self

--- a/pint/facets/plain/unit.py
+++ b/pint/facets/plain/unit.py
@@ -276,7 +276,9 @@ class PlainUnit(PrettyIPython, SharedRegistryObject):
 
         """
         if self._check(value):
-            if not isinstance(value, self._REGISTRY.Quantity):
+            from .quantity import PlainQuantity
+
+            if not isinstance(value, PlainQuantity):
                 value = self._REGISTRY.Quantity(1, value)
             return value.to(self)
         elif strict:

--- a/pint/registry_helpers.py
+++ b/pint/registry_helpers.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 from ._typing import FuncType
 from .errors import DimensionalityError
+from .facets.plain import PlainQuantity, PlainUnit
 from .util import UnitsContainer, to_units_container
 
 if TYPE_CHECKING:
@@ -145,7 +146,7 @@ def _parse_wrap_args(args, registry=None):
 
         # third pass: convert other arguments
         for ndx in unit_args_ndx:
-            if isinstance(values[ndx], ureg.Quantity):
+            if isinstance(values[ndx], PlainQuantity):
                 values[ndx] = ureg._convert(
                     values[ndx]._magnitude, values[ndx]._units, args_as_uc[ndx][0]
                 )
@@ -237,7 +238,7 @@ def wraps(
         args = (args,)
 
     for arg in args:
-        if arg is not None and not isinstance(arg, (ureg.Unit, str)):
+        if arg is not None and not isinstance(arg, (PlainUnit, str)):
             raise TypeError(
                 "wraps arguments must by of type str or Unit, not %s (%s)"
                 % (type(arg), arg)
@@ -248,14 +249,14 @@ def wraps(
     is_ret_container = isinstance(ret, (list, tuple))
     if is_ret_container:
         for arg in ret:
-            if arg is not None and not isinstance(arg, (ureg.Unit, str)):
+            if arg is not None and not isinstance(arg, (PlainUnit, str)):
                 raise TypeError(
                     "wraps 'ret' argument must by of type str or Unit, not %s (%s)"
                     % (type(arg), arg)
                 )
         ret = ret.__class__([_to_units_container(arg, ureg) for arg in ret])
     else:
-        if ret is not None and not isinstance(ret, (ureg.Unit, str)):
+        if ret is not None and not isinstance(ret, (PlainUnit, str)):
             raise TypeError(
                 "wraps 'ret' argument must by of type str or Unit, not %s (%s)"
                 % (type(ret), ret)

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -13,6 +13,8 @@ import pytest
 from pint import (
     Context,
     DimensionalityError,
+    Quantity,
+    Unit,
     UndefinedUnitError,
     UnitRegistry,
     get_application_registry,
@@ -1508,3 +1510,26 @@ def test_issue2305():
     ureg_dec = UnitRegistry(non_int_type=Decimal)
     assert ureg_dec.Quantity(10.0, "degC").to("K").magnitude == 283.15
     assert ureg_dec.Quantity(Decimal(10), "degC").to("K").magnitude == Decimal("283.15")
+
+
+def test_issue2046():
+    # `Unit` and `Quantity` imported from `pint` are aliases for
+    # `UnitRegistry.Unit`/`.Quantity`, not the dynamic subclasses a
+    # UnitRegistry instance builds for itself in `_init_dynamic_classes`.
+    # Both kinds of object share `_REGISTRY` when bound to the application
+    # registry, but `Unit.from_` and `wraps` used to check `isinstance`
+    # against the registry-specific subclass directly, so a "public" object
+    # of the same registry was wrongly rejected.
+    ureg = get_application_registry()
+
+    # Unit.from_ with a public Quantity
+    assert ureg.Unit("meter").from_(Quantity(2, "inch")) == ureg.Quantity(
+        2 * 0.0254, "meter"
+    )
+
+    # wraps with public Units as the argument/return spec
+    def func(x):
+        return x
+
+    wrapped = ureg.wraps(Unit("meter"), [Unit("meter")])(func)
+    assert wrapped(Quantity(200, "centimeter")) == ureg.Quantity(2, "meter")

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -15,6 +15,7 @@ import pytest
 from pint import (
     DimensionalityError,
     OffsetUnitCalculusError,
+    Unit,
     UnitRegistry,
     get_application_registry,
 )
@@ -1685,6 +1686,23 @@ class TestOffsetUnitMath(QuantityTestCase):
             helpers.assert_quantity_almost_equal(
                 op.itruediv(q1_cp, q2), Q_(*expected), atol=0.01
             )
+
+    def test_division_by_plain_unit_from_same_registry(self):
+        ureg = get_application_registry()
+
+        result = ureg.Quantity(2, "L") * Unit("mL")
+        helpers.assert_quantity_equal(result, ureg.Quantity(2, "L * mL"))
+
+        quantity = ureg.Quantity(2, "L")
+        quantity *= Unit("mL")
+        helpers.assert_quantity_equal(quantity, ureg.Quantity(2, "L * mL"))
+
+        result = ureg.Quantity(1, "L").units / Unit("mL")
+        helpers.assert_quantity_equal(result, ureg.Quantity(1000, ""))
+
+        quantity = ureg.Quantity(1, "L")
+        quantity /= Unit("mL")
+        helpers.assert_quantity_equal(quantity, ureg.Quantity(1000, ""))
 
     multiplications_with_autoconvert_to_baseunit = [
         (((100, "kelvin"), (10, "degC")), (28315.0, "kelvin**2")),


### PR DESCRIPTION
## Summary

Reworks #2342's fix for #2046 (public `Unit` objects rejected during quantity `*`/`/`), and fixes two more occurrences of the same underlying bug.

#2342 fixed `Quantity.__mul__`/`__truediv__` rejecting "public" `Unit` objects (e.g. `pint.Unit(...)`) attached to the same registry by adding `isinstance(other, self._REGISTRY.Unit)`. That check is fragile: `self._REGISTRY.Unit` is the per-instance dynamic subclass a `UnitRegistry` builds for itself in `_init_dynamic_classes`, whereas `pint.Unit`/`pint.Quantity` are the un-specialized `UnitRegistry.Unit`/`.Quantity` aliases. Both kinds of object share the same `_REGISTRY`, but a "public" object can still fail an `isinstance` check against that specific dynamic subclass.

This reworks the fix to check against the base `PlainUnit`/`PlainQuantity` classes instead — the same pattern the registry's own operators already use (`PlainUnit.__mul__`/`__eq__`/`compare` all gate on `self._check(other)`, which does a duck-typed `_REGISTRY` identity comparison, plus an `isinstance` against the base class or `self.__class__`).

Applied the same fix to two more call sites with the identical bug, found while reviewing #2342:
- `Unit.from_()` — checked `isinstance(value, self._REGISTRY.Quantity)`.
- `wraps()` / `_parse_wrap_args()` — checked `isinstance(arg, (ureg.Unit, str))` in three places (arg validation, ret validation, and the inner argument-conversion pass).

## Testing

- Added `test_issue2046` (`Unit.from_` and `wraps` with public `Unit`/`Quantity` objects) — verified it fails against the pre-rework `isinstance(x, self._REGISTRY.X)` checks and passes with the base-class checks.
- Full suite: `pixi run --environment test test` — 1637 passed, 1035 skipped, 9 xfailed.
- `pixi run --environment lint ruff check`/`format --check` on the changed files (checked against this repo's pinned pre-0.16 rule set, since `ruff` itself is unpinned on this branch — see #2356).

## Test plan

- [ ] CI: full test suite and lint pass