### PR TITLE
Document compatible_units() in the tutorial

### DIFF
--- a/docs/getting/tutorial.rst
+++ b/docs/getting/tutorial.rst
@@ -142,9 +142,8 @@ Finding compatible units
 ------------------------
 
 With so many units defined, it is not always obvious which ones are
-available to convert to. The ``compatible_units()`` method, available on
-both ``Quantity`` and ``Unit`` objects, returns the set of units sharing
-the same dimensionality:
+available to convert to. The ``compatible_units()`` method returns the
+set of units sharing the same dimensionality:
 
 .. doctest::
 

--- a/docs/getting/tutorial.rst
+++ b/docs/getting/tutorial.rst
@@ -138,6 +138,34 @@ how to do:
 See the section on :doc:`contexts` for information about expanding Pint's
 automatic conversion capabilities for your application.
 
+Finding compatible units
+------------------------
+
+With so many units defined, it is not always obvious which ones are
+available to convert to. The ``compatible_units()`` method, available on
+both ``Quantity`` and ``Unit`` objects, returns the set of units sharing
+the same dimensionality:
+
+.. doctest::
+
+   >>> for unit in sorted(speed.compatible_units(), key=str):
+   ...     print(unit)
+   LMH
+   foot_per_second
+   kilometer_per_hour
+   kilometer_per_second
+   knot
+   meter_per_second
+   mile_per_hour
+   speed_of_light
+   >>> ureg.knot in speed.compatible_units()
+   True
+
+Note that this only lists units that are defined with a name in the
+registry, such as ``knot`` or ``meter_per_second``; it does not include
+every compound unit of the same dimensionality that could be built
+from other units, such as ``mile / hour``.
+
 Simplifying units
 -----------------
 


### PR DESCRIPTION
## Summary
- With so many units defined in the registry, it's not obvious how to discover which units a given `Quantity` or `Unit` can convert to.
- Adds a "Finding compatible units" section to the tutorial demonstrating `compatible_units()`, including a note that it only returns named units of the same dimensionality, not arbitrary compound units that could be built from other units.

## Test plan
- [x] Manually replayed the tutorial's doctest state in Python to confirm the example's output matches exactly (the docs pixi env's Sphinx doctest build is currently broken locally due to an unrelated `kiwisolver` native-extension import error, unrelated to this change)

Fixes #2151