### PR TITLE
Improve typing for Quantity constructor and arithmetic with `timedelta`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,7 +41,6 @@ Other contributors, listed alphabetically, are:
 * Matthieu Dartiailh <marul@laposte.net>
 * Nate Bogdanowicz <natezb@gmail.com>
 * Peter Grayson <jpgrayson@gmail.com>
-* Riccardo Bergamaschi
 * Richard Barnes <rbarnes@umn.edu>
 * Robert Booth <rob@ishigoya.com>
 * Ryan Dwyer <ryanpdwyer@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Other contributors, listed alphabetically, are:
 * Matthieu Dartiailh <marul@laposte.net>
 * Nate Bogdanowicz <natezb@gmail.com>
 * Peter Grayson <jpgrayson@gmail.com>
+* Riccardo Bergamaschi
 * Richard Barnes <rbarnes@umn.edu>
 * Robert Booth <rob@ishigoya.com>
 * Ryan Dwyer <ryanpdwyer@gmail.com>

--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Pint Changelog
 - Remove the ambiguous `Nm` alias from `number_meter` (Textile group), since it's commonly expected to mean newton-meter (torque) (#1966)
 - Fix `unit in registry` raising `AttributeError` instead of returning `True` when checking membership with a `Unit` object rather than a string (#2156)
 - Support `*`, `/`, `+`, and `-` between `Quantity` and `datetime.timedelta`, converting the `timedelta` to a `Quantity` in seconds (#2348)
+- Improve type annotations for `Quantity`'s constructor and support `*`, `/`, `+` and `-` between `Quantity` and `datetime.timedelta` at the typing level (#2373)
 - Fix `DimensionalityError` from `numpy_scalar == quantity` for incompatible dimensions; now returns `False`/`True` like `quantity == numpy_scalar` (#2182)
 - Fix `wraps` raising an `AssertionError` for arguments declared as `"dimensionless"` (affecting math functions such as `exp` or `log`) (#2255)
 - Raise ``DefinitionSyntaxError`` instead of a bare ``AssertionError`` when parsing an expression that is only an operator, e.g. ``ureg('-')`` or ``ureg('*')`` (#2124)

--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,7 @@ Pint Changelog
 - Remove the ambiguous `Nm` alias from `number_meter` (Textile group), since it's commonly expected to mean newton-meter (torque) (#1966)
 - Fix `unit in registry` raising `AttributeError` instead of returning `True` when checking membership with a `Unit` object rather than a string (#2156)
 - Support `*`, `/`, `+`, and `-` between `Quantity` and `datetime.timedelta`, converting the `timedelta` to a `Quantity` in seconds (#2348)
-- Improve type annotations for `Quantity`'s constructor and support `*`, `/`, `+` and `-` between `Quantity` and `datetime.timedelta` at the typing level (#2373)
+- Improve type annotations for `Quantity`'s `__new__` and document support for arithmetic with `datetime.timedelta` introduced in #2348 at the typing level (#2373)
 - Fix `DimensionalityError` from `numpy_scalar == quantity` for incompatible dimensions; now returns `False`/`True` like `quantity == numpy_scalar` (#2182)
 - Fix `wraps` raising an `AssertionError` for arguments declared as `"dimensionless"` (affecting math functions such as `exp` or `log`) (#2255)
 - Raise ``DefinitionSyntaxError`` instead of a bare ``AssertionError`` when parsing an expression that is only an operator, e.g. ``ureg('-')`` or ``ureg('*')`` (#2124)

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -943,10 +943,12 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
         return self.__class__(magnitude, units)
 
+    # Quantity[float] += datetime -> becomes datetime
     @overload
     def __iadd__[T: int | float](
         self: PlainQuantity[T], other: datetime.datetime
-    ) -> datetime.timedelta: ...
+    ) -> datetime.datetime: ...
+    # General overload (should work in most cases)
     @overload
     def __iadd__[T: Magnitude, U: Magnitude](
         self: PlainQuantity[opt.CanIAdd[T, U]], other: PlainQuantity[T] | T
@@ -962,17 +964,12 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
     @overload
     def __add__(
         self: PlainQuantity[int | float], other: datetime.datetime
-    ) -> datetime.timedelta: ...
+    ) -> datetime.datetime: ...
     # PlainQuantity[float | array[float]] + timedelta -> PlainQuantity[float | array[float]]
     @overload
-    def __add__(
-        self: PlainQuantity[float], other: datetime.timedelta | np.timedelta64
-    ) -> PlainQuantity[float]: ...
-    @overload
-    def __add__[X: np.floating, S: Shape](
-        self: PlainQuantity[npt.ArrayND[X, S]],
-        other: datetime.timedelta | np.timedelta64,
-    ) -> PlainQuantity[npt.ArrayND[X, S]]: ...
+    def __add__[T: int | float | npt.ArrayND[np.floating]](
+        self: PlainQuantity[T], other: datetime.timedelta | np.timedelta64
+    ) -> PlainQuantity[T]: ...
     # General overloads (should work in most cases)
     @overload
     def __add__[T: Magnitude, U: Magnitude](
@@ -997,15 +994,9 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
         def __radd__(self, other):
             return self.__add__(other)
 
-    @overload
-    def __isub__(
-        self: PlainQuantity[int | float], other: datetime.datetime
-    ) -> datetime.timedelta: ...
-    @overload
     def __isub__[T: Magnitude, U: Magnitude](
         self: PlainQuantity[opt.CanISub[T, U]], other: PlainQuantity[T] | T
-    ) -> PlainQuantity[U]: ...
-    def __isub__(self, other):
+    ) -> PlainQuantity[U]:
         if is_duck_array_type(type(self._magnitude)):
             return self._iadd_sub(other, operator.isub)
 
@@ -1013,14 +1004,9 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
     # PlainQuantity[float | array[float]] - timedelta -> PlainQuantity[float | array[float]]
     @overload
-    def __sub__(
-        self: PlainQuantity[float], other: datetime.timedelta | np.timedelta64
-    ) -> PlainQuantity[float]: ...
-    @overload
-    def __sub__[X: np.floating, S: Shape](
-        self: PlainQuantity[npt.ArrayND[X, S]],
-        other: datetime.timedelta | np.timedelta64,
-    ) -> PlainQuantity[npt.ArrayND[X, S]]: ...
+    def __sub__[T: int | float | npt.ArrayND[np.floating]](
+        self: PlainQuantity[T], other: datetime.timedelta | np.timedelta64
+    ) -> PlainQuantity[T]: ...
     # General overloads (should work in most cases)
     @overload
     def __sub__[T: Magnitude, U: Magnitude](
@@ -1035,22 +1021,18 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
     def __sub__(self, other):
         return self._add_sub(other, operator.sub)
 
-    # timedelta - PlainQuantity[float | array[float]] -> PlainQuantity[float | array[float]]
-    @overload
-    def __rsub__(
-        self: PlainQuantity[float], other: datetime.timedelta | np.timedelta64
-    ) -> PlainQuantity[float]: ...
-    @overload
-    def __rsub__[X: np.floating, S: Shape](
-        self: PlainQuantity[npt.ArrayND[X, S]],
-        other: datetime.timedelta | np.timedelta64,
-    ) -> PlainQuantity[npt.ArrayND[X, S]]: ...
-    # General overloads (should work in most cases)
+    # datetime - PlainQuantity[float] -> datetime
     @overload
     def __rsub__(
         self: PlainQuantity[int | float],
         other: datetime.datetime,
     ) -> datetime.datetime: ...
+    # timedelta - PlainQuantity[float | array[float]] -> PlainQuantity[float | array[float]]
+    @overload
+    def __rsub__[T: int | float | npt.ArrayND[np.floating]](
+        self: PlainQuantity[T], other: datetime.timedelta | np.timedelta64
+    ) -> PlainQuantity[T]: ...
+    # General overloads (should work in most cases)
     @overload
     def __rsub__[T: Magnitude, U: Magnitude](
         self: PlainQuantity[opt.CanRSub[T, U]], other: T
@@ -1225,14 +1207,9 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
     # Quantity[float | array[float]] * timedelta -> Quantity[float | array[float]]
     @overload
-    def __mul__(
-        self: PlainQuantity[float], other: datetime.timedelta | np.timedelta64
-    ) -> PlainQuantity[float]: ...
-    @overload
-    def __mul__[X: np.floating, S: Shape](
-        self: PlainQuantity[npt.ArrayND[X, S]],
-        other: datetime.timedelta | np.timedelta64,
-    ) -> PlainQuantity[npt.ArrayND[X, S]]: ...
+    def __mul__[T: int | float | npt.ArrayND[np.floating]](
+        self: PlainQuantity[T], other: datetime.timedelta | np.timedelta64
+    ) -> PlainQuantity[T]: ...
     # General overloads (should work in most cases)
     @overload
     def __mul__[T: Magnitude, U: Magnitude](
@@ -1294,14 +1271,9 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
     # PlainQuantity[float | array[float]] / timedelta -> PlainQuantity[float | array[float]]
     @overload
-    def __truediv__(
-        self: PlainQuantity[float], other: datetime.timedelta | np.timedelta64
-    ) -> PlainQuantity[float]: ...
-    @overload
-    def __truediv__[X: np.floating, S: Shape](
-        self: PlainQuantity[npt.ArrayND[X, S]],
-        other: datetime.timedelta | np.timedelta64,
-    ) -> PlainQuantity[npt.ArrayND[X, S]]: ...
+    def __truediv__[T: int | float | npt.ArrayND[np.floating]](
+        self: PlainQuantity[T], other: datetime.timedelta | np.timedelta64
+    ) -> PlainQuantity[T]: ...
     # General overloads
     @overload
     def __truediv__[T: Magnitude, U: Magnitude](
@@ -1320,14 +1292,9 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
     # timedelta / PlainQuantity[float | array[float]] -> PlainQuantity[float | array[float]]
     @overload
-    def __rtruediv__(
-        self: PlainQuantity[float], other: datetime.timedelta | np.timedelta64
-    ) -> PlainQuantity[float]: ...
-    @overload
-    def __rtruediv__[X: np.floating, S: Shape](
-        self: PlainQuantity[npt.ArrayND[X, S]],
-        other: datetime.timedelta | np.timedelta64,
-    ) -> PlainQuantity[npt.ArrayND[X, S]]: ...
+    def __rtruediv__[T: int | float | npt.ArrayND[np.floating]](
+        self: PlainQuantity[T], other: datetime.timedelta | np.timedelta64
+    ) -> PlainQuantity[T]: ...
     # General overloads
     @overload
     def __rtruediv__[T: Magnitude, U: Magnitude](

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -932,7 +932,7 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
         return self.__class__(magnitude, units)
 
     @overload
-    def __iadd__[T: int | float](
+    def __iadd__[T: float](
         self: PlainQuantity[T], other: datetime.datetime
     ) -> datetime.timedelta: ...
     @overload
@@ -948,7 +948,7 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
     @overload
     def __add__(
-        self: PlainQuantity[int | float], other: datetime.datetime
+        self: PlainQuantity[float], other: datetime.datetime
     ) -> datetime.timedelta: ...
     @overload
     def __add__[T: Magnitude, U: Magnitude](
@@ -962,7 +962,7 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
     ) -> PlainQuantity[U]: ...
     def __add__(self, other):
         if isinstance(other, datetime.datetime):
-            return cast("PlainQuantity[int | float]", self).to_timedelta() + other
+            return cast(PlainQuantity[float], self).to_timedelta() + other
         return self._add_sub(other, operator.add)
 
     if TYPE_CHECKING:
@@ -1490,7 +1490,7 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
     @overload
     def __pow__[T: Magnitude, U: Magnitude](
-        self: PlainQuantity[opt.CanPow[T, U]], other: PlainQuantity[T] | T
+        self: PlainQuantity[opt.CanPow2[T, U]], other: PlainQuantity[T] | T
     ) -> PlainQuantity[U]: ...
     @overload
     def __pow__[U: Magnitude](
@@ -1815,7 +1815,7 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
     def _ok_for_muldiv(self, no_offset_units=None) -> bool:
         return True
 
-    def to_timedelta(self: PlainQuantity[int | float]) -> datetime.timedelta:
+    def to_timedelta(self: PlainQuantity[float]) -> datetime.timedelta:
         return datetime.timedelta(microseconds=self.to("microseconds").magnitude)
 
     # We put this last to avoid overriding UnitsContainer

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -1861,7 +1861,7 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
     def _ok_for_muldiv(self, no_offset_units=None) -> bool:
         return True
 
-    def to_timedelta(self: PlainQuantity[float]) -> datetime.timedelta:
+    def to_timedelta(self: PlainQuantity[int | float]) -> datetime.timedelta:
         return datetime.timedelta(microseconds=self.to("microseconds").magnitude)
 
     # We put this last to avoid overriding UnitsContainer

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -144,6 +144,9 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
     """
 
+    # NOTE: The method signatures here must be kept in sync with Quantity's overloads
+    #   (you can find the class in pint/registry.py)
+
     _magnitude: MagnitudeT_co
 
     @property
@@ -193,10 +196,14 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
     def __new__[ScalarT: Scalar](  # type: ignore[misc]
         cls, value: Sequence[ScalarT], units: UnitLike | None = None
     ) -> "PlainQuantity[npt.Array1D]": ...
+    @overload  # This overload allows for `PlainQuantity[Any](<T>)` to return `PlainQuantity[T]`.
+    def __new__[T: Magnitude](
+        cls,
+        value: T,
+        units: UnitLike | None = None,
+    ) -> "PlainQuantity[T]": ...
     @overload
-    def __new__(
-        cls, value: Self | MagnitudeT_co, units: UnitLike | None = None
-    ) -> Self: ...
+    def __new__(cls, value: Self, units: UnitLike | None = None) -> Self: ...
 
     def __new__(cls, value, units: UnitLike | None = None) -> PlainQuantity:
         if is_upcast_type(type(value)):

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -187,7 +187,7 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
     @overload
     def __new__(
-        cls, value: datetime.timedelta, units: UnitLike | None = None
+        cls, value: datetime.timedelta | np.timedelta64, units: UnitLike | None = None
     ) -> "PlainQuantity[float]": ...
     @overload
     def __new__(

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -1292,6 +1292,17 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
         return self._mul_div(other, operator.truediv)
 
+    # PlainQuantity[float | array[float]] / timedelta -> PlainQuantity[float | array[float]]
+    @overload
+    def __truediv__(
+        self: PlainQuantity[float], other: datetime.timedelta | np.timedelta64
+    ) -> PlainQuantity[float]: ...
+    @overload
+    def __truediv__[X: np.floating, S: Shape](
+        self: PlainQuantity[npt.ArrayND[X, S]],
+        other: datetime.timedelta | np.timedelta64,
+    ) -> PlainQuantity[npt.ArrayND[X, S]]: ...
+    # General overloads
     @overload
     def __truediv__[T: Magnitude, U: Magnitude](
         self: PlainQuantity[opt.CanTruediv[T, U]], other: PlainQuantity[T] | T
@@ -1307,6 +1318,17 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
             return self._mul_div(other, self._truedivide_cast_int, operator.truediv)
         return self._mul_div(other, operator.truediv)
 
+    # timedelta / PlainQuantity[float | array[float]] -> PlainQuantity[float | array[float]]
+    @overload
+    def __rtruediv__(
+        self: PlainQuantity[float], other: datetime.timedelta | np.timedelta64
+    ) -> PlainQuantity[float]: ...
+    @overload
+    def __rtruediv__[X: np.floating, S: Shape](
+        self: PlainQuantity[npt.ArrayND[X, S]],
+        other: datetime.timedelta | np.timedelta64,
+    ) -> PlainQuantity[npt.ArrayND[X, S]]: ...
+    # General overloads
     @overload
     def __rtruediv__[T: Magnitude, U: Magnitude](
         self: PlainQuantity[opt.CanRTruediv[T, U]], other: T

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -944,7 +944,7 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
         return self.__class__(magnitude, units)
 
     @overload
-    def __iadd__[T: float](
+    def __iadd__[T: int | float](
         self: PlainQuantity[T], other: datetime.datetime
     ) -> datetime.timedelta: ...
     @overload
@@ -961,7 +961,7 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
     # PlainQuantity[float] + datetime -> datetime
     @overload
     def __add__(
-        self: PlainQuantity[float], other: datetime.datetime
+        self: PlainQuantity[int | float], other: datetime.datetime
     ) -> datetime.timedelta: ...
     # PlainQuantity[float | array[float]] + timedelta -> PlainQuantity[float | array[float]]
     @overload

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     import optype as opt
     import optype.numpy as npt
     from optype import do_neg, do_pos, do_round
+    from typing_extensions import TypeIs
 
     from ..context import Context
     from ..system import System
@@ -271,10 +272,10 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
         return inst
 
-    def _is_timedelta(self, value: Any) -> bool:
+    def _is_timedelta(self, value: object) -> TypeIs[datetime.timedelta]:
         return isinstance(value, datetime.timedelta)
 
-    def _convert_timedelta(self, value: Any) -> tuple[float, str]:
+    def _convert_timedelta(self, value: object) -> tuple[float, str]:
         """Convert a timedelta object to magnitude and unit string."""
         if isinstance(value, datetime.timedelta):
             return value.total_seconds(), "seconds"

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -51,6 +51,7 @@ from .definitions import UnitDefinition
 
 if TYPE_CHECKING:
     import optype as opt
+    import optype.numpy as npt
     from optype import do_neg, do_pos, do_round
 
     from ..context import Context
@@ -181,20 +182,23 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
         return _unpickle_quantity, (PlainQuantity, self.magnitude, self._units)
 
     @overload
-    def __new__(cls, value: MagnitudeT_co, units: UnitLike | None = None) -> Self: ...
-
+    def __new__(
+        cls, value: datetime.timedelta, units: UnitLike | None = None
+    ) -> "PlainQuantity[float]": ...
     @overload
-    def __new__(cls, value: str, units: UnitLike | None = None) -> Self: ...
-
-    @overload
+    def __new__(
+        cls, value: str, units: UnitLike | None = None
+    ) -> "PlainQuantity[Any]": ...
+    @overload  # FIXME: This could be more precise
     def __new__[ScalarT: Scalar](  # type: ignore[misc]
         cls, value: Sequence[ScalarT], units: UnitLike | None = None
+    ) -> "PlainQuantity[npt.Array1D]": ...
+    @overload
+    def __new__(
+        cls, value: Self | MagnitudeT_co, units: UnitLike | None = None
     ) -> Self: ...
 
-    @overload
-    def __new__(cls, value: Self, units: UnitLike | None = None) -> Self: ...
-
-    def __new__(cls, value, units: UnitLike | None = None) -> Self:
+    def __new__(cls, value, units: UnitLike | None = None) -> PlainQuantity:
         if is_upcast_type(type(value)):
             raise TypeError(f"PlainQuantity cannot wrap upcast type {type(value)}")
 

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -1223,6 +1223,17 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
         return self._mul_div(other, operator.mul)
 
+    # Quantity[float | array[float]] * timedelta -> Quantity[float | array[float]]
+    @overload
+    def __mul__(
+        self: PlainQuantity[float], other: datetime.timedelta | np.timedelta64
+    ) -> PlainQuantity[float]: ...
+    @overload
+    def __mul__[X: np.floating, S: Shape](
+        self: PlainQuantity[npt.ArrayND[X, S]],
+        other: datetime.timedelta | np.timedelta64,
+    ) -> PlainQuantity[npt.ArrayND[X, S]]: ...
+    # General overloads (should work in most cases)
     @overload
     def __mul__[T: Magnitude, U: Magnitude](
         self: PlainQuantity[opt.CanMul[T, U]], other: PlainQuantity[T] | T

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -983,7 +983,7 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
     ) -> PlainQuantity[U]: ...
     def __add__(self, other):
         if isinstance(other, datetime.datetime):
-            return cast(PlainQuantity[float], self).to_timedelta() + other
+            return cast("PlainQuantity[int | float]", self).to_timedelta() + other
         return self._add_sub(other, operator.add)
 
     if TYPE_CHECKING:

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -26,7 +26,7 @@ from typing import (
     overload,
 )
 
-from ..._typing import Magnitude, QuantityOrUnitLike, Scalar, Shape, UnitLike
+from ..._typing import Magnitude, QuantityOrUnitLike, Scalar, UnitLike
 from ...compat import (
     HAS_NUMPY,
     _to_magnitude,

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -26,7 +26,7 @@ from typing import (
     overload,
 )
 
-from ..._typing import Magnitude, QuantityOrUnitLike, Scalar, UnitLike
+from ..._typing import Magnitude, QuantityOrUnitLike, Scalar, Shape, UnitLike
 from ...compat import (
     HAS_NUMPY,
     _to_magnitude,
@@ -957,10 +957,21 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
             return self._iadd_sub(other, operator.iadd)
         return self._add_sub(other, operator.add)
 
+    # PlainQuantity[float] + datetime -> datetime
     @overload
     def __add__(
         self: PlainQuantity[float], other: datetime.datetime
     ) -> datetime.timedelta: ...
+    # PlainQuantity[float | array[float]] + timedelta -> PlainQuantity[float | array[float]]
+    @overload
+    def __add__(
+        self: PlainQuantity[float], other: datetime.timedelta
+    ) -> PlainQuantity[float]: ...
+    @overload
+    def __add__[X: np.floating, S: Shape](
+        self: PlainQuantity[npt.ArrayND[X, S]], other: datetime.timedelta
+    ) -> PlainQuantity[npt.ArrayND[X, S]]: ...
+    # General overloads (should work in most cases)
     @overload
     def __add__[T: Magnitude, U: Magnitude](
         self: PlainQuantity[opt.CanAdd[T, U]], other: PlainQuantity[T] | T

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -966,11 +966,12 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
     # PlainQuantity[float | array[float]] + timedelta -> PlainQuantity[float | array[float]]
     @overload
     def __add__(
-        self: PlainQuantity[float], other: datetime.timedelta
+        self: PlainQuantity[float], other: datetime.timedelta | np.timedelta64
     ) -> PlainQuantity[float]: ...
     @overload
     def __add__[X: np.floating, S: Shape](
-        self: PlainQuantity[npt.ArrayND[X, S]], other: datetime.timedelta
+        self: PlainQuantity[npt.ArrayND[X, S]],
+        other: datetime.timedelta | np.timedelta64,
     ) -> PlainQuantity[npt.ArrayND[X, S]]: ...
     # General overloads (should work in most cases)
     @overload
@@ -1010,6 +1011,17 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
 
         return self._add_sub(other, operator.sub)
 
+    # PlainQuantity[float | array[float]] - timedelta -> PlainQuantity[float | array[float]]
+    @overload
+    def __sub__(
+        self: PlainQuantity[float], other: datetime.timedelta | np.timedelta64
+    ) -> PlainQuantity[float]: ...
+    @overload
+    def __sub__[X: np.floating, S: Shape](
+        self: PlainQuantity[npt.ArrayND[X, S]],
+        other: datetime.timedelta | np.timedelta64,
+    ) -> PlainQuantity[npt.ArrayND[X, S]]: ...
+    # General overloads (should work in most cases)
     @overload
     def __sub__[T: Magnitude, U: Magnitude](
         self: PlainQuantity[opt.CanSub[T, U]], other: PlainQuantity[T] | T
@@ -1023,6 +1035,17 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
     def __sub__(self, other):
         return self._add_sub(other, operator.sub)
 
+    # timedelta - PlainQuantity[float | array[float]] -> PlainQuantity[float | array[float]]
+    @overload
+    def __rsub__(
+        self: PlainQuantity[float], other: datetime.timedelta | np.timedelta64
+    ) -> PlainQuantity[float]: ...
+    @overload
+    def __rsub__[X: np.floating, S: Shape](
+        self: PlainQuantity[npt.ArrayND[X, S]],
+        other: datetime.timedelta | np.timedelta64,
+    ) -> PlainQuantity[npt.ArrayND[X, S]]: ...
+    # General overloads (should work in most cases)
     @overload
     def __rsub__(
         self: PlainQuantity[int | float],

--- a/pint/facets/plain/unit.py
+++ b/pint/facets/plain/unit.py
@@ -21,6 +21,10 @@ from ...util import PrettyIPython, SharedRegistryObject, UnitsContainer
 from .definitions import UnitDefinition
 
 if TYPE_CHECKING:
+    import datetime
+
+    import numpy as np
+
     from ..context import Context
     from .quantity import PlainQuantity
 
@@ -143,10 +147,18 @@ class PlainUnit(PrettyIPython, SharedRegistryObject):
 
         return self.dimensionless
 
+    # PlainUnit * PlainUnit -> PlainUnit
     @overload
     def __mul__(self, other: Self) -> Self: ...
+    # PlainUnit * timedelta -> Quantity[float]
+    @overload
+    def __mul__(
+        self, other: datetime.timedelta | np.timedelta64
+    ) -> PlainQuantity[float]: ...
+    # PlainUnit * <Magnitude> -> Quantity[<Magnitude>]
     @overload
     def __mul__[T: Magnitude](self, other: T) -> PlainQuantity[T]: ...
+    # PlainUnit * str -> Quantity
     @overload
     def __mul__(self, other: str) -> PlainQuantity[Any]: ...
     def __mul__(self, other):

--- a/pint/facets/plain/unit.py
+++ b/pint/facets/plain/unit.py
@@ -150,15 +150,15 @@ class PlainUnit(PrettyIPython, SharedRegistryObject):
     # PlainUnit * PlainUnit -> PlainUnit
     @overload
     def __mul__(self, other: Self) -> Self: ...
-    # PlainUnit * timedelta -> Quantity[float]
+    # PlainUnit * timedelta -> PlainQuantity[float]
     @overload
     def __mul__(
         self, other: datetime.timedelta | np.timedelta64
     ) -> PlainQuantity[float]: ...
-    # PlainUnit * <Magnitude> -> Quantity[<Magnitude>]
+    # PlainUnit * <Magnitude> -> PlainQuantity[<Magnitude>]
     @overload
     def __mul__[T: Magnitude](self, other: T) -> PlainQuantity[T]: ...
-    # PlainUnit * str -> Quantity
+    # PlainUnit * str -> PlainQuantity
     @overload
     def __mul__(self, other: str) -> PlainQuantity[Any]: ...
     def __mul__(self, other):

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -305,7 +305,7 @@ class Quantity(
 
         @overload
         def __pow__[T: Magnitude, U: Magnitude](
-            self: Quantity[opt.CanPow[T, U]], other: Quantity[T] | T
+            self: Quantity[opt.CanPow2[T, U]], other: Quantity[T] | T
         ) -> Quantity[U]: ...
         @overload
         def __pow__[U: Magnitude](

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -199,6 +199,17 @@ class Quantity(
             | opt.CanRAdd[MagnitudeT_co, U],
         ) -> Quantity[U]: ...
 
+        # Quantity[float | array[float]] - timedelta -> Quantity[float | array[float]]
+        @overload
+        def __sub__(
+            self: Quantity[float], other: datetime.timedelta | np.timedelta64
+        ) -> Quantity[float]: ...
+        @overload
+        def __sub__[X: np.floating, S: Shape](
+            self: Quantity[npt.ArrayND[X, S]],
+            other: datetime.timedelta | np.timedelta64,
+        ) -> Quantity[npt.ArrayND[X, S]]: ...
+        # General overloads (should work in most cases)
         @overload
         def __sub__[T: Magnitude, U: Magnitude](
             self: Quantity[opt.CanSub[T, U]], other: Quantity[T] | T
@@ -210,6 +221,17 @@ class Quantity(
             | opt.CanRSub[MagnitudeT_co, U],
         ) -> Quantity[U]: ...
 
+        # timedelta - Quantity[float | array[float]] -> Quantity[float | array[float]]
+        @overload
+        def __rsub__(
+            self: Quantity[float], other: datetime.timedelta | np.timedelta64
+        ) -> Quantity[float]: ...
+        @overload
+        def __rsub__[X: np.floating, S: Shape](
+            self: Quantity[npt.ArrayND[X, S]],
+            other: datetime.timedelta | np.timedelta64,
+        ) -> Quantity[npt.ArrayND[X, S]]: ...
+        # General overloads (should work in most cases)
         @overload
         def __rsub__(
             self: Quantity[int | float],

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     from .facets.plain.quantity import PlainQuantity as _PlainQuantity
 
 else:
-    _PlainQuantity = facets.PlainRegistry.Quantity["MagnitudeT_co"]
+    _PlainQuantity = facets.PlainRegistry.Quantity
 
 # To build the Quantity and Unit classes
 # we follow the UnitRegistry bases
@@ -453,11 +453,18 @@ class Unit(
     facets.PlainRegistry.Unit,
 ):
     if TYPE_CHECKING:
-
+        # Unit * Unit -> Unit
         @overload
         def __mul__(self, other: Self) -> Self: ...
+        # Unit * timedelta -> Quantity[float]
+        @overload
+        def __mul__(
+            self, other: datetime.timedelta | np.timedelta64
+        ) -> Quantity[float]: ...
+        # Unit * <Magnitude> -> Quantity[<Magnitude>]
         @overload
         def __mul__[T: Magnitude](self, other: T) -> Quantity[T]: ...
+        # Unit * str -> Quantity
         @overload
         def __mul__(self, other: str) -> Quantity[Any]: ...
 

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -42,6 +42,10 @@ if TYPE_CHECKING:
     from ._typing import Magnitude, Scalar, Shape, UnitLike
     from ._typing import Quantity as _Quantity
     from ._typing import Unit as _Unit
+    from .facets.plain.quantity import PlainQuantity as _PlainQuantity
+
+else:
+    _PlainQuantity = facets.PlainRegistry.Quantity["MagnitudeT_co"]
 
 # To build the Quantity and Unit classes
 # we follow the UnitRegistry bases
@@ -60,7 +64,7 @@ class Quantity(
     facets.NumpyRegistry.Quantity[MagnitudeT_co],
     facets.MeasurementRegistry.Quantity[MagnitudeT_co],
     facets.NonMultiplicativeRegistry.Quantity[MagnitudeT_co],
-    facets.PlainRegistry.Quantity[MagnitudeT_co],
+    _PlainQuantity[MagnitudeT_co],
     Generic[MagnitudeT_co],
 ):
     if TYPE_CHECKING:

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     import optype as opt
     import optype.numpy as npt
 
-    from ._typing import Magnitude, Scalar, Shape, UnitLike
+    from ._typing import Magnitude, Scalar, UnitLike
     from ._typing import Quantity as _Quantity
     from ._typing import Unit as _Unit
     from .facets.plain.quantity import PlainQuantity as _PlainQuantity

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -64,6 +64,8 @@ class Quantity(
     Generic[MagnitudeT_co],
 ):
     if TYPE_CHECKING:
+        # NOTE: This list of method signatures must be kept in sync with PlainQuantity's overloads
+        #   (you can find the class in pint/facets/plain/quantity.py)
 
         @overload
         def __new__(
@@ -77,10 +79,14 @@ class Quantity(
         def __new__[ScalarT: Scalar](  # type: ignore[misc]
             cls, value: Sequence[ScalarT], units: UnitLike | None = None
         ) -> "Quantity[npt.Array1D]": ...
+        @overload  # This overload allows for `Quantity[Any](<T>)` to return `Quantity[T]`.
+        def __new__[T: Magnitude](
+            cls,
+            value: T,
+            units: UnitLike | None = None,
+        ) -> "Quantity[T]": ...
         @overload
-        def __new__(
-            cls, value: Self | MagnitudeT_co, units: UnitLike | None = None
-        ) -> Self: ...
+        def __new__(cls, value: Self, units: UnitLike | None = None) -> Self: ...
 
         @override
         def __iter__[T: Magnitude](

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -160,39 +160,27 @@ class Quantity(
             ],
         ) -> list[list[list[list[Any]]]]: ...
 
+        # Quantity[float] += datetime -> becomes datetime
         @overload
         def __iadd__(
             self: Quantity[int | float], other: datetime.datetime
-        ) -> datetime.timedelta: ...
+        ) -> datetime.datetime: ...
+        # General overload (should work in most cases)
         @overload
         def __iadd__[T: Magnitude, U: Magnitude](
             self: Quantity[opt.CanIAdd[T, U]], other: Quantity[T] | T
-        ) -> Quantity[U]: ...
-
-        @overload
-        def __isub__(
-            self: Quantity[int | float], other: datetime.datetime
-        ) -> datetime.timedelta: ...
-        @overload
-        def __isub__[T: Magnitude, U: Magnitude](
-            self: Quantity[opt.CanISub[T, U]], other: Quantity[T] | T
         ) -> Quantity[U]: ...
 
         # Quantity[float] + datetime -> datetime
         @overload
         def __add__(
             self: Quantity[int | float], other: datetime.datetime
-        ) -> datetime.timedelta: ...
+        ) -> datetime.datetime: ...
         # Quantity[float | array[float]] + timedelta -> Quantity[float | array[float]]
         @overload
-        def __add__(
-            self: Quantity[float], other: datetime.timedelta | np.timedelta64
-        ) -> Quantity[float]: ...
-        @overload
-        def __add__[X: np.floating, S: Shape](
-            self: Quantity[npt.ArrayND[X, S]],
-            other: datetime.timedelta | np.timedelta64,
-        ) -> Quantity[npt.ArrayND[X, S]]: ...
+        def __add__[T: int | float | npt.ArrayND[np.floating]](
+            self: Quantity[T], other: datetime.timedelta | np.timedelta64
+        ) -> Quantity[T]: ...
         # General overloads (should work in most cases)
         @overload
         def __add__[T: Magnitude, U: Magnitude](
@@ -205,16 +193,15 @@ class Quantity(
             | opt.CanRAdd[MagnitudeT_co, U],
         ) -> Quantity[U]: ...
 
+        def __isub__[T: Magnitude, U: Magnitude](
+            self: Quantity[opt.CanISub[T, U]], other: Quantity[T] | T
+        ) -> Quantity[U]: ...
+
         # Quantity[float | array[float]] - timedelta -> Quantity[float | array[float]]
         @overload
-        def __sub__(
-            self: Quantity[float], other: datetime.timedelta | np.timedelta64
-        ) -> Quantity[float]: ...
-        @overload
-        def __sub__[X: np.floating, S: Shape](
-            self: Quantity[npt.ArrayND[X, S]],
-            other: datetime.timedelta | np.timedelta64,
-        ) -> Quantity[npt.ArrayND[X, S]]: ...
+        def __sub__[T: int | float | npt.ArrayND[np.floating]](
+            self: Quantity[T], other: datetime.timedelta | np.timedelta64
+        ) -> Quantity[T]: ...
         # General overloads (should work in most cases)
         @overload
         def __sub__[T: Magnitude, U: Magnitude](
@@ -227,22 +214,18 @@ class Quantity(
             | opt.CanRSub[MagnitudeT_co, U],
         ) -> Quantity[U]: ...
 
-        # timedelta - Quantity[float | array[float]] -> Quantity[float | array[float]]
-        @overload
-        def __rsub__(
-            self: Quantity[float], other: datetime.timedelta | np.timedelta64
-        ) -> Quantity[float]: ...
-        @overload
-        def __rsub__[X: np.floating, S: Shape](
-            self: Quantity[npt.ArrayND[X, S]],
-            other: datetime.timedelta | np.timedelta64,
-        ) -> Quantity[npt.ArrayND[X, S]]: ...
-        # General overloads (should work in most cases)
+        # datetime - Quantity[float] -> datetime
         @overload
         def __rsub__(
             self: Quantity[int | float],
             other: datetime.datetime,
         ) -> datetime.datetime: ...
+        # timedelta - Quantity[float | array[float]] -> Quantity[float | array[float]]
+        @overload
+        def __rsub__[T: int | float | npt.ArrayND[np.floating]](
+            self: Quantity[T], other: datetime.timedelta | np.timedelta64
+        ) -> Quantity[T]: ...
+        # General overloads (should work in most cases)
         @overload
         def __rsub__[T: Magnitude, U: Magnitude](
             self: Quantity[opt.CanRSub[T, U]], other: T
@@ -260,14 +243,9 @@ class Quantity(
 
         # Quantity[float | array[float]] * timedelta -> Quantity[float | array[float]]
         @overload
-        def __mul__(
-            self: Quantity[float], other: datetime.timedelta | np.timedelta64
-        ) -> Quantity[float]: ...
-        @overload
-        def __mul__[X: np.floating, S: Shape](
-            self: Quantity[npt.ArrayND[X, S]],
-            other: datetime.timedelta | np.timedelta64,
-        ) -> Quantity[npt.ArrayND[X, S]]: ...
+        def __mul__[T: int | float | npt.ArrayND[np.floating]](
+            self: Quantity[T], other: datetime.timedelta | np.timedelta64
+        ) -> Quantity[T]: ...
         # General overloads (should work in most cases)
         @overload
         def __mul__[T: Magnitude, U: Magnitude](
@@ -302,14 +280,9 @@ class Quantity(
 
         # Quantity[float | array[float]] / timedelta -> Quantity[float | array[float]]
         @overload
-        def __truediv__(
-            self: Quantity[float], other: datetime.timedelta | np.timedelta64
-        ) -> Quantity[float]: ...
-        @overload
-        def __truediv__[X: np.floating, S: Shape](
-            self: Quantity[npt.ArrayND[X, S]],
-            other: datetime.timedelta | np.timedelta64,
-        ) -> Quantity[npt.ArrayND[X, S]]: ...
+        def __truediv__[T: int | float | npt.ArrayND[np.floating]](
+            self: Quantity[T], other: datetime.timedelta | np.timedelta64
+        ) -> Quantity[T]: ...
         # General overloads
         @overload
         def __truediv__[T: Magnitude, U: Magnitude](
@@ -324,14 +297,9 @@ class Quantity(
 
         # timedelta / Quantity[float | array[float]] -> Quantity[float | array[float]]
         @overload
-        def __rtruediv__(
-            self: Quantity[float], other: datetime.timedelta | np.timedelta64
-        ) -> Quantity[float]: ...
-        @overload
-        def __rtruediv__[X: np.floating, S: Shape](
-            self: Quantity[npt.ArrayND[X, S]],
-            other: datetime.timedelta | np.timedelta64,
-        ) -> Quantity[npt.ArrayND[X, S]]: ...
+        def __rtruediv__[T: int | float | npt.ArrayND[np.floating]](
+            self: Quantity[T], other: datetime.timedelta | np.timedelta64
+        ) -> Quantity[T]: ...
         # General overloads
         @overload
         def __rtruediv__[T: Magnitude, U: Magnitude](

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -294,6 +294,17 @@ class Quantity(
             self: Quantity[opt.CanITruediv[T, U]], other: Quantity[T] | T
         ) -> Quantity[U]: ...
 
+        # Quantity[float | array[float]] / timedelta -> Quantity[float | array[float]]
+        @overload
+        def __truediv__(
+            self: Quantity[float], other: datetime.timedelta | np.timedelta64
+        ) -> Quantity[float]: ...
+        @overload
+        def __truediv__[X: np.floating, S: Shape](
+            self: Quantity[npt.ArrayND[X, S]],
+            other: datetime.timedelta | np.timedelta64,
+        ) -> Quantity[npt.ArrayND[X, S]]: ...
+        # General overloads
         @overload
         def __truediv__[T: Magnitude, U: Magnitude](
             self: Quantity[opt.CanTruediv[T, U]], other: Quantity[T] | T
@@ -305,6 +316,17 @@ class Quantity(
             | opt.CanRTruediv[MagnitudeT_co, U],
         ) -> Quantity[U]: ...
 
+        # timedelta / Quantity[float | array[float]] -> Quantity[float | array[float]]
+        @overload
+        def __rtruediv__(
+            self: Quantity[float], other: datetime.timedelta | np.timedelta64
+        ) -> Quantity[float]: ...
+        @overload
+        def __rtruediv__[X: np.floating, S: Shape](
+            self: Quantity[npt.ArrayND[X, S]],
+            other: datetime.timedelta | np.timedelta64,
+        ) -> Quantity[npt.ArrayND[X, S]]: ...
+        # General overloads
         @overload
         def __rtruediv__[T: Magnitude, U: Magnitude](
             self: Quantity[opt.CanRTruediv[T, U]], other: T

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -252,6 +252,17 @@ class Quantity(
             self: Quantity[opt.CanIMul[T, U]], other: Quantity[T] | T
         ) -> Quantity[U]: ...
 
+        # Quantity[float | array[float]] * timedelta -> Quantity[float | array[float]]
+        @overload
+        def __mul__(
+            self: Quantity[float], other: datetime.timedelta | np.timedelta64
+        ) -> Quantity[float]: ...
+        @overload
+        def __mul__[X: np.floating, S: Shape](
+            self: Quantity[npt.ArrayND[X, S]],
+            other: datetime.timedelta | np.timedelta64,
+        ) -> Quantity[npt.ArrayND[X, S]]: ...
+        # General overloads (should work in most cases)
         @overload
         def __mul__[T: Magnitude, U: Magnitude](
             self: Quantity[opt.CanMul[T, U]], other: Quantity[T] | T

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -37,8 +37,9 @@ if TYPE_CHECKING:
 
     import numpy as np
     import optype as opt
+    import optype.numpy as npt
 
-    from ._typing import Magnitude, UnitLike
+    from ._typing import Magnitude, Scalar, UnitLike
     from ._typing import Quantity as _Quantity
     from ._typing import Unit as _Unit
 
@@ -63,6 +64,23 @@ class Quantity(
     Generic[MagnitudeT_co],
 ):
     if TYPE_CHECKING:
+
+        @overload
+        def __new__(
+            cls, value: datetime.timedelta, units: UnitLike | None = None
+        ) -> "Quantity[float]": ...
+        @overload
+        def __new__(
+            cls, value: str, units: UnitLike | None = None
+        ) -> "Quantity[Any]": ...
+        @overload  # FIXME: This could be more precise
+        def __new__[ScalarT: Scalar](  # type: ignore[misc]
+            cls, value: Sequence[ScalarT], units: UnitLike | None = None
+        ) -> "Quantity[npt.Array1D]": ...
+        @overload
+        def __new__(
+            cls, value: Self | MagnitudeT_co, units: UnitLike | None = None
+        ) -> Self: ...
 
         @override
         def __iter__[T: Magnitude](

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -69,7 +69,9 @@ class Quantity(
 
         @overload
         def __new__(
-            cls, value: datetime.timedelta, units: UnitLike | None = None
+            cls,
+            value: datetime.timedelta | np.timedelta64,
+            units: UnitLike | None = None,
         ) -> "Quantity[float]": ...
         @overload
         def __new__(

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     import optype as opt
     import optype.numpy as npt
 
-    from ._typing import Magnitude, Scalar, UnitLike
+    from ._typing import Magnitude, Scalar, Shape, UnitLike
     from ._typing import Quantity as _Quantity
     from ._typing import Unit as _Unit
 
@@ -172,10 +172,22 @@ class Quantity(
             self: Quantity[opt.CanISub[T, U]], other: Quantity[T] | T
         ) -> Quantity[U]: ...
 
+        # Quantity[float] + datetime -> datetime
         @overload
         def __add__(
             self: Quantity[int | float], other: datetime.datetime
         ) -> datetime.timedelta: ...
+        # Quantity[float | array[float]] + timedelta -> Quantity[float | array[float]]
+        @overload
+        def __add__(
+            self: Quantity[float], other: datetime.timedelta | np.timedelta64
+        ) -> Quantity[float]: ...
+        @overload
+        def __add__[X: np.floating, S: Shape](
+            self: Quantity[npt.ArrayND[X, S]],
+            other: datetime.timedelta | np.timedelta64,
+        ) -> Quantity[npt.ArrayND[X, S]]: ...
+        # General overloads (should work in most cases)
         @overload
         def __add__[T: Magnitude, U: Magnitude](
             self: Quantity[opt.CanAdd[T, U]], other: Quantity[T] | T

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -2055,7 +2055,7 @@ class TestTimedelta(QuantityTestCase):
         after = d - 3 * self.ureg.second
         assert d - datetime.timedelta(seconds=3) == after
         with pytest.raises(DimensionalityError):
-            3 * self.ureg.second - d
+            3 * self.ureg.second - d  # pyright: ignore[reportOperatorIssue]
 
     def test_iadd_isub(self):
         d = datetime.datetime(year=1968, month=1, day=10, hour=3, minute=42, second=24)

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -25,7 +25,12 @@ from pint.facets.plain.unit import UnitsContainer
 from pint.testsuite import QuantityTestCase, assert_no_warnings, helpers
 
 if TYPE_CHECKING:
+    from typing import TypedDict
+
     from pint import Quantity as Q_
+
+    class _TestQuantityKwargs(TypedDict):
+        autoconvert_offset_to_baseunit: bool
 
 
 class FakeWrapper:
@@ -36,7 +41,7 @@ class FakeWrapper:
 
 # TODO: do not subclass from QuantityTestCase
 class TestQuantity(QuantityTestCase):
-    kwargs = dict(autoconvert_offset_to_baseunit=False)
+    kwargs: "_TestQuantityKwargs" = {"autoconvert_offset_to_baseunit": False}
 
     def test_quantity_creation(self, caplog):
         x: Q_[float]

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -1,3 +1,4 @@
+# pyright: reportUnusedExpression=none
 from __future__ import annotations
 
 import copy

--- a/pint/util.py
+++ b/pint/util.py
@@ -289,13 +289,11 @@ def pi_theorem(quantities: dict[str, Any], registry: UnitRegistry | None = None)
             continue
         max_den = max(f.denominator for f in rowi)
         neg = -1 if sum(f < 0 for f in rowi) > sum(f > 0 for f in rowi) else 1
-        results.append(
-            {
-                q[0]: neg * f.numerator * max_den / f.denominator
-                for q, f in zip(quant, rowi)
-                if f.numerator != 0
-            }
-        )
+        results.append({
+            q[0]: neg * f.numerator * max_den / f.denominator
+            for q, f in zip(quant, rowi)
+            if f.numerator != 0
+        })
     return results
 
 
@@ -829,9 +827,9 @@ class ParserHelper(UnitsContainer):
         return self.__class__(self.scale, d, non_int_type=self._non_int_type)
 
     def __str__(self):
-        tmp = "{%s}" % ", ".join(
-            [f"'{key}': {value}" for key, value in sorted(self._d.items())]
-        )
+        tmp = "{%s}" % ", ".join([
+            f"'{key}': {value}" for key, value in sorted(self._d.items())
+        ])
         return f"{self.scale} {tmp}"
 
     def __repr__(self):
@@ -970,7 +968,7 @@ class SharedRegistryObject:
             inst._REGISTRY = application_registry.get()
         return inst
 
-    def _check(self, other: Any) -> "TypeIs[SharedRegistryObject]":
+    def _check(self, other: object) -> "TypeIs[SharedRegistryObject]":
         """Check if the other object use a registry and if so that it is the
         same registry.
 

--- a/pint/util.py
+++ b/pint/util.py
@@ -289,11 +289,13 @@ def pi_theorem(quantities: dict[str, Any], registry: UnitRegistry | None = None)
             continue
         max_den = max(f.denominator for f in rowi)
         neg = -1 if sum(f < 0 for f in rowi) > sum(f > 0 for f in rowi) else 1
-        results.append({
-            q[0]: neg * f.numerator * max_den / f.denominator
-            for q, f in zip(quant, rowi)
-            if f.numerator != 0
-        })
+        results.append(
+            {
+                q[0]: neg * f.numerator * max_den / f.denominator
+                for q, f in zip(quant, rowi)
+                if f.numerator != 0
+            }
+        )
     return results
 
 
@@ -827,9 +829,9 @@ class ParserHelper(UnitsContainer):
         return self.__class__(self.scale, d, non_int_type=self._non_int_type)
 
     def __str__(self):
-        tmp = "{%s}" % ", ".join([
-            f"'{key}': {value}" for key, value in sorted(self._d.items())
-        ])
+        tmp = "{%s}" % ", ".join(
+            [f"'{key}': {value}" for key, value in sorted(self._d.items())]
+        )
         return f"{self.scale} {tmp}"
 
     def __repr__(self):


### PR DESCRIPTION
Typing improvements that reflect the new behaviour introduced in #2367.

- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

---

**Edit**: Additional changes I made:
- Fixed a bug in `__pow__`'s type annotations (`Quantity(...) ** 2` previously resulted in an error, for example)
- Fixed a bug in `__add__`/`__iadd__` type annotations (`<Quantity[...]> + <datetime>` was previously annotated as returning `timedelta` instead of the correct `datetime`)
- Made `Quantity[_MagnitudeT_co]` inherit from `PlainQuantity[_MagnitudeT_co]` directly to reliably pass type information to the base class (this fixes `Quantity[<T>](...).magnitude` being `Any`/`Unknown` instead of the correct `<T>`)
- Other small annotation improvements
