### PR TITLE
Fix to_compact() raising OffsetUnitCalculusError on offset units below 1 (#2005)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Pint Changelog
 0.26.2 (unreleased)
 -------------------
 
-- No changes yet.
+- Fix `Quantity.to_compact()` raising `OffsetUnitCalculusError` for offset units like `degree_Celsius` with magnitude below 1 (#2005)
 
 
 0.26.1 (2026-09-10)

--- a/pint/facets/plain/qto.py
+++ b/pint/facets/plain/qto.py
@@ -175,6 +175,9 @@ def to_compact[Q: PlainQuantity](quantity: Q, unit: UnitsContainer | None = None
     if quantity.unitless or qm == 0 or math.isnan(qm) or math.isinf(qm):
         return quantity
 
+    if quantity._get_non_multiplicative_units():
+        return quantity
+
     SI_powers, SI_bases = _get_si_prefixes(quantity._REGISTRY)
     q_base, unit_str, unit_power = _get_compact_base(quantity, unit)
 

--- a/pint/testsuite/test_infer_base_unit.py
+++ b/pint/testsuite/test_infer_base_unit.py
@@ -124,6 +124,25 @@ def test_to_compact_fraction(sess_registry):
     assert r == Q(1000, "s/m")
 
 
+@pytest.mark.parametrize("magnitude", [0.1, -0.5, 2500])
+def test_to_compact_offset_unit(sess_registry, magnitude):
+    # Offset (non-multiplicative) units such as degree_Celsius cannot take an
+    # SI prefix, so to_compact must return the quantity unchanged instead of
+    # raising OffsetUnitCalculusError (issue #2005).
+    q = sess_registry.Quantity(magnitude, "degree_Celsius")
+    compact = q.to_compact()
+    assert compact.magnitude == magnitude
+    assert compact.units == q.units
+
+
+def test_to_compact_delta_offset_unit_still_compacts(sess_registry):
+    # delta_degree_Celsius is multiplicative, so compacting must still apply a
+    # prefix (no regression from the offset-unit guard).
+    compact = sess_registry.Quantity(0.001, "delta_degree_Celsius").to_compact()
+    expected = sess_registry.Quantity(1.0, "millidelta_degree_Celsius")
+    helpers.assert_quantity_almost_equal(compact, expected)
+
+
 def test_volts(sess_registry):
     r = (
         sess_registry.Quantity(1, "V")


### PR DESCRIPTION
- [x] Closes #2005
- [x] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

## Problem

`Quantity.to_compact()` crashes on a valid offset-unit quantity whose magnitude is below 1 in absolute value:

```python
from pint import Quantity
Quantity(0.1, "degree_Celsius").to_compact()   # raises OffsetUnitCalculusError
```

On the first call it raises (the issue reported `DimensionalityError` on Pint 0.23; on current `master` it is `OffsetUnitCalculusError`). It only appears to work for `1 <= |value| < 1000`.

## Root cause

For `|value| < 1000`, `to_compact` computes a non-zero power of ten and calls `_pick_compact_unit`, which renames the unit to an SI-prefixed spelling (`degree_Celsius` -> `millidegree_Celsius`). Prefixing a non-multiplicative (offset) unit is invalid, so the final `.to(new_unit_container)` raises `OffsetUnitCalculusError`. The `1 <= |value| < 1000` range only survives because there the power is 0, so no prefix is added.

## Fix

Return the quantity unchanged when it contains a non-multiplicative unit, right after the existing early-return guard:

```python
if quantity._get_non_multiplicative_units():
    return quantity
```

This is consistent with the existing behavior for `1 <= |value| < 1000`, which already returns the quantity unchanged. **Design note for maintainers:** I chose "return unchanged" to match that existing behavior rather than converting the quantity to its (multiplicative) base unit -- please confirm this is the desired semantics for offset units. Multiplicative "delta" units (e.g. `delta_degree_Celsius`, whose `_get_non_multiplicative_units()` is empty) are unaffected and still compact normally.

## Tests

Added to `pint/testsuite/test_infer_base_unit.py`:
- `test_to_compact_offset_unit` (parametrized over 0.1, -0.5, 2500): asserts `degree_Celsius` quantities are returned unchanged with no exception.
- `test_to_compact_delta_offset_unit_still_compacts`: asserts `delta_degree_Celsius` still compacts (regression guard).

Red/green verified: reverting the fix makes the new offset tests fail with `OffsetUnitCalculusError`; with the fix all compact tests pass and `ruff check`/`ruff format --check` are clean.

---
This contribution was made with AI assistance (Claude).