### PR TITLE
Raise DefinitionSyntaxError for empty and unbalanced parentheses

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,8 @@ Pint Changelog
 -------------------
 
 - Raise `DefinitionSyntaxError` instead of a bare `RecursionError` for deeply nested expressions
+- Raise `DefinitionSyntaxError` instead of a bare `AssertionError` (empty parentheses) or
+  `tokenize.TokenError` (unbalanced parentheses) when parsing a malformed expression
 - Add a "Try Pint in your browser" page to the docs with an in-browser JupyterLite console and notebook, requiring no local install (#2372)
 - Switch CodSpeed CI benchmarks to `simulation` mode to fix a walltime environment warning.
 - Document that instantiating `Quantity` from a `(magnitude, unit)` pair is significantly faster than from a string or by multiplying by a unit (#1873)

--- a/pint/pint_eval.py
+++ b/pint/pint_eval.py
@@ -465,11 +465,13 @@ def _build_eval_tree(
                     )
                 elif prev_op == "(":
                     # close parenthetical group
-                    assert result is not None
+                    if result is None:
+                        raise DefinitionSyntaxError("empty parentheses in tokens")
                     return result, index
                 else:
                     # parenthetical group ending, but we need to close sub-operations within group
-                    assert result is not None
+                    if result is None:
+                        raise DefinitionSyntaxError("empty parentheses in tokens")
                     return result, index - 1
             elif token_text == "(":
                 # gather parenthetical group
@@ -579,7 +581,13 @@ def build_eval_tree(
 
     if not isinstance(tokens, list):
         # ensure tokens is list so we can access by index
-        tokens = list(tokens)
+        try:
+            tokens = list(tokens)
+        except tokenize.TokenError as exc:
+            # e.g. an unbalanced "(" makes the Python tokenizer raise TokenError
+            # ("unexpected EOF in multi-line statement"); surface it as a pint
+            # syntax error instead.
+            raise DefinitionSyntaxError(str(exc)) from exc
 
     result, _ = _build_eval_tree(tokens, op_priority, 0, 0)
 

--- a/pint/testsuite/test_pint_eval.py
+++ b/pint/testsuite/test_pint_eval.py
@@ -202,3 +202,29 @@ def test_build_eval_tree_deeply_nested_raises_definition_syntax_error(
     evil = "kg " + f"{op} kg " * 1000
     with pytest.raises(DefinitionSyntaxError):
         build_eval_tree(tokenizer(evil))
+
+
+@pytest.mark.parametrize("tokenizer", TOKENIZERS)
+@pytest.mark.parametrize("input_text", ["()", "( )", "( ( ) )", "kg * ()"])
+def test_build_eval_tree_empty_parentheses_raises_definition_syntax_error(
+    tokenizer, input_text: str
+):
+    # An empty parenthetical group has no operand to close, which used to trip a
+    # bare AssertionError instead of a pint DefinitionSyntaxError.
+    from pint.errors import DefinitionSyntaxError
+
+    with pytest.raises(DefinitionSyntaxError):
+        build_eval_tree(tokenizer(input_text))
+
+
+@pytest.mark.parametrize("tokenizer", TOKENIZERS)
+@pytest.mark.parametrize("input_text", ["(", "((", "1 (", "kg (", "(1 + 2"])
+def test_build_eval_tree_unbalanced_parentheses_raises_definition_syntax_error(
+    tokenizer, input_text: str
+):
+    # An unclosed "(" makes Python's tokenizer raise tokenize.TokenError while
+    # the tokens are materialized; it must surface as a pint DefinitionSyntaxError.
+    from pint.errors import DefinitionSyntaxError
+
+    with pytest.raises(DefinitionSyntaxError):
+        build_eval_tree(tokenizer(input_text))


### PR DESCRIPTION
Following the same thread as the recent missing-operand / deep-nesting hardening in the expression parser, I found two more malformed inputs that come back out of `parse_expression` as a Python-internal error rather than pint's own `DefinitionSyntaxError`:

- an empty parenthetical group such as `ureg('( )')` or `ureg('()')` hits `assert result is not None` in `_build_eval_tree`, so it raises a bare `AssertionError` with no message;
- an unclosed `(` such as `ureg('1 (')` or `ureg('(1 + 2')` makes Python's tokenizer raise `tokenize.TokenError` ("unexpected EOF in multi-line statement") when `build_eval_tree` materializes the token generator.

Both now raise `DefinitionSyntaxError`, consistent with how the parser already reports an unopened `)`, a missing operand, or a too-deeply-nested expression. I replaced the two `assert result is not None` lines with an explicit `DefinitionSyntaxError("empty parentheses in tokens")`, and wrapped the `list(tokens)` in `build_eval_tree` to convert `TokenError` into `DefinitionSyntaxError`.

Added parametrized tests alongside the existing missing-operand ones (both tokenizers). They fail on master (AssertionError / TokenError) and pass with the change; the full test_pint_eval and test_quantity suites still pass, and valid expressions including parenthetical groups and uncertainty notation like `1.0(2) meter` are unchanged. I found these by fuzzing `ureg.Quantity` with mutated valid expressions.