### PR TITLE
Fix CodSpeed walltime environment warning in CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -30,4 +30,4 @@ jobs:
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: pytest . --codspeed
-          mode: walltime
+          mode: simulation

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.26.0 (unreleased)
 -------------------
 
+- Switch CodSpeed CI benchmarks to `simulation` mode to fix a walltime environment warning.
 - Fix `is_compatible_with` edge cases with dimensionless types and unit strings with a scaling factor (e.g. `"35000 ft"`) (#1190)
 - Allow string parsing of offset units (#386)
 - Remove the ambiguous `Nm` alias from `number_meter` (Textile group), since it's commonly expected to mean newton-meter (torque) (#1966)


### PR DESCRIPTION
## Summary
- CodSpeed was warning "Unknown Walltime execution environment detected" because `walltime` mode is only reliable on CodSpeed's bare-metal Macro Runners, not standard GitHub-hosted runners.
- Switch `.github/workflows/bench.yml` to `mode: simulation`, which gives consistent results on any runner.

## Test plan
- [ ] Confirm the `codspeed-benchmarks` workflow run on this PR completes without the walltime environment warning