### PR TITLE
Fix DimensionalityError from floating-point noise in fractional exponents (targeted alternative to #2377)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Pint Changelog
 - Raise `DefinitionSyntaxError` instead of a bare `RecursionError` for deeply nested expressions
 - Add a "Try Pint in your browser" page to the docs with an in-browser JupyterLite console and notebook, requiring no local install (#2372)
 - Switch CodSpeed CI benchmarks to `simulation` mode to fix a walltime environment warning.
+- Fix `DimensionalityError` from floating-point noise in combined fractional unit exponents (#1487, #681)
 - Fix `is_compatible_with` edge cases with dimensionless types and unit strings with a scaling factor (e.g. `"35000 ft"`) (#1190)
 - Allow string parsing of offset units (#386)
 - Remove the ambiguous `Nm` alias from `number_meter` (Textile group), since it's commonly expected to mean newton-meter (torque) (#1966)

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -69,6 +69,7 @@ from ...errors import (
 from ...pint_eval import _BINARY_OPERATOR_MAP, build_eval_tree
 from ...util import (
     ParserHelper,
+    _clean_exponent,
     _is_dim,
     create_class_with_registry,
     getattr_maybe_raise,
@@ -744,7 +745,8 @@ class GenericPlainRegistry[QuantityT: PlainQuantity, UnitT: PlainUnit](
         if "[]" in accumulator:
             del accumulator["[]"]
 
-        dims = self.UnitsContainer({k: v for k, v in accumulator.items() if v != 0})
+        cleaned = {k: _clean_exponent(v) for k, v in accumulator.items()}
+        dims = self.UnitsContainer({k: v for k, v in cleaned.items() if v != 0})
 
         cache[input_units] = dims
 

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1156,6 +1156,69 @@ def test_issue1433(func_registry):
     assert func_registry.Quantity("1 micron") == func_registry.Quantity("1 micrometer")
 
 
+@helpers.requires_numpy
+def test_issue681():
+    # Floating-point noise from combining fractional exponents used to leave
+    # a near-integer (not just near-zero) residual, e.g. [time] ** -0.9999999999999998
+    # instead of exactly [time] ** -1, breaking dimensionality-based conversion.
+    import numpy as np
+
+    ureg = UnitRegistry(system="mks")
+    Q_ = ureg.Quantity
+
+    n = Q_(600, ureg.rpm)
+    q = Q_(1000, ureg.watt) / (
+        Q_(42.0, "kg/m**3") * Q_(43.0, "m/s**2") * Q_(100, ureg.meter) * 44.0
+    )
+    f = Q_(52.0, ureg.rpm) * 0.8 * q / Q_(10, "l/s") * ureg.meter**3
+
+    d = (f / n) ** (1 / 3)
+    e = n * d / ureg.meter / np.sqrt(Q_(100.0, ureg.meter) / ureg.meter)
+    result = e.to(ureg.rpm)
+    assert result.magnitude == pytest.approx(5.7333501976722845)
+
+
+def test_issue681_auto_reduce_dimensions():
+    ureg = UnitRegistry(auto_reduce_dimensions=True)
+
+    result = (
+        8
+        * 1000
+        * ureg.kg
+        / ureg.m**3
+        / math.pi**2
+        * 50
+        * ureg.feet
+        * (185 * ureg.gallon / ureg.min) ** 2
+        * 0.007
+        / (1.75 * ureg.inch) ** 5
+    )
+    base = result.to_base_units()
+    assert base.magnitude == pytest.approx(67886.22, rel=1e-4)
+
+
+def test_issue1487():
+    # Floating-point noise from combining fractional exponents (e.g.
+    # meter ** 5.55e-17 instead of exactly meter ** 0) used to make
+    # to_base_units/to_reduced_units/to raise DimensionalityError.
+    ureg = UnitRegistry()
+    Q_ = ureg.Quantity
+
+    V = Q_(1.0, "m/s")
+    k = Q_(1.0, "W/(m*K)")
+    rho = Q_(1.0, "kg/m**3")
+    cp = Q_(1.0, "J/(kg*K)")
+    D = Q_(1.0, "m")
+    nu = Q_(1.0, "m**2/s")
+
+    h_c = 0.023 * V**0.8 * k**0.6 * (rho * cp) ** 0.4 / (D**0.2 * nu**0.4)
+
+    h_c.to_base_units()
+    h_c.to_reduced_units()
+    result = h_c.to("W/(m**2*K)")
+    assert result.magnitude == pytest.approx(0.023)
+
+
 def test_issue1527():
     ureg = UnitRegistry(non_int_type=decimal.Decimal)
     x = ureg.parse_expression("2 microliter milligram/liter")

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1174,6 +1174,7 @@ def test_issue681():
 
     d = (f / n) ** (1 / 3)
     e = n * d / ureg.meter / np.sqrt(Q_(100.0, ureg.meter) / ureg.meter)
+    assert e.is_compatible_with(ureg.rpm)
     result = e.to(ureg.rpm)
     assert result.magnitude == pytest.approx(5.7333501976722845)
 
@@ -1193,6 +1194,7 @@ def test_issue681_auto_reduce_dimensions():
         * 0.007
         / (1.75 * ureg.inch) ** 5
     )
+    assert result.is_compatible_with("kg/m/s**2")
     base = result.to_base_units()
     assert base.magnitude == pytest.approx(67886.22, rel=1e-4)
 
@@ -1213,6 +1215,7 @@ def test_issue1487():
 
     h_c = 0.023 * V**0.8 * k**0.6 * (rho * cp) ** 0.4 / (D**0.2 * nu**0.4)
 
+    assert h_c.is_compatible_with("W/(m**2*K)")
     h_c.to_base_units()
     h_c.to_reduced_units()
     result = h_c.to("W/(m**2*K)")

--- a/pint/testsuite/test_pint_eval.py
+++ b/pint/testsuite/test_pint_eval.py
@@ -202,4 +202,3 @@ def test_build_eval_tree_deeply_nested_raises_definition_syntax_error(
     evil = "kg " + f"{op} kg " * 1000
     with pytest.raises(DefinitionSyntaxError):
         build_eval_tree(tokenizer(evil))
-

--- a/pint/testsuite/test_util.py
+++ b/pint/testsuite/test_util.py
@@ -407,13 +407,18 @@ class TestOtherUtils:
             (-0.9999999999999998, -1.0),
             (0.8000000000000002, 0.8),
             (3, 3),
+            # Below 9 threes, 1/3 is the nearest candidate fraction but still
+            # farther than the 1e-9 tolerance, so it's left unchanged.
+            (0.333333, 0.333333),
+            (0.3333333, 0.3333333),
+            (0.33333333, 0.33333333),
+            # At 9+ threes the gap is within tolerance, so it snaps to 1/3.
+            (0.333333333, 1 / 3),
+            (0.3333333333, 1 / 3),
         ],
     )
     def test_clean_exponent_snaps_noise(self, value, expected):
         assert _clean_exponent(value) == expected
-
-    def test_clean_exponent_leaves_genuine_fraction_unchanged(self):
-        assert _clean_exponent(0.333333) == 0.333333
 
     def test_clean_exponent_leaves_nan_unchanged(self):
         assert math.isnan(_clean_exponent(float("nan")))

--- a/pint/testsuite/test_util.py
+++ b/pint/testsuite/test_util.py
@@ -11,6 +11,7 @@ from pint import pint_eval
 from pint.util import (
     ParserHelper,
     UnitsContainer,
+    _clean_exponent,
     find_connected_nodes,
     find_shortest_path,
     iterable,
@@ -397,3 +398,22 @@ class TestOtherUtils:
         assert sized("test")
         assert not sized(i for i in range(5))
         assert not sized(0)
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (0.49999999999, 0.5),
+            (5.55e-17, 0.0),
+            (-0.9999999999999998, -1.0),
+            (0.8000000000000002, 0.8),
+            (3, 3),
+        ],
+    )
+    def test_clean_exponent_snaps_noise(self, value, expected):
+        assert _clean_exponent(value) == expected
+
+    def test_clean_exponent_leaves_genuine_fraction_unchanged(self):
+        assert _clean_exponent(0.333333) == 0.333333
+
+    def test_clean_exponent_leaves_nan_unchanged(self):
+        assert math.isnan(_clean_exponent(float("nan")))

--- a/pint/util.py
+++ b/pint/util.py
@@ -422,18 +422,19 @@ class udict(dict[str, Scalar]):
 
 
 def _clean_exponent(value: Scalar) -> Scalar:
-    """Snap a dimension/root-unit exponent back to the nearest integer if
-    floating-point noise from combining fractional powers has nudged it just
-    off of one, e.g. ``-0.9999999999999998`` instead of exactly ``-1`` (GH
-    #681), or ``5.55e-17`` instead of exactly ``0`` (GH #1487). Only floats
-    within a tiny absolute tolerance of an integer are snapped; genuinely
-    fractional exponents (like ``0.333333``) are returned unchanged, as are
-    exact numeric types (int, Fraction, Decimal).
+    """Snap a dimension/root-unit exponent back to the nearest simple
+    fraction if floating-point noise from combining fractional powers has
+    nudged it just off of one, e.g. ``-0.9999999999999998`` instead of
+    exactly ``-1`` (GH #681), ``5.55e-17`` instead of exactly ``0`` (GH
+    #1487), or ``0.49999999999`` instead of exactly ``0.5``. Only floats
+    within a tiny absolute tolerance of a low-denominator fraction are
+    snapped; genuinely fractional exponents (like ``0.333333``) are returned
+    unchanged, as are exact numeric types (int, Fraction, Decimal).
     """
-    if isinstance(value, float):
-        rounded = round(value)
-        if math.isclose(value, rounded, abs_tol=1e-9):
-            return float(rounded)
+    if isinstance(value, float) and math.isfinite(value):
+        nearby = Fraction(value).limit_denominator(1000)
+        if math.isclose(value, float(nearby), abs_tol=1e-9):
+            return float(nearby)
     return value
 
 

--- a/pint/util.py
+++ b/pint/util.py
@@ -422,7 +422,7 @@ class udict(dict[str, Scalar]):
 
 
 def _clean_exponent(value: Scalar) -> Scalar:
-    """Snap a dimension/root-unit exponent back to the nearest simple
+    """Snap a dimensionality exponent back to the nearest simple
     fraction if floating-point noise from combining fractional powers has
     nudged it just off of one, e.g. ``-0.9999999999999998`` instead of
     exactly ``-1`` (GH #681), ``5.55e-17`` instead of exactly ``0`` (GH

--- a/pint/util.py
+++ b/pint/util.py
@@ -421,6 +421,22 @@ class udict(dict[str, Scalar]):
         return udict(self)
 
 
+def _clean_exponent(value: Scalar) -> Scalar:
+    """Snap a dimension/root-unit exponent back to the nearest integer if
+    floating-point noise from combining fractional powers has nudged it just
+    off of one, e.g. ``-0.9999999999999998`` instead of exactly ``-1`` (GH
+    #681), or ``5.55e-17`` instead of exactly ``0`` (GH #1487). Only floats
+    within a tiny absolute tolerance of an integer are snapped; genuinely
+    fractional exponents (like ``0.333333``) are returned unchanged, as are
+    exact numeric types (int, Fraction, Decimal).
+    """
+    if isinstance(value, float):
+        rounded = round(value)
+        if math.isclose(value, rounded, abs_tol=1e-9):
+            return float(rounded)
+    return value
+
+
 class UnitsContainer(Mapping[str, Scalar]):
     """The UnitsContainer stores the product of units and their respective
     exponent and implements the corresponding operations.


### PR DESCRIPTION
## Summary
Alternative approach to #2377 for the same bugs (#1487, #681).

- Combining fractional unit powers (e.g. `V**0.8 * k**0.6 * (rho*cp)**0.4 / (D**0.2 * nu**0.4)`) can leave a floating-point-noise residual instead of an exact integer/zero exponent (e.g. `5.55e-17` instead of `0`, or `-0.9999999999999998` instead of `-1`). That noise made `to_base_units()`/`to_reduced_units()`/`to()`/`is_compatible_with()` raise a spurious `DimensionalityError`.
- Instead of snapping every `UnitsContainer` combine (`add`/`__mul__`/`__truediv__`, i.e. every `*`/`/`/`**` between quantities), this only snaps inside `_get_dimensionality` (`pint/facets/plain/registry.py`), the accumulator used specifically when resolving dimensionality for `.to*`/`.is_compatible_with`/`.dimensionality`. Plain arithmetic is untouched and has no added cost.
- Added `_clean_exponent(value)` in `util.py`, used only by `_get_dimensionality`.

Note: since the fix is scoped to the dimensionality comparison rather than the returned unit container itself, the exponents on a converted quantity's `.units` may still show floating-point noise even though the value/dimensionality is correct — tests assert on magnitude/no-exception rather than exact unit equality.

## Test plan
- [x] Added `test_issue1487`, `test_issue681`, `test_issue681_auto_reduce_dimensions`
- [x] Full test suite passes (2269 passed, 0 failures)
- [x] No changes to `UnitsContainer` arithmetic — no measurable cost added to `q1 * q2` / `q1 / q2` / `q1 ** x`