### PR TITLE
Cache derived prefixed units in the persistent registry, not a context overlay

### DIFF
--- a/pint/facets/context/registry.py
+++ b/pint/facets/context/registry.py
@@ -80,6 +80,13 @@ class GenericContextRegistry[QuantityT: Quantity, UnitT: Unit](
         # Allow contexts to add override layers to the units
         self._units: ChainMap[str, UnitDefinition] = ChainMap(self._units)
 
+    @property
+    def _persistent_units(self) -> dict[str, UnitDefinition]:
+        # The last map is the base registry that persists across contexts; the
+        # earlier maps are transient overlays discarded on context exit, so
+        # derived units must be cached in the base one (see #2389).
+        return self._units.maps[-1]
+
     def _register_definition_adders(self) -> None:
         super()._register_definition_adders()
         self._register_adder(ContextDefinition, self.add_context)

--- a/pint/facets/plain/registry.py
+++ b/pint/facets/plain/registry.py
@@ -680,7 +680,10 @@ class GenericPlainRegistry[QuantityT: PlainQuantity, UnitT: PlainUnit](
             name = prefix + unit_name
             symbol = self.get_symbol(name, case_sensitive)
             prefix_def = self._prefixes[prefix]
-            self._units[name] = UnitDefinition(
+            # Cache the derived prefixed unit in the persistent registry rather
+            # than in a transient context overlay that would evict it on exit.
+            # See https://github.com/hgrecco/pint/issues/2389
+            self._persistent_units[name] = UnitDefinition(
                 name,
                 symbol,
                 tuple(),
@@ -704,6 +707,15 @@ class GenericPlainRegistry[QuantityT: PlainQuantity, UnitT: PlainUnit](
             )
 
         return self._prefixes[prefix].symbol + self._units[unit_name].symbol
+
+    @property
+    def _persistent_units(self) -> dict[str, UnitDefinition]:
+        """The unit mapping that survives context enter/exit.
+
+        Plain registries have no context overlays, so this is just ``_units``.
+        Context registries override this to skip the transient overlay.
+        """
+        return self._units
 
     def _get_symbol(self, name: str) -> str:
         return self._units[name].symbol

--- a/pint/testsuite/test_contexts.py
+++ b/pint/testsuite/test_contexts.py
@@ -1024,3 +1024,26 @@ def test_err_new_unit():
     expected = "'bar' is not defined in the unit registry"
     with pytest.raises(UndefinedUnitError, match=expected):
         ureg.enable_contexts("c")
+
+
+def test_prefixed_unit_survives_redefining_context():
+    # A metric-prefixed unit created lazily inside a unit-redefining context
+    # must survive the context exit; it used to be cached in the transient
+    # context overlay and silently evicted, raising KeyError on later
+    # abbreviated formatting. See https://github.com/hgrecco/pint/issues/2389
+    ureg = UnitRegistry(
+        """
+        kilo- = 1000 = k-
+        foo = [d] = f
+        bar = 2 foo = b
+
+        @context c
+            b = 5 f
+        @end
+        """.splitlines()
+    )
+    with ureg.context("c"):
+        q = ureg.Quantity(1, "kilofoo")
+    assert "kilofoo" in ureg._units
+    # This abbreviated format used to raise KeyError after the context exited.
+    assert f"{q:~P}" == "1 kf"


### PR DESCRIPTION
### Summary

Fixes #2389. A metric-prefixed unit created lazily while a unit-redefining context is active is silently evicted when the context exits, causing a `KeyError` on later abbreviated formatting.

```python
ureg = UnitRegistry()
ureg.define("apple = [fruit] = ap")
with ureg.context(some_redefining_context):
    q = ureg.Quantity(1, "megaapple")   # prefixed unit cached lazily
# context exited
f"{q:~P}"                                # KeyError: 'megaapple'
```

### Root cause

`PlainRegistry.get_name` lazily creates a prefixed `UnitDefinition` and caches it in `self._units` (`facets/plain/registry.py`). In `ContextRegistry`, `self._units` is a `ChainMap`, and a unit-redefining context inserts a transient overlay at `maps[0]`. `ChainMap` writes go to `maps[0]`, so the lazy cache lands in the overlay, which is discarded (`del self._units.maps[:-1]`) on context exit. `_get_symbol` then does `self._units[name].symbol` -> `KeyError`. The cached prefixed unit is a pure function of (prefix, base unit) and has nothing to do with the context.

### Fix

Add a `_persistent_units` accessor: `PlainRegistry` returns `self._units`; `ContextRegistry` overrides it to `self._units.maps[-1]` (the base map that survives contexts). The lazy prefixed-unit write uses it.

### Test

Added a regression test in `test_contexts.py`: inside a redefining context, build a prefixed quantity, exit, and assert it is still in the registry and formats (`~P`) without raising. Fails before the fix, passes after; the full `test_contexts.py`/`test_issues.py` suites pass with no regressions.

---

Disclosure: prepared with AI assistance (Claude); I reviewed it and verified the red-green test and suite.
