### PR TITLE
Add / unit modifier to pretty-print fractional exponents as a fraction

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,7 +8,7 @@ Pint Changelog
 - Add a "Try Pint in your browser" page to the docs with an in-browser JupyterLite console and notebook, requiring no local install (#2372)
 - Switch CodSpeed CI benchmarks to `simulation` mode to fix a walltime environment warning.
 - Fix `DimensionalityError` from floating-point noise in combined fractional unit exponents (#1487, #681)
-- Add `/` unit modifier to pretty-print fractional exponents as a fraction (e.g. `s**1.5` -> `s³ᐟ²`) instead of a decimal (#60)
+- Add `/` unit modifier to pretty-print fractional exponents as a fraction (e.g. `s**1.5` -> `s³ᐟ²`) (#60)
 - Fix `is_compatible_with` edge cases with dimensionless types and unit strings with a scaling factor (e.g. `"35000 ft"`) (#1190)
 - Allow string parsing of offset units (#386)
 - Remove the ambiguous `Nm` alias from `number_meter` (Textile group), since it's commonly expected to mean newton-meter (torque) (#1966)

--- a/CHANGES
+++ b/CHANGES
@@ -8,7 +8,7 @@ Pint Changelog
 - Add a "Try Pint in your browser" page to the docs with an in-browser JupyterLite console and notebook, requiring no local install (#2372)
 - Switch CodSpeed CI benchmarks to `simulation` mode to fix a walltime environment warning.
 - Fix `DimensionalityError` from floating-point noise in combined fractional unit exponents (#1487, #681)
-- Add `/` unit modifier to pretty-print fractional exponents as a fraction (e.g. `s**1.5` -> `s ** (3/2)`) instead of a decimal (#60)
+- Add `/` unit modifier to pretty-print fractional exponents as a fraction (e.g. `s**1.5` -> `s³ᐟ²`) instead of a decimal (#60)
 - Fix `is_compatible_with` edge cases with dimensionless types and unit strings with a scaling factor (e.g. `"35000 ft"`) (#1190)
 - Allow string parsing of offset units (#386)
 - Remove the ambiguous `Nm` alias from `number_meter` (Textile group), since it's commonly expected to mean newton-meter (torque) (#1966)

--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ Pint Changelog
 - Add a "Try Pint in your browser" page to the docs with an in-browser JupyterLite console and notebook, requiring no local install (#2372)
 - Switch CodSpeed CI benchmarks to `simulation` mode to fix a walltime environment warning.
 - Fix `DimensionalityError` from floating-point noise in combined fractional unit exponents (#1487, #681)
+- Add `/` unit modifier to pretty-print fractional exponents as a fraction (e.g. `s**1.5` -> `s ** (3/2)`) instead of a decimal (#60)
 - Fix `is_compatible_with` edge cases with dimensionless types and unit strings with a scaling factor (e.g. `"35000 ft"`) (#1190)
 - Allow string parsing of offset units (#386)
 - Remove the ambiguous `Nm` alias from `number_meter` (Textile group), since it's commonly expected to mean newton-meter (torque) (#1966)

--- a/docs/getting/faq.rst
+++ b/docs/getting/faq.rst
@@ -97,18 +97,20 @@ multiplications by ``meter ** 0.1`` don't quite add up to exactly
    True
 
 This comes at a performance cost (roughly 25% slower than plain ``float``
-for typical arithmetic), and it only stays exact as long as every operand
-is exact: raising an exact ``Fraction``-based unit to an ordinary ``float``
-power converts its exponent back to ``float``, reintroducing the same
-fragility:
+for typical arithmetic), and it only stays exact as long as every exponent
+is exact: combining an exact ``Fraction`` exponent with an ordinary
+``float`` exponent on the same unit produces a ``float`` result, the same
+noise-prone type this is meant to avoid:
 
 .. doctest::
 
-   >>> u3
-   Unit("meter")
-   >>> u3 ** 2.0
-   Unit("meter ** 2")
-   >>> type((u3**2.0)._units["meter"])
+   >>> Q_ = ureg2.Quantity
+   >>> a = Q_(1, ureg2.m ** fractions.Fraction(8, 10))
+   >>> b = Q_(1, ureg2.m ** 0.5)
+   >>> c = a * b
+   >>> c.units._units["meter"]
+   1.3
+   >>> type(c.units._units["meter"])
    <class 'float'>
 
 

--- a/docs/getting/faq.rst
+++ b/docs/getting/faq.rst
@@ -1,5 +1,7 @@
 .. _faq:
 
+.. currentmodule:: pint
+
 Frequently asked questions
 ==========================
 
@@ -8,6 +10,55 @@ Why the name *Pint*?
 --------------------
 
 Pint is a unit and sounds like Python in the first syllable. Most important, it is a good unit for beer.
+
+
+How can I avoid floating-point precision issues altogether?
+-------------------------------------------------------------
+
+By default, ``UnitRegistry`` uses ``float`` for magnitudes, which is subject
+to the usual floating-point rounding behavior:
+
+.. doctest::
+
+   >>> import pint
+   >>> ureg = pint.UnitRegistry()
+   >>> ureg("1 gallon").to("l")
+   Quantity(3.785411783999999, "liter")
+
+If you need exact arithmetic instead, pass ``non_int_type`` when creating
+the registry:
+
+.. doctest::
+
+   >>> import decimal
+   >>> ureg = pint.UnitRegistry(non_int_type=decimal.Decimal)
+   >>> ureg("1 gallon").to("l")
+   Quantity(Decimal('3.785411784000000000000000000'), "liter")
+
+or, for exact fractions:
+
+.. doctest::
+
+   >>> import fractions
+   >>> ureg = pint.UnitRegistry(non_int_type=fractions.Fraction)
+
+This avoids floating-point noise entirely (no rounding to begin with), at
+the cost of some performance compared to plain ``float``.
+
+
+Why does my quantity have a unit with a strange exponent like ``meter ** 0.9999999999999998``?
+-------------------------------------------------------------------------------------------------
+
+Combining quantities raised to fractional powers (e.g. multiplying and
+dividing several quantities each raised to a different fractional exponent)
+can leave a tiny floating-point residual on an exponent that should be an
+exact integer or zero, instead of the number of a whole quantity you might
+expect.
+
+Converting the quantity with :py:meth:`Quantity.to`, :py:meth:`Quantity.to_base_units`,
+or :py:meth:`Quantity.to_reduced_units` recomputes the units against the
+requested target and resolves this: the result has exactly the units you
+asked for, with no leftover noise.
 
 
 You mention other similar Python libraries. Can you point me to those?

--- a/docs/getting/faq.rst
+++ b/docs/getting/faq.rst
@@ -12,7 +12,7 @@ Why the name *Pint*?
 Pint is a unit and sounds like Python in the first syllable. Most important, it is a good unit for beer.
 
 
-How can I avoid floating-point precision issues?
+How can I avoid magnitude floating point issues?
 -------------------------------------------------------------
 
 By default, ``UnitRegistry`` uses ``float`` for magnitudes, which is subject
@@ -46,19 +46,69 @@ This avoids floating-point noise entirely (no rounding to begin with), at
 the cost of some performance compared to plain ``float``.
 
 
-Why does my quantity have a unit with a strange exponent like ``meter ** 0.9999999999999998``?
+How can I avoid exponent floating point issues?
 -------------------------------------------------------------------------------------------------
 
 Combining quantities raised to fractional powers (e.g. multiplying and
 dividing several quantities each raised to a different fractional exponent)
 can leave a tiny floating-point residual on an exponent that should be an
 exact integer or zero, instead of the number of a whole quantity you might
-expect.
+expect, e.g. ``meter ** 0.9999999999999998`` instead of exactly ``meter ** 1``.
 
 Converting the quantity with :py:meth:`Quantity.to`, :py:meth:`Quantity.to_base_units`,
 or :py:meth:`Quantity.to_reduced_units` recomputes the units against the
 requested target and resolves this: the result has exactly the units you
 asked for, with no leftover noise.
+
+.. note::
+
+   Formatters may round the displayed exponent, hiding the issue rather than
+   fixing it: ``meter ** 0.9999999999999998`` still *prints* as
+   ``meter ** 1``, even though the stored exponent is not exactly ``1``.
+
+Using ``non_int_type=fractions.Fraction`` (see above) avoids this noise from
+the start, since fractional exponents are then combined exactly instead of
+as rounded floats -- but only if the exponent itself is a ``Fraction``, not
+a plain ``float``: raising to a ``float`` power still produces a ``float``
+exponent, and the same noise, even in a ``Fraction``-based registry. Ten
+multiplications by ``meter ** 0.1`` don't quite add up to exactly
+``meter ** 1``; ten multiplications by ``meter ** Fraction(1, 10)`` do:
+
+.. doctest::
+
+   >>> u = ureg.Unit("meter") ** 0.1
+   >>> for _ in range(9):
+   ...     u = u * ureg.Unit("meter") ** 0.1
+   >>> u == ureg.Unit("meter")
+   False
+
+   >>> import fractions
+   >>> ureg2 = pint.UnitRegistry(non_int_type=fractions.Fraction)
+   >>> u2 = ureg2.Unit("meter") ** 0.1
+   >>> for _ in range(9):
+   ...     u2 = u2 * ureg2.Unit("meter") ** 0.1
+   >>> u2 == ureg2.Unit("meter")
+   False
+
+   >>> u3 = ureg2.Unit("meter") ** fractions.Fraction(1, 10)
+   >>> for _ in range(9):
+   ...     u3 = u3 * ureg2.Unit("meter") ** fractions.Fraction(1, 10)
+   >>> u3 == ureg2.Unit("meter")
+   True
+
+This comes at a performance cost (roughly 25% slower than plain ``float``
+for typical arithmetic), and it only stays exact as long as every operand
+is exact: multiplying an exact ``Fraction``-based quantity by an ordinary
+``float`` converts its magnitude back to ``float``, reintroducing the same
+floating-point noise:
+
+.. doctest::
+
+   >>> q = ureg2("1 gallon").to("l")
+   >>> q
+   Quantity(Fraction(473176473, 125000000), "liter")
+   >>> q * 1.5
+   Quantity(5.678117675999999, "liter")
 
 
 You mention other similar Python libraries. Can you point me to those?

--- a/docs/getting/faq.rst
+++ b/docs/getting/faq.rst
@@ -98,17 +98,18 @@ multiplications by ``meter ** 0.1`` don't quite add up to exactly
 
 This comes at a performance cost (roughly 25% slower than plain ``float``
 for typical arithmetic), and it only stays exact as long as every operand
-is exact: multiplying an exact ``Fraction``-based quantity by an ordinary
-``float`` converts its magnitude back to ``float``, reintroducing the same
-floating-point noise:
+is exact: raising an exact ``Fraction``-based unit to an ordinary ``float``
+power converts its exponent back to ``float``, reintroducing the same
+fragility:
 
 .. doctest::
 
-   >>> q = ureg2("1 gallon").to("l")
-   >>> q
-   Quantity(Fraction(473176473, 125000000), "liter")
-   >>> q * 1.5
-   Quantity(5.678117675999999, "liter")
+   >>> u3
+   Unit("meter")
+   >>> u3 ** 2.0
+   Unit("meter ** 2")
+   >>> type((u3**2.0)._units["meter"])
+   <class 'float'>
 
 
 You mention other similar Python libraries. Can you point me to those?

--- a/docs/getting/faq.rst
+++ b/docs/getting/faq.rst
@@ -12,7 +12,7 @@ Why the name *Pint*?
 Pint is a unit and sounds like Python in the first syllable. Most important, it is a good unit for beer.
 
 
-How can I avoid floating-point precision issues altogether?
+How can I avoid floating-point precision issues?
 -------------------------------------------------------------
 
 By default, ``UnitRegistry`` uses ``float`` for magnitudes, which is subject

--- a/docs/user/formatting.rst
+++ b/docs/user/formatting.rst
@@ -77,7 +77,39 @@ Modifier Meaning                                             Example
 ======== =================================================== ================================
 ``~``    Use the unit's symbol instead of its canonical name ``kg⋅m/s²`` (``f"{u:~P}"``)
 ``^``    Use negative exponents instead of ratio             ``kg⋅m⋅s⁻²`` (``f"{u:~^P}"``)
+``/``    Show a fractional exponent as a fraction, not a     ``s ** (3/2)`` (``f"{u:~/P}"``)
+         decimal
 ======== =================================================== ================================
+
+By default, a fractional exponent (e.g. from raising a unit to a fractional
+power) is shown as a decimal, which loses precision for anything but a simple
+fraction. The ``/`` modifier instead renders it using ``**`` with the
+exponent as a ``(numerator/denominator)`` fraction:
+
+.. doctest::
+
+   >>> u = ureg.Unit("second") ** 1.5
+   >>> f"{u:~P}"
+   's¹⋅⁵'
+   >>> f"{u:~/P}"
+   's ** (3/2)'
+
+The exponent is snapped to the nearest fraction with a denominator of at
+most 1000, which also absorbs the kind of floating-point noise that
+combining fractional powers can leave behind (see issues #1487 and #681):
+a value that should be exactly ``-1`` but landed on
+``-0.9999999999999998``, or one that should be exactly ``0`` but landed on
+``5.55e-17``, both snap back to a clean exponent instead of printing the
+noise:
+
+.. doctest::
+
+   >>> noisy_minus_one = ureg.Unit("second") ** -0.9999999999999998
+   >>> f"{noisy_minus_one:~/P}"
+   '1/s'
+   >>> noisy_near_zero = ureg.Unit("meter") ** 5.55e-17
+   >>> f"{noisy_near_zero:~/P}"
+   'm ** 0'
 
 Magnitude modifiers
 -------------------

--- a/docs/user/formatting.rst
+++ b/docs/user/formatting.rst
@@ -83,7 +83,7 @@ Modifier Meaning                                             Example
 .. note::
 
    The ``/`` modifier converts floats to the nearest fraction with a
-   denominator of at most 1000, aleviating floating point issues:
+   denominator of at most 1000, hiding floating point issues:
 
    .. doctest::
 

--- a/docs/user/formatting.rst
+++ b/docs/user/formatting.rst
@@ -80,24 +80,11 @@ Modifier Meaning                                             Example
 ``/``    Show exponent as a fraction                            ``s³ᐟ²`` (``f"{u:~/P}"``)
 ======== =================================================== ================================
 
-By default, a fractional exponent (e.g. from raising a unit to a fractional
-power) is shown as a decimal, which loses precision for anything but a simple
-fraction. The ``/`` modifier instead renders it as a pretty printed fraction,
-entirely in superscript (numerator, slash, and denominator):
-
-.. doctest::
-
-   >>> u = ureg.Unit("second") ** 1.5
-   >>> f"{u:~P}"
-   's¹⋅⁵'
-   >>> f"{u:~/P}"
-   's³ᐟ²'
-
 .. note::
 
-   The exponent is snapped to the nearest fraction with a denominator of at
-   most 1000, which also absorbs floating-point noise from combining
-   fractional powers (see issues #1487 and #681):
+   The ``/`` modifier converts floats to the nearest fraction with a
+   denominator of at most 1000, aleviating floating point issues (see
+   issues #1487 and #681):
 
    .. doctest::
 

--- a/docs/user/formatting.rst
+++ b/docs/user/formatting.rst
@@ -83,8 +83,7 @@ Modifier Meaning                                             Example
 .. note::
 
    The ``/`` modifier converts floats to the nearest fraction with a
-   denominator of at most 1000, aleviating floating point issues (see
-   issues #1487 and #681):
+   denominator of at most 1000, aleviating floating point issues:
 
    .. doctest::
 

--- a/docs/user/formatting.rst
+++ b/docs/user/formatting.rst
@@ -77,14 +77,13 @@ Modifier Meaning                                             Example
 ======== =================================================== ================================
 ``~``    Use the unit's symbol instead of its canonical name ``kg⋅m/s²`` (``f"{u:~P}"``)
 ``^``    Use negative exponents instead of ratio             ``kg⋅m⋅s⁻²`` (``f"{u:~^P}"``)
-``/``    Show a fractional exponent as a fraction, not a     ``s ** (3/2)`` (``f"{u:~/P}"``)
-         decimal
+``/``    Show exponent as a fraction                            ``s³ᐟ²`` (``f"{u:~/P}"``)
 ======== =================================================== ================================
 
 By default, a fractional exponent (e.g. from raising a unit to a fractional
 power) is shown as a decimal, which loses precision for anything but a simple
-fraction. The ``/`` modifier instead renders it using ``**`` with the
-exponent as a ``(numerator/denominator)`` fraction:
+fraction. The ``/`` modifier instead renders it as a pretty printed fraction,
+entirely in superscript (numerator, slash, and denominator):
 
 .. doctest::
 
@@ -92,24 +91,20 @@ exponent as a ``(numerator/denominator)`` fraction:
    >>> f"{u:~P}"
    's¹⋅⁵'
    >>> f"{u:~/P}"
-   's ** (3/2)'
+   's³ᐟ²'
 
-The exponent is snapped to the nearest fraction with a denominator of at
-most 1000, which also absorbs the kind of floating-point noise that
-combining fractional powers can leave behind (see issues #1487 and #681):
-a value that should be exactly ``-1`` but landed on
-``-0.9999999999999998``, or one that should be exactly ``0`` but landed on
-``5.55e-17``, both snap back to a clean exponent instead of printing the
-noise:
+.. note::
 
-.. doctest::
+   The exponent is snapped to the nearest fraction with a denominator of at
+   most 1000, which also absorbs floating-point noise from combining
+   fractional powers (see issues #1487 and #681):
 
-   >>> noisy_minus_one = ureg.Unit("second") ** -0.9999999999999998
-   >>> f"{noisy_minus_one:~/P}"
-   '1/s'
-   >>> noisy_near_zero = ureg.Unit("meter") ** 5.55e-17
-   >>> f"{noisy_near_zero:~/P}"
-   'm ** 0'
+   .. doctest::
+
+      >>> f"{ureg.Unit('second') ** -0.9999999999999998:~/P}"
+      '1/s'
+      >>> f"{ureg.Unit('meter') ** 5.55e-17:~/P}"
+      'm⁰'
 
 Magnitude modifiers
 -------------------

--- a/pint/delegates/formatter/_format_helpers.py
+++ b/pint/delegates/formatter/_format_helpers.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import re
 from collections.abc import Callable, Generator, Iterable
 from contextlib import contextmanager
+from fractions import Fraction
 from functools import partial
 from locale import LC_NUMERIC, getlocale, setlocale
 from typing import (
@@ -98,6 +99,20 @@ def pretty_fmt_exponent(num: Number) -> str:
     for n in range(10):
         ret = ret.replace(str(n), _PRETTY_EXPONENTS[n])
     return ret
+
+
+def pretty_fmt_exponent_fraction(num: Number, max_denominator: int = 1000) -> str:
+    """Format a number as a simple fraction exponent, e.g. ``1.5`` -> ``"(3/2)"``.
+
+    The exponent is converted to a `Fraction`, snapped to the nearest
+    fraction with a denominator of at most `max_denominator` via
+    `limit_denominator`. A genuine fraction is parenthesized (e.g.
+    ``"(3/2)"``); a whole number is returned bare (e.g. ``"2"``).
+    """
+    frac = Fraction(num).limit_denominator(max_denominator)
+    if frac.denominator == 1:
+        return str(frac.numerator)
+    return f"({frac.numerator}/{frac.denominator})"
 
 
 def join_u(fmt: str, iterable: Iterable[Any]) -> str:

--- a/pint/delegates/formatter/_format_helpers.py
+++ b/pint/delegates/formatter/_format_helpers.py
@@ -101,18 +101,28 @@ def pretty_fmt_exponent(num: Number) -> str:
     return ret
 
 
+def _pretty_digits(n: int, digits: str) -> str:
+    return "".join(digits[int(d)] for d in str(n))
+
+
 def pretty_fmt_exponent_fraction(num: Number, max_denominator: int = 1000) -> str:
-    """Format a number as a simple fraction exponent, e.g. ``1.5`` -> ``"(3/2)"``.
+    """Format a number as a pretty printed fraction exponent, e.g.
+    ``1.5`` -> ``"³ᐟ²"`` (superscript numerator, superscript slash,
+    superscript denominator).
 
     The exponent is converted to a `Fraction`, snapped to the nearest
     fraction with a denominator of at most `max_denominator` via
-    `limit_denominator`. A genuine fraction is parenthesized (e.g.
-    ``"(3/2)"``); a whole number is returned bare (e.g. ``"2"``).
+    `limit_denominator`. A whole number is rendered the same way as
+    `pretty_fmt_exponent` (a superscript integer).
     """
     frac = Fraction(num).limit_denominator(max_denominator)
+    sign = "⁻" if frac < 0 else ""
+    frac = abs(frac)
+    numerator = _pretty_digits(frac.numerator, _PRETTY_EXPONENTS)
     if frac.denominator == 1:
-        return str(frac.numerator)
-    return f"({frac.numerator}/{frac.denominator})"
+        return sign + numerator
+    denominator = _pretty_digits(frac.denominator, _PRETTY_EXPONENTS)
+    return f"{sign}{numerator}ᐟ{denominator}"
 
 
 def join_u(fmt: str, iterable: Iterable[Any]) -> str:

--- a/pint/delegates/formatter/_spec_helpers.py
+++ b/pint/delegates/formatter/_spec_helpers.py
@@ -69,7 +69,7 @@ def extract_custom_flags(spec: str) -> str:
     # sort by length, with longer items first
     known_flags = sorted(REGISTERED_FORMATTERS.keys(), key=len, reverse=True)
 
-    flag_re = re.compile("(" + "|".join(known_flags + ["~", "^"]) + ")")
+    flag_re = re.compile("(" + "|".join(known_flags + ["~", "^", "/"]) + ")")
     custom_flags = flag_re.findall(spec)
 
     return "".join(custom_flags)
@@ -84,6 +84,7 @@ def remove_custom_flags(spec: str) -> str:
     for flag in sorted(REGISTERED_FORMATTERS.keys(), key=len, reverse=True) + [
         "~",
         "^",
+        "/",
     ]:
         if flag:
             spec = spec.replace(flag, "")

--- a/pint/delegates/formatter/plain.py
+++ b/pint/delegates/formatter/plain.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 from ..._typing import Magnitude
 from ...compat import Unpack, ndarray, np
+from ...util import _clean_exponent
 from ._compound_unit_helpers import (
     BabelKwds,
     localize_per,
@@ -32,6 +33,7 @@ from ._format_helpers import (
     join_unc,
     override_locale,
     pretty_fmt_exponent,
+    pretty_fmt_exponent_fraction,
 )
 from ._spec_helpers import (
     remove_custom_flags,
@@ -340,6 +342,15 @@ class PrettyFormatter(BaseFormatter):
             registry=self._registry,
         )
 
+        if "/" in uspec:
+            # Snap each exponent to the nearest simple fraction before
+            # `formatter()` sees it, so its "omit the exponent when exactly
+            # 1 (or -1)" shortcut also fires on noise like
+            # 0.9999999999999998 (#681) or 5.55e-17 (#1487), not just the
+            # rendering of a genuine fraction.
+            numerator = [(key, _clean_exponent(value)) for key, value in numerator]
+            denominator = [(key, _clean_exponent(value)) for key, value in denominator]
+
         if babel_kwds.get("locale", None):
             length = babel_kwds.get("length") or ("short" if "~" in uspec else "long")
             division_fmt = localize_per(length, babel_kwds.get("locale"), "{}/{}")
@@ -356,9 +367,11 @@ class PrettyFormatter(BaseFormatter):
             single_denominator=False,
             product_fmt="⋅",
             division_fmt=division_fmt,
-            power_fmt="{}{}",
+            power_fmt="{} ** {}" if "/" in uspec else "{}{}",
             parentheses_fmt="({})",
-            exp_call=pretty_fmt_exponent,
+            exp_call=pretty_fmt_exponent_fraction
+            if "/" in uspec
+            else pretty_fmt_exponent,
         )
 
     def format_quantity[MagnitudeT: Magnitude](

--- a/pint/delegates/formatter/plain.py
+++ b/pint/delegates/formatter/plain.py
@@ -343,11 +343,6 @@ class PrettyFormatter(BaseFormatter):
         )
 
         if "/" in uspec:
-            # Snap each exponent to the nearest simple fraction before
-            # `formatter()` sees it, so its "omit the exponent when exactly
-            # 1 (or -1)" shortcut also fires on noise like
-            # 0.9999999999999998 (#681) or 5.55e-17 (#1487), not just the
-            # rendering of a genuine fraction.
             numerator = [(key, _clean_exponent(value)) for key, value in numerator]
             denominator = [(key, _clean_exponent(value)) for key, value in denominator]
 

--- a/pint/delegates/formatter/plain.py
+++ b/pint/delegates/formatter/plain.py
@@ -367,7 +367,7 @@ class PrettyFormatter(BaseFormatter):
             single_denominator=False,
             product_fmt="⋅",
             division_fmt=division_fmt,
-            power_fmt="{} ** {}" if "/" in uspec else "{}{}",
+            power_fmt="{}{}",
             parentheses_fmt="({})",
             exp_call=pretty_fmt_exponent_fraction
             if "/" in uspec

--- a/pint/testsuite/test_formatting.py
+++ b/pint/testsuite/test_formatting.py
@@ -109,8 +109,10 @@ def test_format_unit_fraction_exponent_absorbs_noise(func_registry):
     """
     # Noise near an integer, e.g. from combining fractional powers (#681).
     u = func_registry.Unit("second") ** -0.9999999999999998
+    assert format(u, "~P") == "1/s¹"
     assert format(u, "~/P") == "1/s"
 
     # Noise near zero (#1487): the residual exponent snaps to 0.
     u2 = func_registry.Unit("meter") ** 5.55e-17
+    assert format(u2, "~P") == "m⁵⋅⁵⁵e⁻¹⁷"
     assert format(u2, "~/P") == "m⁰"

--- a/pint/testsuite/test_formatting.py
+++ b/pint/testsuite/test_formatting.py
@@ -81,3 +81,30 @@ def test_format_unit_caret_negative_power(func_registry):
     assert format(u, "~^P") == "s⁻¹"
     # Without ^ flag: 1/s (ratio form, unchanged)
     assert format(u, "~P") == "1/s"
+
+
+def test_format_unit_fraction_exponent(func_registry):
+    """format_unit with / flag renders fractional exponents as a plain
+    fraction instead of a decimal (fixes #60).
+    """
+    u = func_registry.Unit("second") ** 1.5
+    assert format(u, "~P") == "s¹⋅⁵"
+    assert format(u, "~/P") == "s ** (3/2)"
+
+    # Whole-number exponents are unaffected (still a plain, unparenthesized
+    # exponent using the ** notation this modifier switches to).
+    u2 = func_registry.Unit("meter") ** 2
+    assert format(u2, "~/P") == "m ** 2"
+
+
+def test_format_unit_fraction_exponent_absorbs_noise(func_registry):
+    """The / flag snaps near-integer floating-point noise back to a clean
+    exponent, the same noise that caused DimensionalityError in #1487/#681.
+    """
+    # Noise near an integer, e.g. from combining fractional powers (#681).
+    u = func_registry.Unit("second") ** -0.9999999999999998
+    assert format(u, "~/P") == "1/s"
+
+    # Noise near zero (#1487): the residual exponent snaps to 0.
+    u2 = func_registry.Unit("meter") ** 5.55e-17
+    assert format(u2, "~/P") == "m ** 0"

--- a/pint/testsuite/test_formatting.py
+++ b/pint/testsuite/test_formatting.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from fractions import Fraction
+
 import pytest
 
 import pint.formatting as fmt
@@ -84,17 +86,21 @@ def test_format_unit_caret_negative_power(func_registry):
 
 
 def test_format_unit_fraction_exponent(func_registry):
-    """format_unit with / flag renders fractional exponents as a plain
-    fraction instead of a decimal (fixes #60).
+    """format_unit with / flag renders fractional exponents as a pretty
+    printed fraction (superscript numerator, superscript slash, superscript
+    denominator) instead of a decimal (fixes #60).
     """
     u = func_registry.Unit("second") ** 1.5
     assert format(u, "~P") == "s¹⋅⁵"
-    assert format(u, "~/P") == "s ** (3/2)"
+    assert format(u, "~/P") == "s³ᐟ²"
 
-    # Whole-number exponents are unaffected (still a plain, unparenthesized
-    # exponent using the ** notation this modifier switches to).
+    # Whole-number exponents are unaffected (still a plain superscript).
     u2 = func_registry.Unit("meter") ** 2
-    assert format(u2, "~/P") == "m ** 2"
+    assert format(u2, "~/P") == "m²"
+
+    # An exact Fraction exponent renders the same as the equivalent float.
+    u3 = func_registry.Unit("second") ** Fraction(3, 2)
+    assert format(u3, "~/P") == "s³ᐟ²"
 
 
 def test_format_unit_fraction_exponent_absorbs_noise(func_registry):
@@ -107,4 +113,4 @@ def test_format_unit_fraction_exponent_absorbs_noise(func_registry):
 
     # Noise near zero (#1487): the residual exponent snaps to 0.
     u2 = func_registry.Unit("meter") ** 5.55e-17
-    assert format(u2, "~/P") == "m ** 0"
+    assert format(u2, "~/P") == "m⁰"


### PR DESCRIPTION
## Summary
Fixes #60.

- A fractional exponent (e.g. from `unit ** 1.5`) is normally rendered as a lossy decimal in pretty-print (`s¹⋅⁵`). Adds a new `/` unit modifier that instead renders it as `unit ** (numerator/denominator)`, converting the exponent to a `Fraction` and snapping it via `.limit_denominator(1000)`.
- `s ** 1.5` -> `f"{u:~/P}"` -> `s ** (3/2)`. Whole-number exponents are unaffected (`m ** 2`, not parenthesized).
- As a side benefit, since the snap absorbs near-integer floating-point noise, the same modifier cleans up the kind of residual noise from combining fractional powers that caused `DimensionalityError` in #1487/#681 — e.g. `unit ** -0.9999999999999998` renders as `1/unit` instead of the raw noise, when this modifier is used. (Note: this is purely a *display* fix for that noise; the actual correctness fix for #1487/#681 already landed separately in #2381.)
- Wired into `_spec_helpers.py`'s custom-flag recognition alongside the existing `~`/`^` modifiers, and into `PrettyFormatter.format_unit` (`plain.py`). Pre-snaps exponents before calling the shared `formatter()` helper so its existing "omit exponent when exactly 1/-1" shortcut also benefits, not just the rendering.

## Docs
Added a "Unit modifiers" table row and a worked example (including the near-1 and near-0 noise cases) to `docs/user/formatting.rst`.

## Test plan
- [x] `test_format_unit_fraction_exponent`, `test_format_unit_fraction_exponent_absorbs_noise` in `test_formatting.py`
- [x] Doctests in `docs/user/formatting.rst` pass (`sphinx-build -b doctest`)
- [x] Full test suite passes (2289 passed)
- [x] `pre-commit run --all-files` clean