### PR TITLE
Fix is_compatible_with edge cases with dimensionless types and strings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.26.0 (unreleased)
 -------------------
 
+- Fix `is_compatible_with` edge cases with dimensionless types and unit strings with a scaling factor (e.g. `"35000 ft"`) (#1190)
 - Allow string parsing of offset units (#386)
 - Remove the ambiguous `Nm` alias from `number_meter` (Textile group), since it's commonly expected to mean newton-meter (torque) (#1966)
 - Fix `unit in registry` raising `AttributeError` instead of returning `True` when checking membership with a `Unit` object rather than a string (#2156)

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -515,7 +515,8 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
         if isinstance(other, str):
             return (
-                self.dimensionality == self._REGISTRY.parse_units(other).dimensionality
+                self.dimensionality
+                == self._REGISTRY.parse_expression(other).dimensionality
             )
 
         return self.dimensionless

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -1091,7 +1091,12 @@ class GenericPlainRegistry[QuantityT: PlainQuantity, UnitT: PlainUnit](
                 obj2, *contexts, **ctx_kwargs
             )
 
-        return not isinstance(obj2, (self.Quantity, self.Unit))
+        if isinstance(obj2, (self.Quantity, self.Unit, str)):
+            return self.is_compatible_with(obj2, obj1, *contexts, **ctx_kwargs)
+
+        # neither obj1 nor obj2 is a Quantity, Unit or str, so both are
+        # treated as dimensionless and are therefore compatible.
+        return True
 
     def convert[T](
         self,

--- a/pint/facets/plain/unit.py
+++ b/pint/facets/plain/unit.py
@@ -137,7 +137,8 @@ class PlainUnit(PrettyIPython, SharedRegistryObject):
 
         if isinstance(other, str):
             return (
-                self.dimensionality == self._REGISTRY.parse_units(other).dimensionality
+                self.dimensionality
+                == self._REGISTRY.parse_expression(other).dimensionality
             )
 
         return self.dimensionless

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -808,6 +808,65 @@ class TestQuantity(QuantityTestCase):
 
         assert c.is_compatible_with(12)
 
+    def test_is_compatible_with_offset_units(self):
+        # 1190: offset units follow a different code path (via .to()) when
+        # contexts are involved, so make sure dimensionality-based
+        # compatibility still holds for them.
+        a = self.Q_(100, "degC")
+        b = self.Q_(50, "degF")
+
+        assert a.is_compatible_with(b)
+        assert a.is_compatible_with("degF")
+        assert a.is_compatible_with("kelvin")
+        assert a.is_compatible_with(self.U_("kelvin"))
+        assert not a.is_compatible_with("kg")
+
+    def test_is_compatible_with_string_with_magnitude(self):
+        # 1190: parsing a string with a scaling factor used to raise
+        # ValueError instead of being treated like any other unit string.
+        a = self.Q_(80, "in")
+
+        assert a.is_compatible_with("35000 ft")
+        assert not a.is_compatible_with("35000 kg")
+
+    def test_registry_is_compatible_with(self):
+        # 1190: UnitRegistry.is_compatible_with(obj1, obj2) used to be
+        # asymmetric when obj1 was a plain number/array and obj2 was a
+        # Quantity or Unit.
+        ureg = self.ureg
+
+        assert ureg.is_compatible_with(ureg.deg, 10.0)
+        assert ureg.is_compatible_with(10.0, ureg.deg)
+        assert ureg.is_compatible_with(self.Q_(10, ""), ureg.deg)
+        assert ureg.is_compatible_with(ureg.deg, self.Q_(10, ""))
+        assert not ureg.is_compatible_with(10.0, ureg.meter)
+        assert not ureg.is_compatible_with(ureg.meter, 10.0)
+
+        assert ureg.is_compatible_with("80 in", "35000 ft")
+        assert ureg.is_compatible_with("in", "35000 ft")
+        assert not ureg.is_compatible_with("80 in", "35000 kg")
+
+    def test_registry_is_compatible_with_non_pint_types(self):
+        # 1190: when neither argument is a Quantity, Unit or str, both are
+        # treated as dimensionless (matching master's pre-existing, if
+        # accidental, behavior of never raising here).
+        ureg = self.ureg
+
+        assert ureg.is_compatible_with(10.0, 5.0)
+        assert ureg.is_compatible_with(True, False)
+        assert ureg.is_compatible_with(None, None)
+        assert ureg.is_compatible_with({"a": 1}, {"a": 1})
+
+    @helpers.requires_numpy
+    def test_registry_is_compatible_with_np(self):
+        # 1190
+        ureg = self.ureg
+        arr = np.array([1, 2, 3, 4])
+
+        assert ureg.is_compatible_with(arr, ureg.deg)
+        assert ureg.is_compatible_with(ureg.deg, arr)
+        assert not ureg.is_compatible_with(arr, ureg.meter)
+
     def test_is_compatible_with_with_context(self):
         a = self.Q_(532.0, "nm")
         b = self.Q_(563.5, "terahertz")

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -229,6 +229,22 @@ class TestUnit(QuantityTestCase):
         unit = self.ureg.Unit("")
         assert unit.is_compatible_with(0.5)
 
+    def test_is_compatible_with_offset_units(self):
+        # 1190
+        unit = self.ureg.Unit("degC")
+
+        assert unit.is_compatible_with(self.ureg.Unit("degF"))
+        assert unit.is_compatible_with("kelvin")
+        assert not unit.is_compatible_with("kg")
+
+    def test_is_compatible_with_string_with_magnitude(self):
+        # 1190: parsing a string with a scaling factor used to raise
+        # ValueError instead of being treated like any other unit string.
+        unit = self.ureg.Unit("in")
+
+        assert unit.is_compatible_with("35000 ft")
+        assert not unit.is_compatible_with("35000 kg")
+
     def test_systems(self):
         unit = self.ureg.Unit("m")
         assert unit.systems == frozenset({"cgs", "atomic", "Planck", "mks", "SI"})


### PR DESCRIPTION
this uses #1191 (opened in 2020 by @jules-ch, never merged) and keeps existing master behaviour rather than raising TypeError as @keewis suggested. If we want to raise that can be done in another PR.


## Summary

Following on from #1191 (opened in 2020 by @jules-ch, never merged) and its underlying issue #1190, which reported that `is_compatible_with` had several inconsistent edge cases. These are all still present on current `master`:

```python
>>> ureg.is_compatible_with(np.array([1, 2, 3, 4]), ureg.deg)
False  # expected True

>>> ureg.is_compatible_with(ureg.deg, 10.0)
True
>>> ureg.is_compatible_with(10.0, ureg.deg)
False  # expected True (asymmetric)

>>> ureg.is_compatible_with("80 in", "35000 ft")
ValueError: Unit expression cannot have a scaling factor.
```

- `UnitRegistry.is_compatible_with(obj1, obj2)`: when `obj1` wasn't a `Quantity`/`Unit`/`str`, it returned `not isinstance(obj2, (Quantity, Unit))` instead of actually checking dimensionality, causing the asymmetry above. Now, if `obj2` is a `Quantity`/`Unit`/`str`, the arguments are swapped so `obj2`'s own `is_compatible_with` handles it; otherwise `obj1` is treated as a dimensionless `Quantity`, matching the existing single-argument `Quantity`/`Unit` `is_compatible_with` behavior.
- `Quantity.is_compatible_with()` / `Unit.is_compatible_with()`: string arguments were parsed with `parse_units()`, which rejects a leading magnitude (`"35000 ft"`). Switched to `parse_expression()`, consistent with `jules-ch`'s original suggestion in #1190.
- Added a couple of tests for offset units (`degC`/`degF`) per `dalito`'s review comment on #1191, since that code path goes through `.to()` when contexts are involved.

I didn't carry over the `TypeError` for `dict`/`bool`/`None` from the original PR's proposed rewrite — the author themselves was unsure whether that should be an error or `False`, and it's outside the scope of the reported bug.

## Test plan
- [x] Added tests in `test_quantity.py` (`test_is_compatible_with_offset_units`, `test_is_compatible_with_string_with_magnitude`, `test_registry_is_compatible_with`, `test_registry_is_compatible_with_np`) and `test_unit.py` (`test_is_compatible_with_offset_units`, `test_is_compatible_with_string_with_magnitude`) covering all the reported edge cases
- [x] Full test suite passes in both the plain and numpy-inclusive environments

Fixes #1190