### PR TITLE
Fix DimensionalityError from floating-point noise in fractional exponents

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Pint Changelog
 - Fix `DimensionalityError` from a leftover floating-point-noise exponent (e.g. `meter ** 5.55e-17` instead of exactly `meter ** 0`) after combining fractional unit powers, which broke `to_base_units`, `to_reduced_units`, and `to` (#1487)
 - Fix `DimensionalityError` from floating-point noise in combined fractional unit exponents (e.g. `meter ** 5.55e-17`) (#1487)
 - Fix `DimensionalityError` from floating-point noise in combined fractional unit exponents (e.g. `meter ** 5.55e-17` or `[time] ** -0.9999999999999998` instead of exactly `meter ** 0`/`[time] ** -1`) (#1487, #681)
+- Fix `DimensionalityError` from floating-point noise in combined fractional unit exponents (#1487, #681)
 - Fix `is_compatible_with` edge cases with dimensionless types and unit strings with a scaling factor (e.g. `"35000 ft"`) (#1190)
 - Allow string parsing of offset units (#386)
 - Remove the ambiguous `Nm` alias from `number_meter` (Textile group), since it's commonly expected to mean newton-meter (torque) (#1966)

--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ Pint Changelog
 - Switch CodSpeed CI benchmarks to `simulation` mode to fix a walltime environment warning.
 - Fix `DimensionalityError` from a leftover floating-point-noise exponent (e.g. `meter ** 5.55e-17` instead of exactly `meter ** 0`) after combining fractional unit powers, which broke `to_base_units`, `to_reduced_units`, and `to` (#1487)
 - Fix `DimensionalityError` from floating-point noise in combined fractional unit exponents (e.g. `meter ** 5.55e-17`) (#1487)
+- Fix `DimensionalityError` from floating-point noise in combined fractional unit exponents (e.g. `meter ** 5.55e-17` or `[time] ** -0.9999999999999998` instead of exactly `meter ** 0`/`[time] ** -1`) (#1487, #681)
 - Fix `is_compatible_with` edge cases with dimensionless types and unit strings with a scaling factor (e.g. `"35000 ft"`) (#1190)
 - Allow string parsing of offset units (#386)
 - Remove the ambiguous `Nm` alias from `number_meter` (Textile group), since it's commonly expected to mean newton-meter (torque) (#1966)

--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Pint Changelog
 - Add a "Try Pint in your browser" page to the docs with an in-browser JupyterLite console and notebook, requiring no local install (#2372)
 - Switch CodSpeed CI benchmarks to `simulation` mode to fix a walltime environment warning.
 - Fix `DimensionalityError` from a leftover floating-point-noise exponent (e.g. `meter ** 5.55e-17` instead of exactly `meter ** 0`) after combining fractional unit powers, which broke `to_base_units`, `to_reduced_units`, and `to` (#1487)
+- Fix `DimensionalityError` from floating-point noise in combined fractional unit exponents (e.g. `meter ** 5.55e-17`) (#1487)
 - Fix `is_compatible_with` edge cases with dimensionless types and unit strings with a scaling factor (e.g. `"35000 ft"`) (#1190)
 - Allow string parsing of offset units (#386)
 - Remove the ambiguous `Nm` alias from `number_meter` (Textile group), since it's commonly expected to mean newton-meter (torque) (#1966)

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Pint Changelog
 
 - Add a "Try Pint in your browser" page to the docs with an in-browser JupyterLite console and notebook, requiring no local install (#2372)
 - Switch CodSpeed CI benchmarks to `simulation` mode to fix a walltime environment warning.
+- Fix `DimensionalityError` from a leftover floating-point-noise exponent (e.g. `meter ** 5.55e-17` instead of exactly `meter ** 0`) after combining fractional unit powers, which broke `to_base_units`, `to_reduced_units`, and `to` (#1487)
 - Fix `is_compatible_with` edge cases with dimensionless types and unit strings with a scaling factor (e.g. `"35000 ft"`) (#1190)
 - Allow string parsing of offset units (#386)
 - Remove the ambiguous `Nm` alias from `number_meter` (Textile group), since it's commonly expected to mean newton-meter (torque) (#1966)

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -69,8 +69,8 @@ from ...errors import (
 from ...pint_eval import _BINARY_OPERATOR_MAP, build_eval_tree
 from ...util import (
     ParserHelper,
+    _clean_exponent,
     _is_dim,
-    _is_negligible_exponent,
     create_class_with_registry,
     getattr_maybe_raise,
     logger,
@@ -745,9 +745,8 @@ class GenericPlainRegistry[QuantityT: PlainQuantity, UnitT: PlainUnit](
         if "[]" in accumulator:
             del accumulator["[]"]
 
-        dims = self.UnitsContainer(
-            {k: v for k, v in accumulator.items() if not _is_negligible_exponent(v)}
-        )
+        cleaned = {k: _clean_exponent(v) for k, v in accumulator.items()}
+        dims = self.UnitsContainer({k: v for k, v in cleaned.items() if v != 0})
 
         cache[input_units] = dims
 
@@ -961,13 +960,10 @@ class GenericPlainRegistry[QuantityT: PlainQuantity, UnitT: PlainUnit](
             else:
                 factor *= d_factor**-d_exponent
 
-        units = self.UnitsContainer(
-            {
-                k: v
-                for k, v in accumulators.items()
-                if k is not None and not _is_negligible_exponent(v)
-            }
-        )
+        cleaned = {
+            k: _clean_exponent(v) for k, v in accumulators.items() if k is not None
+        }
+        units = self.UnitsContainer({k: v for k, v in cleaned.items() if v != 0})
 
         # Check if any of the final units is non multiplicative and return None instead.
         if check_nonmult:

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -70,6 +70,7 @@ from ...pint_eval import _BINARY_OPERATOR_MAP, build_eval_tree
 from ...util import (
     ParserHelper,
     _is_dim,
+    _is_negligible_exponent,
     create_class_with_registry,
     getattr_maybe_raise,
     logger,
@@ -744,7 +745,9 @@ class GenericPlainRegistry[QuantityT: PlainQuantity, UnitT: PlainUnit](
         if "[]" in accumulator:
             del accumulator["[]"]
 
-        dims = self.UnitsContainer({k: v for k, v in accumulator.items() if v != 0})
+        dims = self.UnitsContainer(
+            {k: v for k, v in accumulator.items() if not _is_negligible_exponent(v)}
+        )
 
         cache[input_units] = dims
 
@@ -959,7 +962,11 @@ class GenericPlainRegistry[QuantityT: PlainQuantity, UnitT: PlainUnit](
                 factor *= d_factor**-d_exponent
 
         units = self.UnitsContainer(
-            {k: v for k, v in accumulators.items() if k is not None and v != 0}
+            {
+                k: v
+                for k, v in accumulators.items()
+                if k is not None and not _is_negligible_exponent(v)
+            }
         )
 
         # Check if any of the final units is non multiplicative and return None instead.

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1156,6 +1156,47 @@ def test_issue1433(func_registry):
     assert func_registry.Quantity("1 micron") == func_registry.Quantity("1 micrometer")
 
 
+@helpers.requires_numpy
+def test_issue681():
+    # Floating-point noise from combining fractional exponents used to leave
+    # a near-integer (not just near-zero) residual, e.g. [time] ** -0.9999999999999998
+    # instead of exactly [time] ** -1, breaking dimensionality-based conversion.
+    ureg = UnitRegistry(system="mks")
+    Q_ = ureg.Quantity
+
+    n = Q_(600, ureg.rpm)
+    q = Q_(1000, ureg.watt) / (
+        Q_(42.0, "kg/m**3") * Q_(43.0, "m/s**2") * Q_(100, ureg.meter) * 44.0
+    )
+    f = Q_(52.0, ureg.rpm) * 0.8 * q / Q_(10, "l/s") * ureg.meter**3
+
+    d = (f / n) ** (1 / 3)
+    e = n * d / ureg.meter / np.sqrt(Q_(100.0, ureg.meter) / ureg.meter)
+    result = e.to(ureg.rpm)
+    assert result.units == ureg.Unit("rpm")
+    assert result.magnitude == pytest.approx(5.7333501976722845)
+
+
+def test_issue681_auto_reduce_dimensions():
+    ureg = UnitRegistry(auto_reduce_dimensions=True)
+
+    result = (
+        8
+        * 1000
+        * ureg.kg
+        / ureg.m**3
+        / math.pi**2
+        * 50
+        * ureg.feet
+        * (185 * ureg.gallon / ureg.min) ** 2
+        * 0.007
+        / (1.75 * ureg.inch) ** 5
+    )
+    base = result.to_base_units()
+    assert base.units == ureg.Unit("kg/m/s**2")
+    assert base.magnitude == pytest.approx(67886.22, rel=1e-4)
+
+
 def test_issue1487():
     # Floating-point noise from combining fractional exponents (e.g.
     # meter ** 5.55e-17 instead of exactly meter ** 0) used to make

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1156,6 +1156,29 @@ def test_issue1433(func_registry):
     assert func_registry.Quantity("1 micron") == func_registry.Quantity("1 micrometer")
 
 
+def test_issue1487():
+    # Floating-point noise from combining fractional exponents (e.g.
+    # meter ** 5.55e-17 instead of exactly meter ** 0) used to make
+    # to_base_units/to_reduced_units/to raise DimensionalityError.
+    ureg = UnitRegistry()
+    Q_ = ureg.Quantity
+
+    V = Q_(1.0, "m/s")
+    k = Q_(1.0, "W/(m*K)")
+    rho = Q_(1.0, "kg/m**3")
+    cp = Q_(1.0, "J/(kg*K)")
+    D = Q_(1.0, "m")
+    nu = Q_(1.0, "m**2/s")
+
+    h_c = 0.023 * V**0.8 * k**0.6 * (rho * cp) ** 0.4 / (D**0.2 * nu**0.4)
+
+    h_c.to_base_units()
+    h_c.to_reduced_units()
+    result = h_c.to("W/(m**2*K)")
+    assert result.magnitude == pytest.approx(0.023)
+    assert result.units == ureg.Unit("W/(m**2*K)")
+
+
 def test_issue1527():
     ureg = UnitRegistry(non_int_type=decimal.Decimal)
     x = ureg.parse_expression("2 microliter milligram/liter")

--- a/pint/util.py
+++ b/pint/util.py
@@ -421,6 +421,20 @@ class udict(dict[str, Scalar]):
         return udict(self)
 
 
+def _is_negligible_exponent(value: Scalar) -> bool:
+    """Whether a UnitsContainer exponent should be treated as zero.
+
+    Floats get a small absolute tolerance to absorb the floating-point noise
+    that repeated multiplication/division of fractional exponents can
+    accumulate (e.g. ``meter ** 5.55e-17`` instead of exactly ``meter ** 0``),
+    which otherwise breaks dimensionality-based conversion (see GH #1487).
+    Exact numeric types (int, Fraction, Decimal) are compared exactly.
+    """
+    if isinstance(value, float):
+        return math.isclose(value, 0.0, abs_tol=1e-10)
+    return value == 0
+
+
 class UnitsContainer(Mapping[str, Scalar]):
     """The UnitsContainer stores the product of units and their respective
     exponent and implements the corresponding operations.
@@ -489,10 +503,10 @@ class UnitsContainer(Mapping[str, Scalar]):
         """
         newval = self._d[key] + self._normalize_nonfloat_value(value)
         new = self.copy()
-        if newval:
-            new._d[key] = newval
-        else:
+        if _is_negligible_exponent(newval):
             new._d.pop(key)
+        else:
+            new._d[key] = newval
         new._hash = None
         return new
 
@@ -619,7 +633,7 @@ class UnitsContainer(Mapping[str, Scalar]):
         new = self.copy()
         for key, value in other.items():
             new._d[key] += value
-            if new._d[key] == 0:
+            if _is_negligible_exponent(new._d[key]):
                 del new._d[key]
 
         new._hash = None
@@ -646,7 +660,7 @@ class UnitsContainer(Mapping[str, Scalar]):
         new = self.copy()
         for key, value in other.items():
             new._d[key] -= self._normalize_nonfloat_value(value)
-            if new._d[key] == 0:
+            if _is_negligible_exponent(new._d[key]):
                 del new._d[key]
 
         new._hash = None

--- a/pint/util.py
+++ b/pint/util.py
@@ -421,18 +421,20 @@ class udict(dict[str, Scalar]):
         return udict(self)
 
 
-def _is_negligible_exponent(value: Scalar) -> bool:
-    """Whether a UnitsContainer exponent should be treated as zero.
-
-    Floats get a small absolute tolerance to absorb the floating-point noise
-    that repeated multiplication/division of fractional exponents can
-    accumulate (e.g. ``meter ** 5.55e-17`` instead of exactly ``meter ** 0``),
-    which otherwise breaks dimensionality-based conversion (see GH #1487).
-    Exact numeric types (int, Fraction, Decimal) are compared exactly.
+def _clean_exponent(value: Scalar) -> Scalar:
+    """Snap a UnitsContainer exponent back to the nearest integer if
+    floating-point noise from combining fractional powers has nudged it just
+    off of one, e.g. ``-0.9999999999999998`` instead of exactly ``-1`` (GH
+    #681), or ``5.55e-17`` instead of exactly ``0`` (GH #1487). Only floats
+    within a tiny absolute tolerance of an integer are snapped; genuinely
+    fractional exponents (like ``0.333333``) are returned unchanged, as are
+    exact numeric types (int, Fraction, Decimal).
     """
     if isinstance(value, float):
-        return math.isclose(value, 0.0, abs_tol=1e-10)
-    return value == 0
+        rounded = round(value)
+        if math.isclose(value, rounded, abs_tol=1e-9):
+            return float(rounded)
+    return value
 
 
 class UnitsContainer(Mapping[str, Scalar]):
@@ -501,9 +503,9 @@ class UnitsContainer(Mapping[str, Scalar]):
         UnitsContainer
             A copy of this container.
         """
-        newval = self._d[key] + self._normalize_nonfloat_value(value)
+        newval = _clean_exponent(self._d[key] + self._normalize_nonfloat_value(value))
         new = self.copy()
-        if _is_negligible_exponent(newval):
+        if newval == 0:
             new._d.pop(key)
         else:
             new._d[key] = newval
@@ -632,9 +634,11 @@ class UnitsContainer(Mapping[str, Scalar]):
 
         new = self.copy()
         for key, value in other.items():
-            new._d[key] += value
-            if _is_negligible_exponent(new._d[key]):
+            combined = _clean_exponent(new._d[key] + value)
+            if combined == 0:
                 del new._d[key]
+            else:
+                new._d[key] = combined
 
         new._hash = None
         return new
@@ -659,9 +663,13 @@ class UnitsContainer(Mapping[str, Scalar]):
 
         new = self.copy()
         for key, value in other.items():
-            new._d[key] -= self._normalize_nonfloat_value(value)
-            if _is_negligible_exponent(new._d[key]):
+            combined = _clean_exponent(
+                new._d[key] - self._normalize_nonfloat_value(value)
+            )
+            if combined == 0:
                 del new._d[key]
+            else:
+                new._d[key] = combined
 
         new._hash = None
         return new


### PR DESCRIPTION
## Summary
- `UnitsContainer.add`/`__mul__`/`__truediv__` decided whether a cancelled-out exponent should be dropped with an exact `== 0` check. Repeated multiplication/division of fractional powers (e.g. `V**0.8 * k**0.6 * (rho*cp)**0.4 / (D**0.2 * nu**0.4)`) accumulates floating-point rounding error, so a unit that should cancel to exactly 0 was instead left with a residual exponent like `5.55e-17`. That leftover then made `to_base_units()`/`to_reduced_units()`/`to(...)` raise `DimensionalityError`, since the target dimensionality has no matching entry for it.
- The same noise also shows up as a *non-zero* exponent that's just off an integer, e.g. `[time] ** -0.9999999999999998` instead of exactly `[time] ** -1` (#681) — a plain "is this negligible/zero" check doesn't catch that case.
- `_get_root_units` and `_get_dimensionality` in `facets/plain/registry.py` have their own separate exponent accumulators with the same exact-comparison issue, so they needed the same fix.
- Added `_clean_exponent(value)` in `util.py`: a `float` gets snapped to the nearest integer when within `1e-9` of one (covering both the "should be 0" and "should be some other exact integer" cases); genuinely fractional exponents (like `0.333333`) and exact types (`int`, `Fraction`, `Decimal`) are left untouched.

Fixes #1487
Fixes #681

## Performance
Added a few hundred ns per `UnitsContainer` combine (`round()` + `math.isclose`), which is swamped by everything else a `Quantity` operation already does:

| operation | before | after | delta |
|---|---|---|---|
| `q1 * q2` | 9.05 µs | 9.35 µs | +3.3% |
| `q1 / q2` | 9.36 µs | 9.64 µs | +2.9% |
| `q1 ** 0.8` | 6.99 µs | 7.20 µs | +3.0% |
| full #1487 repro expression | 92.2 µs | 96.4 µs | +4.5% |
| `.to_base_units()` | 17.0 µs | 16.1 µs | -5.7% (noise) |
| `.to_reduced_units()` | 169.7 µs | 170.1 µs | +0.2% |

## Test plan
- [x] Added `test_issue1487` (original repro), `test_issue681` and `test_issue681_auto_reduce_dimensions` (both examples from that issue's thread, including the `auto_reduce_dimensions=True` case)
- [x] Full test suite passes (2369 passed)
- [x] `pre-commit run` clean
- [x] No new `pyright` errors (verified against the unmodified baseline)