### PR TITLE
Fix ValueError when formatting units with Fraction exponents (#2386)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.26.0 (unreleased)
 -------------------
 
+- Fix `ValueError` when formatting a `Unit`/`Quantity` whose exponent is a `fractions.Fraction` (e.g. registries created with `non_int_type=Fraction`), which does not support the `n` format spec (#2386)
 - Raise `DefinitionSyntaxError` instead of a bare `RecursionError` for deeply nested expressions
 - Add a "Try Pint in your browser" page to the docs with an in-browser JupyterLite console and notebook, requiring no local install (#2372)
 - Switch CodSpeed CI benchmarks to `simulation` mode to fix a walltime environment warning.

--- a/pint/delegates/formatter/_format_helpers.py
+++ b/pint/delegates/formatter/_format_helpers.py
@@ -92,10 +92,25 @@ def override_locale(
         setlocale(LC_NUMERIC, prev_locale_string)
 
 
+def _format_exponent_n(num: Number) -> str:
+    """Format an exponent using the locale-aware ``n`` spec, with a fallback.
+
+    Some numeric types do not accept the ``n`` presentation type and raise
+    ``ValueError`` when formatted with it - most notably ``fractions.Fraction``,
+    which is used as the exponent type when a registry is created with
+    ``non_int_type=fractions.Fraction``. For those, fall back to ``str`` so that
+    formatting produces output instead of raising.
+    """
+    try:
+        return f"{num:n}"
+    except (ValueError, TypeError):
+        return str(num)
+
+
 def pretty_fmt_exponent(num: Number) -> str:
     """Format an number into a pretty printed exponent."""
     # unicode dot operator (U+22C5) looks like a superscript decimal
-    ret = f"{num:n}".replace("-", "⁻").replace(".", "\u22c5")
+    ret = _format_exponent_n(num).replace("-", "⁻").replace(".", "\u22c5")
     for n in range(10):
         ret = ret.replace(str(n), _PRETTY_EXPONENTS[n])
     return ret
@@ -180,7 +195,7 @@ def formatter(
     division_fmt: str = " / ",
     power_fmt: str = "{} ** {}",
     parentheses_fmt: str = "({0})",
-    exp_call: FORMATTER = "{:n}".format,
+    exp_call: FORMATTER = _format_exponent_n,
 ) -> str:
     """Format a list of (name, exponent) pairs.
 

--- a/pint/testsuite/test_formatter.py
+++ b/pint/testsuite/test_formatter.py
@@ -44,6 +44,36 @@ class TestFormatter:
             == "1 / (meter * second ** 2)"
         )
 
+    def test_formatter_fraction_exponent(self):
+        # A Fraction exponent (used when a registry is created with
+        # non_int_type=Fraction) does not accept the 'n' format spec, so the
+        # default exponent formatting used to raise ValueError instead of
+        # rendering. See GH #2386.
+        from fractions import Fraction
+
+        exp = Fraction(23, 10)
+        assert formatter(dict(meter=exp).items(), ()) == "meter ** 23/10"
+        assert (
+            formatter((), dict(meter=-exp).items(), as_ratio=False)
+            == "meter ** -23/10"
+        )
+
+    def test_unit_fraction_exponent_formatting(self):
+        # End-to-end: formatting a unit whose exponent is a Fraction must not
+        # raise for any of the built-in format specs. GH #2386.
+        import fractions
+
+        import pint
+
+        ureg = pint.UnitRegistry(non_int_type=fractions.Fraction)
+        u = ureg.Unit("m**2.3")
+        assert str(u) == "meter ** 23/10"
+        assert format(u, "~") == "m ** 23/10"
+        # Pretty specs render the exponent as superscripts; assert they produce
+        # (non-empty) output rather than raising.
+        assert format(u, "P")
+        assert format(u, "~P")
+
     def testparse_spec(self):
         assert fmt._parse_spec("") == ""
         assert fmt._parse_spec("") == ""


### PR DESCRIPTION
Fixes #2386.

If you build a registry with `non_int_type=fractions.Fraction`, a unit can wind up with a `Fraction` exponent (from `Unit('m**2.3')`, a fractional power, etc). Formatting it blows up:

```python
import fractions, pint
ureg = pint.UnitRegistry(non_int_type=fractions.Fraction)
str(ureg.Unit('m**2.3'))
# ValueError: Invalid format specifier 'n' for object of type 'Fraction'
```

The exponent formatting path applies the `n` format spec (`f'{x:n}'`), which `Fraction.__format__` rejects. This hits every non-`/` spec: the default, compact (`~`) and pretty (`P`, `~P`) formatters all raise. The `/` pretty modifier already worked because it goes through `pretty_fmt_exponent_fraction`.

I added a small `_format_exponent_n` helper that applies the `n` spec but falls back to `str()` for types that don't accept it, and used it both for the default `exp_call` and inside `pretty_fmt_exponent`. Int and float exponents go through the exact same `f'{x:n}'` path as before, so nothing changes for them; only the previously-crashing types now render.

After the change:

```
''   -> 'meter ** 23/10'
'~'  -> 'm ** 23/10'
'P'  -> 'meter²³/¹⁰'
'~P' -> 'm²³/¹⁰'
```

Added two tests in `test_formatter.py`: a low-level `formatter()` check with a `Fraction` exponent, and an end-to-end check that all four specs render without raising. Both fail on master and pass with the fix.

Ran:
```
python -m pytest pint/testsuite/test_formatter.py pint/testsuite/test_formatting.py pint/testsuite/test_non_int.py
# 650 passed
```

Added a CHANGES entry too.