### PR TITLE
Raise DefinitionSyntaxError instead of RecursionError for deeply nested expressions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.26.0 (unreleased)
 -------------------
 
+- Raise `DefinitionSyntaxError` instead of an uncaught `RecursionError` when parsing a deeply nested expression (e.g. many chained `**` or `^` operators), bounding operator-recursion depth in `_build_eval_tree`
 - Fix `is_compatible_with` edge cases with dimensionless types and unit strings with a scaling factor (e.g. `"35000 ft"`) (#1190)
 - Allow string parsing of offset units (#386)
 - Remove the ambiguous `Nm` alias from `number_meter` (Textile group), since it's commonly expected to mean newton-meter (torque) (#1966)

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Pint Changelog
 0.26.0 (unreleased)
 -------------------
 
-- Raise `DefinitionSyntaxError` instead of an uncaught `RecursionError` when parsing a deeply nested expression (e.g. many chained `**` or `^` operators), bounding operator-recursion depth in `_build_eval_tree`
+- Raise `DefinitionSyntaxError` instead of a bare `RecursionError` for deeply nested expressions
 - Fix `is_compatible_with` edge cases with dimensionless types and unit strings with a scaling factor (e.g. `"35000 ft"`) (#1190)
 - Allow string parsing of offset units (#386)
 - Remove the ambiguous `Nm` alias from `number_meter` (Textile group), since it's commonly expected to mean newton-meter (torque) (#1966)

--- a/pint/pint_eval.py
+++ b/pint/pint_eval.py
@@ -89,6 +89,7 @@ _OP_PRIORITY = {
 # chained ``**``) can recurse past ``sys.getrecursionlimit()`` and raise an
 # uncaught ``RecursionError`` out of the public API. 100 is far above any
 # legitimate unit expression while staying well below CPython's default limit.
+# See https://github.com/hgrecco/pint/pull/2376
 _MAX_RECURSION_DEPTH = 100
 
 

--- a/pint/pint_eval.py
+++ b/pint/pint_eval.py
@@ -83,6 +83,14 @@ _OP_PRIORITY = {
     "-": 0,
 }
 
+# Maximum nesting depth for operator recursion in _build_eval_tree. Python's
+# tokenize caps nested parentheses at 200 but does not cap operator nesting, so
+# without this bound a deeply nested right-associative expression (e.g. many
+# chained ``**``) can recurse past ``sys.getrecursionlimit()`` and raise an
+# uncaught ``RecursionError`` out of the public API. 100 is far above any
+# legitimate unit expression while staying well below CPython's default limit.
+_MAX_RECURSION_DEPTH = 100
+
 
 class IteratorLookAhead[S]:
     """An iterator with lookahead buffer.
@@ -434,6 +442,12 @@ def _build_eval_tree(
         If there is a syntax error.
 
     """
+
+    if depth > _MAX_RECURSION_DEPTH:
+        raise DefinitionSyntaxError(
+            f"maximum recursion depth exceeded in expression parsing "
+            f"({_MAX_RECURSION_DEPTH}); expression is too deeply nested"
+        )
 
     result = None
 

--- a/pint/testsuite/test_pint_eval.py
+++ b/pint/testsuite/test_pint_eval.py
@@ -184,3 +184,22 @@ def test_build_eval_tree_missing_operand_raises_definition_syntax_error(
 
     with pytest.raises(DefinitionSyntaxError):
         build_eval_tree(tokenizer(input_text))
+
+
+@pytest.mark.parametrize("tokenizer", TOKENIZERS)
+@pytest.mark.parametrize("op", ["**", "^"])
+def test_build_eval_tree_deeply_nested_raises_definition_syntax_error(
+    tokenizer, op: str
+):
+    # Regression test for uncontrolled recursion (CWE-674): a deeply nested
+    # right-associative expression must raise a pint DefinitionSyntaxError
+    # instead of an uncaught RecursionError out of the public API. Python's
+    # tokenize caps nested parentheses but not operator nesting, so without
+    # the depth bound in _build_eval_tree a ~6 KB payload of chained ``**`` /
+    # ``^`` operators recurses past sys.getrecursionlimit().
+    from pint.errors import DefinitionSyntaxError
+
+    evil = "kg " + f"{op} kg " * 1000
+    with pytest.raises(DefinitionSyntaxError):
+        build_eval_tree(tokenizer(evil))
+


### PR DESCRIPTION
## Summary

`UnitRegistry.parse_expression` (and every code path through `pint.pint_eval._build_eval_tree`) raised an uncaught `RecursionError` when given a deeply nested right-associative expression. Python's `tokenize` caps nested parentheses at 200 but does **not** cap operator nesting, so a small (~6 KB) attacker-controlled string of chained `**` or `^` operators — e.g. `"kg " + "** kg " * 1000` — recursed past `sys.getrecursionlimit()` and crashed the public API. This is a denial-of-service vector (CWE-674) for any application that passes user-controlled strings to `parse_expression`, `Quantity(value, unit_str)`, `unit_registry(unit_str)`, or `wraps`-decorated functions.

## Fix

Bound the operator-recursion depth in `_build_eval_tree`: a module-level constant `_MAX_RECURSION_DEPTH = 100` is checked at function entry, and exceeding it raises `DefinitionSyntaxError` (consistent with the handling of #2124) instead of recursing into a `RecursionError`.

- `100` is far above any legitimate unit expression (typically fewer than 5 nesting levels) while staying well below CPython's default recursion limit of `1000`.
- Parenthetical groups already reset the depth counter to `0` and `tokenize` caps them at 200, so the new bound targets the previously-unbounded operator-nesting path.

## Test

- Added `test_build_eval_tree_deeply_nested_raises_definition_syntax_error` in `pint/testsuite/test_pint_eval.py`, parametrized over both tokenizers (`plain_tokenizer`, `uncertainty_tokenizer`) and both exponent operators (`**`, `^`), asserting that a 1000-operator payload raises `DefinitionSyntaxError` rather than `RecursionError`.
- `pint/testsuite/test_pint_eval.py`: **149 passed** (incl. the new test).
- `pint/testsuite/test_quantity.py`: **355 passed, 224 skipped, 106 subtests passed** — no regressions.

Checklist:
- [x] The change is fully covered by automated unit tests
- [x] Added an entry to the CHANGES file
- [x] Documented in docs/ as appropriate (internal parser fix, no user-facing API change)
- [ ] Closes # (no existing issue — reporting here directly)
- [ ] Executed `pre-commit run --all-files` — `pixi run lint` could not be executed in the contribution environment; the change follows the project `ruff` config (`E4, E7, E9, F, I`) by matching the surrounding code style. Happy to adjust if `ruff` flags anything.