### PR TITLE
fix(formatter): do not raise on Fraction unit exponents

### DIFF
--- a/pint/delegates/formatter/_format_helpers.py
+++ b/pint/delegates/formatter/_format_helpers.py
@@ -92,10 +92,28 @@ def override_locale(
         setlocale(LC_NUMERIC, prev_locale_string)
 
 
+def fmt_exponent_number(num: Number) -> str:
+    """Format an exponent as a plain number.
+
+    Falls back to ``str`` for types that do not accept the ``n`` format
+    spec, such as ``fractions.Fraction`` (used when the registry is
+    created with ``non_int_type=Fraction``).
+    """
+    try:
+        return f"{num:n}"
+    except (TypeError, ValueError):
+        return str(num)
+
+
 def pretty_fmt_exponent(num: Number) -> str:
     """Format an number into a pretty printed exponent."""
     # unicode dot operator (U+22C5) looks like a superscript decimal
-    ret = f"{num:n}".replace("-", "⁻").replace(".", "\u22c5")
+    ret = (
+        fmt_exponent_number(num)
+        .replace("-", "⁻")
+        .replace(".", "\u22c5")
+        .replace("/", "ᐟ")
+    )
     for n in range(10):
         ret = ret.replace(str(n), _PRETTY_EXPONENTS[n])
     return ret
@@ -180,7 +198,7 @@ def formatter(
     division_fmt: str = " / ",
     power_fmt: str = "{} ** {}",
     parentheses_fmt: str = "({0})",
-    exp_call: FORMATTER = "{:n}".format,
+    exp_call: FORMATTER = fmt_exponent_number,
 ) -> str:
     """Format a list of (name, exponent) pairs.
 

--- a/pint/testsuite/test_formatter.py
+++ b/pint/testsuite/test_formatter.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from fractions import Fraction
+
 import pytest
 
+from pint import UnitRegistry
 from pint import formatting as fmt
 from pint.delegates.formatter._format_helpers import formatter, join_u
 from pint.formatting import formatter as pf_formatter
@@ -56,6 +59,16 @@ class TestFormatter:
         assert fmt.format_unit("", "C") == "dimensionless"
         with pytest.raises(ValueError):
             fmt.format_unit("m", "W")
+
+    def test_fraction_exponent(self):
+        # Fraction does not accept the "n" format spec, so formatting a unit
+        # with a Fraction exponent used to raise ValueError. See issue #2386.
+        ureg = UnitRegistry(non_int_type=Fraction)
+        unit = ureg.Unit("m**2.3")
+        assert f"{unit}" == "meter ** 23/10"
+        assert f"{unit:P}" == "meter²³ᐟ¹⁰"
+        assert f"{unit:C}" == "meter**23/10"
+        assert f"{ureg.Quantity('3 m**2.3')}" == "3 meter ** 23/10"
 
     def test_pf_formatter(self):
         assert pf_formatter({}.items()) == ""


### PR DESCRIPTION
- [x] Closes #2386
- [x] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

With `non_int_type=Fraction`, unit exponents are `Fraction`s, and both the default `exp_call` and `pretty_fmt_exponent` format them with the `n` spec, which `Fraction.__format__` rejects — so `str(ureg.Unit("m**2.3"))` raised `ValueError`. Exponent formatting now goes through `fmt_exponent_number()`, which falls back to `str()` for types that do not accept `n`; the pretty formatter maps the resulting `/` to the superscript slash already used by `pretty_fmt_exponent_fraction`. Float and int exponents are unchanged.

`m**2.3` now renders as `meter ** 23/10` (`meter²³ᐟ¹⁰` with `:P`).

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
