### PR TITLE
Fix spurious DimensionalityError in to_preferred

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Pint Changelog
 
 - Fix `numpy.sum`/`numpy.nansum` not converting a Quantity `initial` value, unlike `numpy.max`/`numpy.min` (#2400)
 - Fix `Quantity.to_compact()` raising `OffsetUnitCalculusError` for offset units like `degree_Celsius` with magnitude below 1 (#2005)
+- Fix `to_preferred` raising a spurious `DimensionalityError` for some preferred units (#2395)
 
 
 0.26.1 (2026-09-10)

--- a/pint/facets/plain/qto.py
+++ b/pint/facets/plain/qto.py
@@ -297,7 +297,7 @@ def _get_preferred(
                     preferred_unit.dimensionality[d] for d in dims
                 )
                 if all(
-                    s_exps_tail[i] * p_exps_head == p_exps_tail[i] ** s_exps_head
+                    s_exps_tail[i] * p_exps_head == p_exps_tail[i] * s_exps_head
                     for i in range(n)
                 ):
                     ratio = p_exps_head / s_exps_head

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -474,6 +474,7 @@ class TestQuantity(QuantityTestCase):
         result = Q_("1 volt").to_preferred(preferred_units)
         assert result.units == ureg.volts
 
+    @helpers.requires_scipy
     def test_to_preferred_no_spurious_dimensionality_error(self):
         # find_simple() compared the dimensionality exponent-vectors with `**`
         # instead of `*`, so a preferred unit whose exponent signature happened

--- a/pint/testsuite/test_quantity.py
+++ b/pint/testsuite/test_quantity.py
@@ -474,6 +474,18 @@ class TestQuantity(QuantityTestCase):
         result = Q_("1 volt").to_preferred(preferred_units)
         assert result.units == ureg.volts
 
+    def test_to_preferred_no_spurious_dimensionality_error(self):
+        # find_simple() compared the dimensionality exponent-vectors with `**`
+        # instead of `*`, so a preferred unit whose exponent signature happened
+        # to satisfy the spurious exponential identity was matched, and to()
+        # then raised a DimensionalityError on a perfectly valid call.
+        ureg = self.ureg
+        Q_ = self.Q_
+
+        q = Q_(1.0, "m**3 * s**4")
+        result = q.to_preferred([ureg.Unit("m**2 * s**2")])
+        assert result.to_base_units() == q.to_base_units()
+
     def test_to_preferred_accepts_unitlike_strings(self):
         ureg = self.ureg
         q = self.Q_("1 g")


### PR DESCRIPTION
## Summary

`Quantity.to_preferred` can raise a `DimensionalityError` on a perfectly valid call because of a wrong operator in its proportionality test.

In `pint/facets/plain/qto.py`, `_get_preferred`'s `find_simple` helper decides whether the quantity's dimensionality exponent-vector is a scalar multiple of a candidate preferred unit's — a **linear** condition, `s_tail[i] * p_head == p_tail[i] * s_head`. The code instead had:

```python
if all(
    s_exps_tail[i] * p_exps_head == p_exps_tail[i] ** s_exps_head
    for i in range(n)
):
```

`p_exps_tail[i] ** s_exps_head` raises to a power instead of multiplying. It only coincides with the correct test when the head exponent is `1` (`x**1 == x`), which is why the existing `to_preferred` tests (all head-exponent 1) never exercised the difference.

With a non-1 head exponent, the wrong test can report a **spurious match**. `find_simple` then returns `preferred_unit ** (s_head / p_head)`, which is not dimensionally equivalent to the quantity, and `to_preferred` calls `.to(...)` on it and raises:

```python
>>> import pint; ureg = pint.UnitRegistry(); Q_ = ureg.Quantity
>>> Q_(1.0, "m**3 * s**4").to_preferred([ureg.Unit("m**2 * s**2")])
pint.errors.DimensionalityError: Cannot convert from 'meter ** 3 * second ** 4'
([length] ** 3 * [time] ** 4) to 'meter ** 3 * second ** 3' ([length] ** 3 * [time] ** 3)
```

Here `s_exps=[3,4]`, `p_exps=[2,2]`: the buggy test computes `4*2 == 2**3` → `8 == 8` → a spurious match, whereas the correct `4*2 == 2*3` → `8 == 6` is False.

## Fix

One character — use `*` so the exponent-vector proportionality test is linear:

```python
    s_exps_tail[i] * p_exps_head == p_exps_tail[i] * s_exps_head
```

An explicit non-proportional case no longer matches (so no spurious `DimensionalityError`), and legitimate proportional matches with a head exponent other than 1 are now caught by `find_simple` instead of being dropped to the optimizer.

## Testing

Added `test_to_preferred_no_spurious_dimensionality_error`. Before the fix it raises `DimensionalityError`; after, it passes. The existing `test_to_preferred` cases are unchanged (all head-exponent 1, so unaffected). `ruff` is clean and I added a `CHANGES` entry.