### PR TITLE
Quantity.searchsorted drops the sorter argument

### DIFF
--- a/pint/facets/numpy/quantity.py
+++ b/pint/facets/numpy/quantity.py
@@ -198,7 +198,7 @@ class NumpyQuantity[MagnitudeT: Magnitude](PlainQuantity[MagnitudeT]):
             v = self.__class__(v, "").to(self)
         else:
             raise DimensionalityError("dimensionless", self._units)
-        return self.magnitude.searchsorted(v, side)
+        return self.magnitude.searchsorted(v, side, sorter)
 
     def dot(self, b):
         """Dot product of two arrays.

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -684,6 +684,13 @@ class TestNumpyUnclassified(TestNumpyMethods):
         with pytest.raises(DimensionalityError):
             q.searchsorted([1.5, 2.5])
 
+    def test_searchsorted_sorter(self):
+        q = [30.0, 10.0, 20.0] * self.ureg.m
+        sorter = [1, 2, 0]
+        self.assertNDArrayEqual(
+            q.searchsorted([15.0, 25.0] * self.ureg.m, "left", sorter), [1, 2]
+        )
+
     def test_searchsorted_numpy_func(self):
         """Test searchsorted as numpy function."""
         q = self.q.flatten()


### PR DESCRIPTION
`Quantity.searchsorted` takes a `sorter` and never passes it on:

```python
return self.magnitude.searchsorted(v, side)
```

So a sorter given for an unsorted array is dropped and the indices come back wrong, with no error.

```python
a = np.array([30.0, 10.0, 20.0])
s = np.argsort(a)                 # [1, 2, 0]
q = ureg.Quantity(a, "meter")

a.searchsorted(15.0, "left", s)                          # 1
q.searchsorted(ureg.Quantity(15.0, "meter"), "left", s)  # 2
```

The parameter came from #683, which added it so `np.searchsorted` would delegate to this method. The signature was updated. The call under it was not. The test that went in with it passes no sorter, which is why this sat quietly since 2018.

One argument forwarded, plus a test with an unsorted magnitude, which is the only case where a sorter changes the answer.

Suite is 2290 passing with the change. Reverting just the `quantity.py` line fails the new test alone, and the skip count is 140 either way, so nothing moved into a skip. I ran it without `testsuite/benchmarks`.
