### PR TITLE
Localize units whose pint name differs from the CLDR identifier

### DIFF
--- a/pint/delegates/formatter/_compound_unit_helpers.py
+++ b/pint/delegates/formatter/_compound_unit_helpers.py
@@ -21,6 +21,7 @@ from typing import (
     TypedDict,
 )
 
+from ...babel_names import _babel_units
 from ...compat import babel_parse
 from ...util import UnitsContainer
 from .sorting import SortFunc
@@ -104,6 +105,10 @@ def localize_unit_name(
     from babel.units import _find_unit_pattern, get_unit_name
 
     q_unit = _find_unit_pattern(measurement_unit, locale=locale)
+    if not q_unit and measurement_unit in _babel_units:
+        # Some pint unit names differ from the CLDR identifier babel expects
+        # (e.g. ``kilowatt_hour`` vs ``energy-kilowatt-hour``).
+        q_unit = _find_unit_pattern(_babel_units[measurement_unit], locale=locale)
     if not q_unit:
         return measurement_unit
 

--- a/pint/testsuite/test_babel.py
+++ b/pint/testsuite/test_babel.py
@@ -77,6 +77,15 @@ def test_unit_format_babel():
         volume.format_babel()
 
 
+@helpers.requires_babel(["fr_FR"])
+def test_unit_format_babel_pint_specific_name():
+    # Units whose pint name differs from the CLDR identifier must still be
+    # localized, see issue #2234.
+    ureg = UnitRegistry(fmt_locale="fr_FR")
+    assert ureg.Unit("kWh").format_babel() == "kilowatt-heure"
+    assert ureg.Unit("light_year").format_babel() == "année-lumière"
+
+
 @helpers.requires_babel()
 def test_no_registry_locale(func_registry):
     ureg = func_registry


### PR DESCRIPTION
- [x] Closes #2234
- [ ] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

`format_babel` returned the raw pint name for units such as `kilowatt_hour`
(`"kilowatt_hour"` instead of `"kilowatt-heure"`). `localize_unit_name` passed the
pint unit name straight to babel's `_find_unit_pattern`, which only knows CLDR
identifiers, so any unit listed in pint's own `_babel_units` mapping
(`kilowatt_hour`, `light_year`, `mph`, ...) fell through untranslated. The lookup
now retries through `_babel_units`; units whose pint name already matches a CLDR
identifier are unaffected.

I ran `ruff check`/`ruff format --check` on the two changed files rather than the
full pre-commit suite, and did not add a CHANGES entry — happy to add one if you
prefer.

This change was prepared with AI assistance; the regression test was run locally
and fails without the fix.
