### PR TITLE
Remove ambiguous Nm alias from number_meter

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.26.0 (unreleased)
 -------------------
 
+- Remove the ambiguous `Nm` alias from `number_meter` (Textile group), since it's commonly expected to mean newton-meter (torque) (#1966)
 - Fix `unit in registry` raising `AttributeError` instead of returning `True` when checking membership with a `Unit` object rather than a string (#2156)
 - Fix `DimensionalityError` from `numpy_scalar == quantity` for incompatible dimensions; now returns `False`/`True` like `quantity == numpy_scalar` (#2182)
 - Fix `wraps` raising an `AssertionError` for arguments declared as `"dimensionless"` (affecting math functions such as `exp` or `log`) (#2255)

--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -710,7 +710,7 @@ neper = 1 ; logbase: 2.71828182845904523536028747135266249775724709369995; logfa
     RKM  = gf / tex
 
     number_english = 840 * yard / pound = Ne = NeC = ECC
-    number_meter = kilometer / kilogram = Nm
+    number_meter = kilometer / kilogram
 @end
 
 
@@ -866,7 +866,7 @@ neper = 1 ; logbase: 2.71828182845904523536028747135266249775724709369995; logfa
 
 @context textile
     # Allow switching between Direct count system (i.e. tex) and
-    # Indirect count system (i.e. Ne, Nm)
+    # Indirect count system (i.e. number_english, number_meter)
     [mass] / [length] <-> [length] / [mass]: 1 / value
 @end
 

--- a/pint/testsuite/test_contexts.py
+++ b/pint/testsuite/test_contexts.py
@@ -698,12 +698,12 @@ class TestDefinedContexts:
         ureg = class_registry
         qty_direct = 1.331 * ureg.tex
         with pytest.raises(DimensionalityError):
-            qty_indirect = qty_direct.to("Nm")
+            qty_indirect = qty_direct.to("number_meter")
 
         with ureg.context("textile"):
             from pint.util import find_shortest_path
 
-            qty_indirect = qty_direct.to("Nm")
+            qty_indirect = qty_direct.to("number_meter")
             a = qty_direct.to_base_units()
             b = qty_indirect.to_base_units()
             da, db = Context.__keytransform__(a.dimensionality, b.dimensionality)


### PR DESCRIPTION
## Summary
- Removes the `Nm` alias from the Textile group's `number_meter` unit (`pint/default_en.txt`), since `Nm` is widely expected to mean newton-meter (torque) but previously resolved to `kilometer/kilogram` with dimensionality `[length]/[mass]` — a silent, confusing mismatch.
- Updates the `textile` context comment and `test_contexts.py` to reference `number_meter` by its full name instead of the removed alias.
- `number_meter` itself is untouched and still usable by its full name.

Closes #1966.

## Test plan
- [x] `pixi run -e test test` passes (1658 passed)
- [x] Verified `ureg('Nm')` now raises `UndefinedUnitError` instead of silently resolving to `number_meter`
- [x] Verified `ureg('number_meter')` still works