### PR TITLE
Prefer Greek mu (U+03BC) over micro sign (U+00B5) for micro- prefix

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,7 @@ Pint Changelog
   the public upcast type map as mutable (#2063)
 - `Quantity` now converts  `datetime.timedelta` objects to seconds or specified units when
   initializing a `Quantity` with a `datetime.timedelta` value.  (#1978)
+- Prefer the Greek mu `μ` (U+03BC) over the micro sign `µ` (U+00B5) as the default symbol for the `micro-` prefix and `micron`, matching the Unicode standard's recommendation (#2177)
 
 0.25.3 (2026-03-19)
 -------------------

--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -72,7 +72,7 @@ pico- =  1e-12 = p-
 nano- =  1e-9  = n-
 # The micro (U+00B5) and Greek mu (U+03BC) are both valid prefixes,
 # and they often use the same glyph.
-micro- = 1e-6  = µ- = μ- = u- = mu- = mc-
+micro- = 1e-6  = μ- = µ- = u- = mu- = mc-
 milli- = 1e-3  = m-
 centi- = 1e-2  = c-
 deci- =  1e-1  = d-
@@ -156,7 +156,7 @@ strain = 1 = ε = ϵ     # NOTE: ε = U+03B5 (GREEK SMALL LETTER EPSILON), ϵ = 
 
 # Length
 angstrom = 1e-10 * meter = Å = ångström = Å
-micron = micrometer = µ = μ
+micron = micrometer = μ = µ
 fermi = femtometer = fm
 light_year = speed_of_light * julian_year = ly = lightyear
 astronomical_unit = 149597870700 * meter = au  # since Aug 2012

--- a/pint/testsuite/conftest.py
+++ b/pint/testsuite/conftest.py
@@ -14,7 +14,7 @@ atto- =  1e-18 = a-
 femto- = 1e-15 = f-
 pico- =  1e-12 = p-
 nano- =  1e-9  = n-
-micro- = 1e-6  = µ- = μ- = u- = mu- = mc-
+micro- = 1e-6  = μ- = µ- = u- = mu- = mc-
 milli- = 1e-3  = m-
 centi- = 1e-2  = c-
 deci- =  1e-1  = d-

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1294,7 +1294,7 @@ def test_issue2017():
 
     @fmt.register_unit_format("test2017")
     def _test_format(unit, registry, **options):
-        proc = {u.replace("µ", "u"): e for u, e in unit.items()}
+        proc = {u.replace("µ", "u").replace("μ", "u"): e for u, e in unit.items()}
         return fmt.formatter(
             proc.items(),
             as_ratio=True,


### PR DESCRIPTION
## Summary
- The Unicode standard (https://unicode.org/reports/tr25/, section 2.5) recommends U+03BC (Greek mu, `μ`) as the preferred character for the micro symbol, but pint currently lists U+00B5 (micro sign, `µ`) first, making it the default symbol used when formatting (e.g. with `~`).
- Reorders the aliases for the `micro-` prefix and `micron` unit so `μ` (U+03BC) is used by default, while `µ` (U+00B5) remains a recognized alias for parsing.

## Test plan
- [x] `pytest pint/testsuite` passes locally
- [x] Updated `test_issue2017`'s custom formatter to strip both mu variants, since it now produces `μ` instead of `µ`

Fixes #2177