### PR TITLE
Format negative magnitudes with the pretty exponent

### DIFF
--- a/pint/delegates/formatter/html.py
+++ b/pint/delegates/formatter/html.py
@@ -41,10 +41,6 @@ if TYPE_CHECKING:
     from ...facets.plain import PlainQuantity, PlainUnit
 
 _EXP_PATTERN = re.compile(r"(-?[0-9]\.?[0-9]*)e(-?)\+?0*([0-9]+)")
-# The leading sign is part of the pattern rather than relaxing match() to search().
-# An array magnitude is one bracketed string of several numbers, and sub() below builds
-# its replacement once from the first match, so a search() would give every element the
-# first element's exponent: [1e-16 1 1e+10] would render as [1x10^-16 1 1x10^-16].
 
 
 class HTMLFormatter(BaseFormatter):

--- a/pint/delegates/formatter/html.py
+++ b/pint/delegates/formatter/html.py
@@ -40,7 +40,11 @@ if TYPE_CHECKING:
     from ...facets.measurement import Measurement
     from ...facets.plain import PlainQuantity, PlainUnit
 
-_EXP_PATTERN = re.compile(r"([0-9]\.?[0-9]*)e(-?)\+?0*([0-9]+)")
+_EXP_PATTERN = re.compile(r"(-?[0-9]\.?[0-9]*)e(-?)\+?0*([0-9]+)")
+# The leading sign is part of the pattern rather than relaxing match() to search().
+# An array magnitude is one bracketed string of several numbers, and sub() below builds
+# its replacement once from the first match, so a search() would give every element the
+# first element's exponent: [1e-16 1 1e+10] would render as [1x10^-16 1 1x10^-16].
 
 
 class HTMLFormatter(BaseFormatter):

--- a/pint/delegates/formatter/latex.py
+++ b/pint/delegates/formatter/latex.py
@@ -163,7 +163,7 @@ def siunitx_format_unit(
     return "".join(lpos) + "".join(lneg)
 
 
-_EXP_PATTERN = re.compile(r"([0-9]\.?[0-9]*)e(-?)\+?0*([0-9]+)")
+_EXP_PATTERN = re.compile(r"(-?[0-9]\.?[0-9]*)e(-?)\+?0*([0-9]+)")
 
 
 class LatexFormatter(BaseFormatter):

--- a/pint/delegates/formatter/plain.py
+++ b/pint/delegates/formatter/plain.py
@@ -46,7 +46,11 @@ if TYPE_CHECKING:
     from ...registry import UnitRegistry
 
 
-_EXP_PATTERN = re.compile(r"([0-9]\.?[0-9]*)e(-?)\+?0*([0-9]+)")
+_EXP_PATTERN = re.compile(r"(-?[0-9]\.?[0-9]*)e(-?)\+?0*([0-9]+)")
+# The leading sign is part of the pattern rather than relaxing match() to search().
+# An array magnitude is one bracketed string of several numbers, and sub() below builds
+# its replacement once from the first match, so a search() would give every element the
+# first element's exponent: [1e-16 1 1e+10] would render as [1x10^-16 1 1x10^-16].
 
 
 class BaseFormatter:

--- a/pint/delegates/formatter/plain.py
+++ b/pint/delegates/formatter/plain.py
@@ -47,10 +47,6 @@ if TYPE_CHECKING:
 
 
 _EXP_PATTERN = re.compile(r"(-?[0-9]\.?[0-9]*)e(-?)\+?0*([0-9]+)")
-# The leading sign is part of the pattern rather than relaxing match() to search().
-# An array magnitude is one bracketed string of several numbers, and sub() below builds
-# its replacement once from the first match, so a search() would give every element the
-# first element's exponent: [1e-16 1 1e+10] would render as [1x10^-16 1 1x10^-16].
 
 
 class BaseFormatter:

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1666,6 +1666,8 @@ def test_issue2182():
     assert q != np.float64(5.0)
     assert np.float64(5.0) != q  # used to raise DimensionalityError
     assert np.array(5.0) != q  # used to raise DimensionalityError
+
+
 def test_negative_magnitude_pretty_exponent():
     # The exponent pattern was anchored with match() but did not allow a leading
     # sign, so a negative magnitude never matched and kept the raw "e-07" form

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1666,3 +1666,27 @@ def test_issue2182():
     assert q != np.float64(5.0)
     assert np.float64(5.0) != q  # used to raise DimensionalityError
     assert np.array(5.0) != q  # used to raise DimensionalityError
+def test_negative_magnitude_pretty_exponent():
+    # The exponent pattern was anchored with match() but did not allow a leading
+    # sign, so a negative magnitude never matched and kept the raw "e-07" form
+    # while its positive counterpart was formatted.
+    ureg = UnitRegistry()
+
+    assert f"{ureg.Quantity(1.5e-7, 'meter'):P}" == "1.5×10⁻⁷ meter"
+    assert f"{ureg.Quantity(-1.5e-7, 'meter'):P}" == "-1.5×10⁻⁷ meter"
+
+    assert f"{ureg.Quantity(-1.5e-7, 'meter'):H}" == "-1.5×10<sup>-7</sup> meter"
+
+
+@helpers.requires_numpy
+def test_negative_magnitude_pretty_exponent_leaves_arrays_alone():
+    # Guards the tempting fix. Relaxing match() to search() so the leading "-" stops
+    # blocking would match inside an array's bracketed string, and sub() builds its
+    # replacement once from the first match, so every element would be rewritten with
+    # the first element's exponent: [1e-16 1 1e+10] -> [1×10⁻¹⁶ 1 1×10⁻¹⁶].
+    ureg = UnitRegistry()
+
+    for values in ([1e-16, 1.0, 1e10], [-1e-16, 1.0, 1e10]):
+        formatted = f"{ureg.Quantity(np.array(values), 'meter'):P}"
+        assert "×10" not in formatted
+        assert formatted == f"{ureg.Quantity(np.array(values), 'meter'):}"


### PR DESCRIPTION
Re-opening this per @andrewgsavage's "if you put a PR with those changes in again I'll take a look" on #2350. This is the same fix, rewritten to be array-safe, and rebased on current master.

### The bug, still present on master

`_EXP_PATTERN` is applied with an anchored `match()` but has no leading sign, so a negative magnitude never matches at position 0:

```python
_EXP_PATTERN = re.compile(r"([0-9]\.?[0-9]*)e(-?)\+?0*([0-9]+)")
```

```
 1.5e-07 meter  ->  1.5×10⁻⁷ meter
-1.5e-07 meter  -> -1.5e-07 meter     <- unformatted
```

Both `plain.py` (`:P`) and `html.py` (`:H`) carry the same pattern and the same problem.

### The fix, and the trap it avoids

The obvious change is `match()` to `search()`, so the leading `-` stops blocking. That is what I did the first time, and it is wrong.

An array magnitude is formatted as one bracketed string containing several numbers. `search()` finds an exponent somewhere inside it, and then the substitution builds its replacement **once, from the first match**:

```python
exp = int(m.group(2) + m.group(3))
mstr = _EXP_PATTERN.sub(r"\1×10" + pretty_fmt_exponent(exp), mstr)
```

so every element is rewritten with the *first* element's exponent, and `[1e-16 1 1e+10]` renders as `[1×10⁻¹⁶ 1 1×10⁻¹⁶]`. Wrong numbers, not wrong styling.

So the sign goes in the pattern and the anchor stays:

```python
_EXP_PATTERN = re.compile(r"(-?[0-9]\.?[0-9]*)e(-?)\+?0*([0-9]+)")
```

A scalar matches at position 0 with the sign in group 1; a bracketed array still fails at position 0 and is left alone, exactly as today.

### Tests

Two, in `test_issues.py`:

- `test_negative_magnitude_pretty_exponent` covers the scalar case for `:P` and `:H`
- `test_negative_magnitude_pretty_exponent_leaves_arrays_alone` pins the trap above, so a future `search()` cannot pass review

Reverting just the pattern in both files turns the first red and leaves the second green, which is the right split: the array test is a guard, not the bug.

Full suite on Python 3.13: **2266 passed, 139 skipped, 11 xfailed**, benchmarks excluded (they need `pytest-codspeed`).
