### PR TITLE
Fix list/tuple of numeric strings not respecting non_int_type

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ Pint Changelog
 - Add a "Try Pint in your browser" page to the docs with an in-browser JupyterLite console and notebook, requiring no local install (#2372)
 - Switch CodSpeed CI benchmarks to `simulation` mode to fix a walltime environment warning.
 - Fix `DimensionalityError` from floating-point noise in combined fractional unit exponents (#1487, #681)
+- Fix a list/tuple of numeric strings keeping a string dtype instead of being parsed with the registry's `non_int_type` (#1735)
 - Add `/` unit modifier to pretty-print fractional exponents as a fraction (e.g. `s**1.5` -> `s³ᐟ²`) (#60)
 - Fix `is_compatible_with` edge cases with dimensionless types and unit strings with a scaling factor (e.g. `"35000 ft"`) (#1190)
 - Allow string parsing of offset units (#386)

--- a/pint/compat.py
+++ b/pint/compat.py
@@ -299,12 +299,16 @@ if HAS_NUMPY:
     else:
         NUMERIC_TYPES = (Number, Decimal, ndarray, np.number)
 
-    def _to_magnitude(value, force_ndarray=False, force_ndarray_like=False):
+    def _to_magnitude(
+        value, force_ndarray=False, force_ndarray_like=False, non_int_type=float
+    ):
         if isinstance(value, (dict, bool)) or value is None:
             raise TypeError(f"Invalid magnitude for Quantity: {value!r}")
         elif isinstance(value, str) and value == "":
             raise ValueError("Quantity magnitude cannot be an empty string.")
         elif isinstance(value, (list, tuple)):
+            if any(isinstance(v, str) for v in value):
+                value = [non_int_type(v) if isinstance(v, str) else v for v in value]
             return np.asarray(value)
         elif HAS_UNCERTAINTIES:
             from pint.facets.measurement.objects import Measurement
@@ -340,7 +344,9 @@ else:
     NUMERIC_TYPES = (Number, Decimal)
     NP_NO_VALUE = None
 
-    def _to_magnitude(value, force_ndarray=False, force_ndarray_like=False):
+    def _to_magnitude(
+        value, force_ndarray=False, force_ndarray_like=False, non_int_type=float
+    ):
         if force_ndarray or force_ndarray_like:
             raise ValueError(
                 "Cannot force to ndarray or ndarray-like when NumPy is not present."

--- a/pint/facets/plain/quantity.py
+++ b/pint/facets/plain/quantity.py
@@ -265,7 +265,10 @@ class PlainQuantity(PrettyIPython, SharedRegistryObject, Generic[MagnitudeT_co])
             )
         else:
             magnitude = _to_magnitude(
-                value, inst.force_ndarray, inst.force_ndarray_like
+                value,
+                inst.force_ndarray,
+                inst.force_ndarray_like,
+                non_int_type=inst._REGISTRY.non_int_type,
             )
         inst._magnitude = cast("MagnitudeT_co", magnitude)
         inst._units = units

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1157,6 +1157,25 @@ def test_issue1433(func_registry):
 
 
 @helpers.requires_numpy
+def test_issue1735():
+    # A list/tuple of numeric strings used to keep a string dtype instead of
+    # being parsed into the registry's non_int_type, unlike an equivalent
+    # scalar string (e.g. Quantity("2", "m")), which already parses correctly.
+    ureg = UnitRegistry()
+
+    q = ureg.Quantity(["0.0", "1.0"], "kg")
+    assert q.magnitude.dtype != object
+    assert list(q.magnitude) == [0.0, 1.0]
+
+    q_tuple = ureg.Quantity(("1.5", "2.5"), "kg")
+    assert list(q_tuple.magnitude) == [1.5, 2.5]
+
+    ureg_dec = UnitRegistry(non_int_type=decimal.Decimal)
+    q_dec = ureg_dec.Quantity(["0.0", "1.0"], "kg")
+    assert list(q_dec.magnitude) == [decimal.Decimal("0.0"), decimal.Decimal("1.0")]
+
+
+@helpers.requires_numpy
 def test_issue681():
     # Floating-point noise from combining fractional exponents used to leave
     # a near-integer (not just near-zero) residual, e.g. [time] ** -0.9999999999999998


### PR DESCRIPTION
## Summary
Fixes the remaining part of #1735, per the still-open discrepancy raised in https://github.com/hgrecco/pint/issues/1735#issuecomment-3996839039.

- The scalar case (`Quantity("2", "m")`) already parses the string into the registry's `non_int_type` correctly (fixed previously via #2068) — confirmed still working on current master.
- The list/tuple case did not: `Quantity(["0.0", "1.0"], "kg")` kept a string-dtype numpy array (`array(['0.0', '1.0'], dtype='<U3')`) instead of parsing each element, as originally reported by @dalito in this issue thread.
- `_to_magnitude` (`pint/compat.py`, both the NumPy and no-NumPy variants) now accepts an optional `non_int_type` parameter (default `float`, preserving existing behavior for other call sites); when given a list/tuple containing strings, each string element is converted via `non_int_type(...)` before building the array.
- `PlainQuantity.__new__` (`pint/facets/plain/quantity.py`) passes `inst._REGISTRY.non_int_type` through at its `_to_magnitude` call site for the array/list magnitude path, so it's consistent with the scalar-string path (which already uses `ParserHelper.from_string(value, inst._REGISTRY.non_int_type)`).

## Test plan
- [x] Added `test_issue1735` covering list, tuple, and a `Decimal`-based registry
- [x] Full test suite passes (2290 passed) on both the NumPy and no-NumPy pixi environments
- [x] `pre-commit run --all-files` clean