### PR TITLE
Fix RecursionError in find_connected_nodes for deeply chained graphs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.26.0 (unreleased)
 -------------------
 
+- Fix `RecursionError` in `find_connected_nodes` for deeply chained context graphs by replacing recursion with an iterative DFS
 - Raise `DefinitionSyntaxError` instead of a bare `RecursionError` for deeply nested expressions
 - Add a "Try Pint in your browser" page to the docs with an in-browser JupyterLite console and notebook, requiring no local install (#2372)
 - Switch CodSpeed CI benchmarks to `simulation` mode to fix a walltime environment warning.

--- a/pint/testsuite/test_util.py
+++ b/pint/testsuite/test_util.py
@@ -298,6 +298,19 @@ class TestGraph:
         g[2] = {3}
         assert find_connected_nodes(g, 9) is None
 
+    def test_find_connected_nodes_deep_chain(self):
+        # Regression test for CWE-674: the recursive predecessor of
+        # find_connected_nodes raised RecursionError on a linear chain
+        # longer than sys.getrecursionlimit(). The iterative version
+        # must handle it without crashing.
+        n = 2000
+        g = collections.defaultdict(set)
+        for i in range(n):
+            g[i].add(i + 1)
+        result = find_connected_nodes(g, 0)
+        assert result is not None
+        assert len(result) == n + 1
+
     def test_shortest_path(self):
         g = collections.defaultdict(set)
         g[1] = {2}

--- a/pint/util.py
+++ b/pint/util.py
@@ -402,11 +402,7 @@ def find_connected_nodes[TH: Hashable](
         return None
 
     visited = visited or set()
-    # Iterative DFS to avoid RecursionError on deeply chained graphs
-    # (CWE-674). The recursive predecessor recursed once per unvisited
-    # adjacent node, so a linear chain longer than sys.getrecursionlimit()
-    # raised an uncaught RecursionError. See GH #2376 for the same class
-    # of issue in _build_eval_tree.
+    # Iterative DFS to avoid RecursionError on deep chains: https://github.com/hgrecco/pint/issues/2388
     stack = [start]
     while stack:
         node = stack.pop()

--- a/pint/util.py
+++ b/pint/util.py
@@ -402,11 +402,18 @@ def find_connected_nodes[TH: Hashable](
         return None
 
     visited = visited or set()
-    visited.add(start)
-
-    for node in graph[start]:
-        if node not in visited:
-            find_connected_nodes(graph, node, visited)
+    # Iterative DFS to avoid RecursionError on deeply chained graphs
+    # (CWE-674). The recursive predecessor recursed once per unvisited
+    # adjacent node, so a linear chain longer than sys.getrecursionlimit()
+    # raised an uncaught RecursionError. See GH #2376 for the same class
+    # of issue in _build_eval_tree.
+    stack = [start]
+    while stack:
+        node = stack.pop()
+        if node in visited:
+            continue
+        visited.add(node)
+        stack.extend(graph[node] - visited)
 
     return visited
 


### PR DESCRIPTION
## Problem

`find_connected_nodes` in `pint/util.py` used unbounded recursion to traverse the context dimension graph. For each unvisited adjacent node it recursed once, so a linear chain longer than `sys.getrecursionlimit()` (default 1000) raised an uncaught `RecursionError`.

The function is reachable from the public API when contexts are enabled:

```
ureg.enable_contexts(...)
ureg.get_compatible_units(unit)
  -> ContextRegistry._get_compatible_units
  -> find_connected_nodes(self._active_ctx.graph, src_dim)
```

This is the same class of issue (CWE-674) that was fixed in `_build_eval_tree` (#2376).

## Fix

Replace the recursion with an iterative DFS using an explicit stack. The `visited` set still ensures each node is processed at most once, so the result is identical — only the call mechanism changes.

```python
stack = [start]
while stack:
    node = stack.pop()
    if node in visited:
        continue
    visited.add(node)
    stack.extend(graph[node] - visited)
```

## Verification

- PoC: a 2000-node linear chain that previously raised `RecursionError` now visits all 2001 nodes successfully.
- All 86 tests in `test_util.py` and `test_contexts.py` pass.
- Added a regression test `test_find_connected_nodes_deep_chain`.

## Files changed

- `pint/util.py` — recursive → iterative DFS (net +12 lines)
- `pint/testsuite/test_util.py` — regression test (+13 lines)
- `CHANGES` — changelog entry