### PR TITLE
Fix DimensionalityError from numpy-scalar-initiated == on incompatible dims

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,8 +4,7 @@ Pint Changelog
 0.26.0 (unreleased)
 -------------------
 
-- Fix `DimensionalityError` raised by `numpy.float64(x) == quantity` (and other numpy-scalar/array-initiated `==`/`!=` comparisons) for quantities of incompatible dimensions, instead returning `False`/`True` as `quantity == x`/`quantity != x` already did (#2182)
-
+- Fix `DimensionalityError` from `numpy_scalar == quantity` for incompatible dimensions; now returns `False`/`True` like `quantity == numpy_scalar` (#2182)
 - Fix `wraps` raising an `AssertionError` for arguments declared as `"dimensionless"` (affecting math functions such as `exp` or `log`) (#2255)
 - Raise ``DefinitionSyntaxError`` instead of a bare ``AssertionError`` when parsing an expression that is only an operator, e.g. ``ureg('-')`` or ``ureg('*')`` (#2124)
 - Document registry preprocessors with an example for parsing non-standard square-unit spellings (#1211, #2062)

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@ Pint Changelog
 0.26.0 (unreleased)
 -------------------
 
+- Fix `DimensionalityError` raised by `numpy.float64(x) == quantity` (and other numpy-scalar/array-initiated `==`/`!=` comparisons) for quantities of incompatible dimensions, instead returning `False`/`True` as `quantity == x`/`quantity != x` already did (#2182)
+
 - Fix `wraps` raising an `AssertionError` for arguments declared as `"dimensionless"` (affecting math functions such as `exp` or `log`) (#2255)
 - Raise ``DefinitionSyntaxError`` instead of a bare ``AssertionError`` when parsing an expression that is only an operator, e.g. ``ureg('-')`` or ``ureg('*')`` (#2124)
 - Document registry preprocessors with an example for parsing non-standard square-unit spellings (#1211, #2062)

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -386,12 +386,10 @@ Define ufunc behavior collections.
 """
 strip_unit_input_output_ufuncs = ["isnan", "isinf", "isfinite", "signbit", "sign"]
 matching_input_bare_output_ufuncs = [
-    "equal",
     "greater",
     "greater_equal",
     "less",
     "less_equal",
-    "not_equal",
 ]
 matching_input_set_units_output_ufuncs = {"arctan2": "radian"}
 set_units_ufuncs = {
@@ -487,6 +485,24 @@ for ufunc_str in strip_unit_input_output_ufuncs:
 for ufunc_str in matching_input_bare_output_ufuncs:
     # Require all inputs to match units, but output plain ndarray/duck array
     implement_func("ufunc", ufunc_str, input_units="all_consistent", output_unit=None)
+
+
+def implement_eq_ne_ufunc(ufunc_str, dunder):
+    # Unlike the other comparison ufuncs, equal/not_equal must not raise on
+    # incompatible dimensions: `q1 == q2` returns False (and `!=` True) for
+    # mismatched units, same as Python's usual equality semantics. Delegate to
+    # PlainQuantity.__eq__/__ne__, which already implements that.
+    if np is None:
+        return
+
+    @implements(ufunc_str, "ufunc")
+    def implementation(x1, x2, *args, **kwargs):
+        quantity, other = (x1, x2) if _is_quantity(x1) else (x2, x1)
+        return getattr(quantity, dunder)(other)
+
+
+implement_eq_ne_ufunc("equal", "__eq__")
+implement_eq_ne_ufunc("not_equal", "__ne__")
 
 for ufunc_str, out_unit in matching_input_set_units_output_ufuncs.items():
     # Require all inputs to match units, but output in specified unit

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1617,3 +1617,23 @@ def test_issue1513():
         == ureg.Quantity(50, "frac_bare").to_base_units()
     )
     assert ureg.get_root_units("frac") == ureg.get_root_units("frac_bare")
+
+
+@helpers.requires_numpy
+def test_issue2182():
+    # Comparing a Quantity to an incompatible-dimension value returns False (and
+    # `!=` returns True), regardless of which side of `==`/`!=` the Quantity is on.
+    ureg = UnitRegistry()
+    q = ureg.Quantity(5.0, "Hz")
+
+    assert not (q == 5.0)
+    assert not (5.0 == q)
+    assert not (q == np.float64(5.0))
+    assert not (np.float64(5.0) == q)  # used to raise DimensionalityError
+    assert not (np.array(5.0) == q)  # used to raise DimensionalityError
+
+    assert q != 5.0
+    assert 5.0 != q
+    assert q != np.float64(5.0)
+    assert np.float64(5.0) != q  # used to raise DimensionalityError
+    assert np.array(5.0) != q  # used to raise DimensionalityError

--- a/pint/testsuite/test_umath.py
+++ b/pint/testsuite/test_umath.py
@@ -722,10 +722,18 @@ class TestComparisonUfuncs(TestUFuncs):
         self._testn2(np.less_equal, self.q1, (self.q2,), (self.qm,))
 
     def test_not_equal(self):
-        self._testn2(np.not_equal, self.q1, (self.q2,), (self.qm,))
+        # Unlike the other comparison ufuncs, not_equal must not raise for
+        # incompatible dimensions: it should report everything as unequal,
+        # matching Quantity.__ne__ and Python's usual equality semantics.
+        self._testn2(np.not_equal, self.q1, (self.q2,))
+        assert np.all(np.not_equal(self.q1, self.qm))
 
     def test_equal(self):
-        self._testn2(np.equal, self.q1, (self.q2,), (self.qm,))
+        # Unlike the other comparison ufuncs, equal must not raise for
+        # incompatible dimensions: it should report everything as unequal,
+        # matching Quantity.__eq__ and Python's usual equality semantics.
+        self._testn2(np.equal, self.q1, (self.q2,))
+        assert not np.any(np.equal(self.q1, self.qm))
 
 
 class TestFloatingUfuncs(TestUFuncs):


### PR DESCRIPTION
## Summary

Fixes #2182.

`quantity == other` already returns `False` gracefully for incompatible dimensions (and `!=` returns `True`), matching Python's usual equality semantics. But when the left-hand operand is a NumPy scalar/array instead (`np.float64(5.0) == quantity`), the comparison goes through NumPy's `equal` ufunc dispatch via `Quantity.__array_ufunc__` rather than `Quantity.__eq__` directly. That path was previously bundled with `<`, `>`, etc. in `matching_input_bare_output_ufuncs`, which converts all inputs to consistent units and raises `DimensionalityError` on mismatch — appropriate for ordering comparisons, but not for equality.

```python
>>> ureg.Quantity(5.0, 'Hz') == 5.0
False
>>> np.float64(5.0) == ureg.Quantity(5.0, 'Hz')  # used to raise DimensionalityError
False
```

## Changes

- Split `equal`/`not_equal` out of `matching_input_bare_output_ufuncs` in `pint/facets/numpy/numpy_func.py` and give them a dedicated `__array_ufunc__` implementation that delegates to whichever operand is the `Quantity`'s own `__eq__`/`__ne__`, so both entry points agree.
- Updated `TestComparisonUfuncs.test_equal`/`test_not_equal` in `pint/testsuite/test_umath.py`, which previously asserted the old (buggy) raising behavior for incompatible dimensions.
- Added a CHANGES entry.

## Test plan

- [x] `pytest pint/testsuite/test_umath.py pint/testsuite/test_quantity.py pint/testsuite/test_numpy.py pint/testsuite/test_issues.py` — all pass
- [x] Full test suite (`pytest pint/testsuite`) — 2682 passed, 0 failed
- [x] Manually verified all combinations from the issue (`Quantity == float`, `float == Quantity`, `Quantity == np.float64`, `np.float64 == Quantity`, `np.array == Quantity`) now return `False`/`True` consistently, while ordering comparisons (`<`, `>`, ...) still correctly raise `DimensionalityError` for incompatible dimensions