### PR TITLE
Make ReadTheDocs build with the same command as local docbuild

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,4 @@ build:
       - pixi install -e docs
     build:
       html:
-        - pixi run -e docs docbuild
-        - mkdir -p $READTHEDOCS_OUTPUT/html
-        - cp -r build/html/. $READTHEDOCS_OUTPUT/html/
+        - pixi run -e docs docbuild $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,9 +5,12 @@ build:
     python: "3.12"
   apt_packages:
     - graphviz
-sphinx:
-  configuration: docs/conf.py
-  fail_on_warning: false
+  jobs:
+    build:
+      html:
+        # Same command as the `docbuild` pixi task in pyproject.toml, so RTD
+        # builds the docs the same way as local development.
+        - sphinx-build -n -j auto -b html -d $READTHEDOCS_OUTPUT/doctrees docs $READTHEDOCS_OUTPUT/html
 python:
    install:
      - method: pip

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,19 +1,11 @@
 version: 2
 build:
   os: ubuntu-22.04
-  tools:
-    python: "3.12"
-  apt_packages:
-    - graphviz
-  jobs:
-    build:
-      html:
-        # Same command as the `docbuild` pixi task in pyproject.toml, so RTD
-        # builds the docs the same way as local development.
-        - sphinx-build -n -j auto -b html -d $READTHEDOCS_OUTPUT/doctrees docs $READTHEDOCS_OUTPUT/html
-python:
-   install:
-     - method: pip
-       path: .
-       extra_requirements:
-         - docs
+  commands:
+    # Use the same pixi "docs" environment and task as local development
+    # (see [tool.pixi.environments] "docs" and [tool.pixi.feature.docs.tasks]
+    # "docbuild" in pyproject.toml), instead of a separate pip install.
+    - curl -fsSL https://pixi.sh/install.sh | sh
+    - $HOME/.pixi/bin/pixi run -e docs docbuild
+    - mkdir -p $READTHEDOCS_OUTPUT/html
+    - cp -r build/html/. $READTHEDOCS_OUTPUT/html/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,11 +1,21 @@
 version: 2
+
 build:
   os: ubuntu-22.04
-  commands:
-    # Use the same pixi "docs" environment and task as local development
-    # (see [tool.pixi.environments] "docs" and [tool.pixi.feature.docs.tasks]
-    # "docbuild" in pyproject.toml), instead of a separate pip install.
-    - curl -fsSL https://pixi.sh/install.sh | sh
-    - $HOME/.pixi/bin/pixi run -e docs docbuild
-    - mkdir -p $READTHEDOCS_OUTPUT/html
-    - cp -r build/html/. $READTHEDOCS_OUTPUT/html/
+  tools:
+    python: "3.12"
+  jobs:
+    # Use the same pixi "docs" environment as local development (see
+    # [tool.pixi.environments] "docs" in pyproject.toml), following the
+    # pattern from
+    # https://docs.readthedocs.com/platform/stable/build-customization.html
+    create_environment:
+      - asdf plugin add pixi
+      - asdf install pixi latest
+      - asdf global pixi latest
+    install:
+      - pixi install -e docs
+    build:
+      html:
+        # Same command as the `docbuild` pixi task in pyproject.toml.
+        - pixi run -e docs sphinx-build -n -j auto -b html -d $READTHEDOCS_OUTPUT/doctrees docs $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,9 +5,6 @@ build:
   tools:
     python: "3.12"
   jobs:
-    # Use the same pixi "docs" environment as local development (see
-    # [tool.pixi.environments] "docs" in pyproject.toml), following the
-    # pattern from
     # https://docs.readthedocs.com/platform/stable/build-customization.html
     create_environment:
       - asdf plugin add pixi

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,5 +14,6 @@ build:
       - pixi install -e docs
     build:
       html:
-        # Same command as the `docbuild` pixi task in pyproject.toml.
-        - pixi run -e docs sphinx-build -n -j auto -b html -d $READTHEDOCS_OUTPUT/doctrees docs $READTHEDOCS_OUTPUT/html
+        - pixi run -e docs docbuild
+        - mkdir -p $READTHEDOCS_OUTPUT/html
+        - cp -r build/html/. $READTHEDOCS_OUTPUT/html/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,9 @@ typecheck = "pyright"
 pint = { path = ".", editable = true }
 
 [tool.pixi.feature.docs.tasks]
-docbuild = "sphinx-build -n -j auto -b html -d build/doctrees docs build/html"
+docbuild = { cmd = "sphinx-build -n -j auto -b html -d build/doctrees docs {{ loc }}", args = [
+  { arg = "loc", default = "build/html" },
+] }
 doctest = "sphinx-build -a -j auto -b doctest -d build/doctrees docs build/doctest"
 
 [tool.pixi.feature.docs.dependencies]


### PR DESCRIPTION
## Summary
- RTD was using its own default `sphinx-build` invocation, which could drift from what `pixi run docbuild` runs locally.
- Override `build.jobs.build.html` in `.readthedocs.yaml` to run the exact same command as the `docbuild` pixi task (`sphinx-build -n -j auto -b html -d ... docs ...`), so docs are built identically in both places.

## Test plan
- [ ] Confirm RTD build succeeds on this PR's preview build