### PR TITLE
Support * and / between Quantity and datetime.timedelta

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Pint Changelog
 -------------------
 
 - Fix `unit in registry` raising `AttributeError` instead of returning `True` when checking membership with a `Unit` object rather than a string (#2156)
+- Support `*` and `/` between `Quantity` and `datetime.timedelta`, converting the `timedelta` to a `Quantity` in seconds (#2348)
 - Fix `DimensionalityError` from `numpy_scalar == quantity` for incompatible dimensions; now returns `False`/`True` like `quantity == numpy_scalar` (#2182)
 - Fix `wraps` raising an `AssertionError` for arguments declared as `"dimensionless"` (affecting math functions such as `exp` or `log`) (#2255)
 - Raise ``DefinitionSyntaxError`` instead of a bare ``AssertionError`` when parsing an expression that is only an operator, e.g. ``ureg('-')`` or ``ureg('*')`` (#2124)

--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,7 @@ Pint Changelog
 -------------------
 
 - Fix `unit in registry` raising `AttributeError` instead of returning `True` when checking membership with a `Unit` object rather than a string (#2156)
-- Support `*` and `/` between `Quantity` and `datetime.timedelta`, converting the `timedelta` to a `Quantity` in seconds (#2348)
+- Support `*`, `/`, `+`, and `-` between `Quantity` and `datetime.timedelta`, converting the `timedelta` to a `Quantity` in seconds (#2348)
 - Fix `DimensionalityError` from `numpy_scalar == quantity` for incompatible dimensions; now returns `False`/`True` like `quantity == numpy_scalar` (#2182)
 - Fix `wraps` raising an `AssertionError` for arguments declared as `"dimensionless"` (affecting math functions such as `exp` or `log`) (#2255)
 - Raise ``DefinitionSyntaxError`` instead of a bare ``AssertionError`` when parsing an expression that is only an operator, e.g. ``ureg('-')`` or ``ureg('*')`` (#2124)

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -687,6 +687,9 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
             operator function (e.g. operator.add, operator.isub)
 
         """
+        if self._is_timedelta(other):
+            other = self.__class__(other)
+
         if not self._check(other):
             # other not a PlainQuantity
             try:
@@ -799,6 +802,9 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
         op : function
             operator function (e.g. operator.add, operator.isub)
         """
+        if self._is_timedelta(other):
+            other = self.__class__(other)
+
         if not self._check(other):
             # other not from same Registry or not a PlainQuantity
             if zero_or_nan(other, True):

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -215,7 +215,7 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
         if inst._is_timedelta(value):
             m, u = inst._convert_timedelta(value)
             inst._magnitude = m
-            inst._units = inst.UnitsContainer({u: 1})
+            inst._units = inst._REGISTRY.parse_units(u)._units
             if units:
                 inst.ito(units)
             return inst
@@ -1037,6 +1037,9 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
         if units_op is None:
             units_op = magnitude_op
 
+        if self._is_timedelta(other):
+            other = self.__class__(other)
+
         offset_units_self = self._get_non_multiplicative_units()
         no_offset_units_self = len(offset_units_self)
 
@@ -1105,6 +1108,9 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
         """
         if units_op is None:
             units_op = magnitude_op
+
+        if self._is_timedelta(other):
+            other = self.__class__(other)
 
         offset_units_self = self._get_non_multiplicative_units()
         no_offset_units_self = len(offset_units_self)
@@ -1247,6 +1253,9 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
         other: opt.CanTruediv[MagnitudeT_co, U],
     ) -> PlainQuantity[U]: ...
     def __rtruediv__(self: PlainQuantity, other) -> PlainQuantity:
+        if self._is_timedelta(other):
+            return self.__class__(other) / self
+
         try:
             other_magnitude = _to_magnitude(
                 other, self.force_ndarray, self.force_ndarray_like

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -2053,6 +2053,48 @@ class TestTimedelta(QuantityTestCase):
             q, self.Q_(np.array([0.1, 0.2, 0.36]), "m/s**2")
         )
 
+    def test_add_sub_timedelta(self):
+        # 2348
+        t = datetime.timedelta(seconds=10)
+        q = self.Q_(3.6, "s")
+        assert q + t == self.Q_(13.6, "s")
+        assert t + q == self.Q_(13.6, "s")
+        assert q - t == self.Q_(-6.4, "s")
+        assert t - q == self.Q_(6.4, "s")
+
+        with pytest.raises(DimensionalityError):
+            self.Q_(3.6, "m") + t
+
+        q2 = self.Q_(3.6, "s")
+        q2 += t
+        assert q2 == self.Q_(13.6, "s")
+        q3 = self.Q_(3.6, "s")
+        q3 -= t
+        assert q3 == self.Q_(-6.4, "s")
+
+    @helpers.requires_numpy
+    def test_add_sub_timedelta_np(self):
+        # 2348
+        t = datetime.timedelta(seconds=10)
+        q = self.Q_(np.array([1.0, 2.0, 3.6]), "s")
+        helpers.assert_quantity_almost_equal(
+            q + t, self.Q_(np.array([11.0, 12.0, 13.6]), "s")
+        )
+        helpers.assert_quantity_almost_equal(
+            t + q, self.Q_(np.array([11.0, 12.0, 13.6]), "s")
+        )
+        helpers.assert_quantity_almost_equal(
+            q - t, self.Q_(np.array([-9.0, -8.0, -6.4]), "s")
+        )
+        helpers.assert_quantity_almost_equal(
+            t - q, self.Q_(np.array([9.0, 8.0, 6.4]), "s")
+        )
+
+        q += t
+        helpers.assert_quantity_almost_equal(
+            q, self.Q_(np.array([11.0, 12.0, 13.6]), "s")
+        )
+
     @pytest.mark.parametrize(
         ["timedelta_unit", "pint_unit"],
         (

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -2015,6 +2015,44 @@ class TestTimedelta(QuantityTestCase):
         assert q_hours == 3 * self.ureg.second
         assert q_hours.units == self.ureg.hour
 
+    def test_mul_div(self):
+        # 2348
+        t = datetime.timedelta(seconds=10)
+        q = self.Q_(3.6, "m/s")
+        assert q * t == self.Q_(36.0, "m")
+        assert t * q == self.Q_(36.0, "m")
+        assert q / t == self.Q_(0.36, "m/s**2")
+        assert t / q == self.Q_(10 / 3.6, "s**2/m")
+
+    @helpers.requires_numpy
+    def test_mul_div_np(self):
+        # 2348
+        t = datetime.timedelta(seconds=10)
+        q = self.Q_(np.array([1.0, 2.0, 3.6]), "m/s")
+        helpers.assert_quantity_almost_equal(
+            q * t, self.Q_(np.array([10.0, 20.0, 36.0]), "m")
+        )
+        helpers.assert_quantity_almost_equal(
+            t * q, self.Q_(np.array([10.0, 20.0, 36.0]), "m")
+        )
+        helpers.assert_quantity_almost_equal(
+            q / t, self.Q_(np.array([0.1, 0.2, 0.36]), "m/s**2")
+        )
+        helpers.assert_quantity_almost_equal(
+            t / q, self.Q_(10 / np.array([1.0, 2.0, 3.6]), "s**2/m")
+        )
+
+        q *= t
+        helpers.assert_quantity_almost_equal(
+            q, self.Q_(np.array([10.0, 20.0, 36.0]), "m")
+        )
+
+        q = self.Q_(np.array([1.0, 2.0, 3.6]), "m/s")
+        q /= t
+        helpers.assert_quantity_almost_equal(
+            q, self.Q_(np.array([0.1, 0.2, 0.36]), "m/s**2")
+        )
+
     @pytest.mark.parametrize(
         ["timedelta_unit", "pint_unit"],
         (


### PR DESCRIPTION
## Summary
- Previously, `Quantity * timedelta` (and its reflected form) wrapped the raw `timedelta` object as the magnitude, and `Quantity / timedelta` raised `TypeError`, since `timedelta` was never converted into a proper duration `Quantity` before the arithmetic.
- `*` and `/` (in both directions, and their in-place forms) now convert a `datetime.timedelta` operand into a `Quantity` in seconds first, so the result is a normal `Quantity`:
  ```python
  >>> q = Quantity(3.6, "m/s")
  >>> t = timedelta(seconds=10)
  >>> q * t
  Quantity(36.0, "meter")
  >>> q / t
  Quantity(0.36, "meter / second ** 2")
  >>> t / q
  Quantity(2.7777777777777777, "second ** 2 / meter")
  ```
- Also fixes a latent bug in the `datetime.timedelta`-to-`Quantity` `__init__` path (added in #1978) that stored `"seconds"` (a plural alias) as the raw `UnitsContainer` key instead of resolving it to the canonical `"second"` name. This surfaced once `timedelta` operands were routed through regular arithmetic, which does direct unit-definition lookups.
- Note: `numpy.timedelta64` involved in numpy ufunc dispatch (e.g. `numpy_array_quantity * np.timedelta64(...)`) has a separate, pre-existing limitation not addressed here; this PR covers `datetime.timedelta`, matching the issue's scope, including quantities backed by numpy array magnitudes.

## Test plan
- [x] Added `TestTimedelta.test_mul_div` and `test_mul_div_np` in `pint/testsuite/test_quantity.py` covering scalar and numpy-array-backed quantities, both directions of `*`/`/`, and in-place `*=`/`/=`
- [x] Full test suite passes in both the plain (`pixi run -e test`) and numpy-inclusive (`pixi run -e docs`) environments

Fixes #2348