### PR TITLE
Improve type annotations for `Unit`'s `/`, `**` and copies

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,7 @@ Pint Changelog
   initializing a `Quantity` with a `datetime.timedelta` value.  (#1978)
 - Improve type annotations for `Quantity` (#2302, #2303)
 - Improve type annotations for `Quantity`'s `__new__` and document support for arithmetic with `datetime.timedelta` introduced in #2348 at the typing level (#2373)
+- Improve type annotations for `Unit`: `/` and `**` keep the unit type, and `__copy__`/`__deepcopy__` keep the registry subclass
 
 ### Formatting changes
 

--- a/pint/facets/plain/unit.py
+++ b/pint/facets/plain/unit.py
@@ -1,3 +1,5 @@
+# pyright: reportInvalidTypeArguments=warning
+
 """
 pint.facets.plain.unit
 ~~~~~~~~~~~~~~~~~~~~~
@@ -24,6 +26,7 @@ if TYPE_CHECKING:
     import datetime
 
     import numpy as np
+    import optype as opt
 
     from ..context import Context
     from .quantity import PlainQuantity
@@ -53,11 +56,11 @@ class PlainUnit(PrettyIPython, SharedRegistryObject):
                 )
             )
 
-    def __copy__(self) -> PlainUnit:
+    def __copy__(self) -> Self:
         ret = self.__class__(self._units)
         return ret
 
-    def __deepcopy__(self, memo) -> PlainUnit:
+    def __deepcopy__(self, memo) -> Self:
         ret = self.__class__(copy.deepcopy(self._units, memo))
         return ret
 
@@ -176,6 +179,21 @@ class PlainUnit(PrettyIPython, SharedRegistryObject):
 
     __rmul__ = __mul__
 
+    # PlainUnit / PlainUnit -> PlainUnit
+    @overload
+    def __truediv__(self, other: Self) -> Self: ...
+    # PlainUnit / timedelta -> PlainQuantity[float]
+    @overload
+    def __truediv__(
+        self, other: datetime.timedelta | np.timedelta64
+    ) -> PlainQuantity[float]: ...
+    # PlainUnit / <Magnitude> or PlainQuantity[<Magnitude>]
+    #   -> PlainQuantity[type of 1 / <Magnitude>]
+    @overload
+    def __truediv__[U: Magnitude](
+        self,
+        other: PlainQuantity[opt.CanRTruediv[int, U]] | opt.CanRTruediv[int, U],
+    ) -> PlainQuantity[U]: ...
     def __truediv__(self, other):
         if self._check(other):
             if isinstance(other, self.__class__):
@@ -200,7 +218,7 @@ class PlainUnit(PrettyIPython, SharedRegistryObject):
     __div__ = __truediv__
     __rdiv__ = __rtruediv__
 
-    def __pow__(self, other) -> PlainUnit:
+    def __pow__(self, other) -> Self:
         if isinstance(other, NUMERIC_TYPES):
             return self.__class__(self._units**other)
 

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -438,6 +438,22 @@ class Unit(
 
         __rmul__ = __mul__
 
+        # Unit / Unit -> Unit
+        @overload
+        def __truediv__(self, other: Self) -> Self: ...
+        # Unit / timedelta -> Quantity[float]
+        @overload
+        def __truediv__(
+            self, other: datetime.timedelta | np.timedelta64
+        ) -> Quantity[float]: ...
+        # Unit / <Magnitude> or Quantity[<Magnitude>]
+        #   -> Quantity[type of 1 / <Magnitude>]
+        @overload
+        def __truediv__[U: Magnitude](
+            self,
+            other: Quantity[opt.CanRTruediv[int, U]] | opt.CanRTruediv[int, U],
+        ) -> Quantity[U]: ...
+
 
 class GenericUnitRegistry[QuantityT: _Quantity, UnitT: _Unit](
     facets.GenericSystemRegistry[QuantityT, UnitT],

--- a/pint/testsuite/test_unit.py
+++ b/pint/testsuite/test_unit.py
@@ -7,6 +7,7 @@ import math
 import operator
 import re
 from contextlib import nullcontext as does_not_raise
+from typing import assert_type
 
 import pytest
 
@@ -199,6 +200,8 @@ class TestUnit(QuantityTestCase):
         assert x / 1 == self.Q_(1, "m")
         assert x / 0.5 == self.Q_(2.0, "m")
         assert x / self.Q_(1, "m") == self.Q_(1)
+        assert x / self.U_("s") == self.U_("m / s")
+        assert_type(x / self.U_("s"), UnitRegistry.Unit)
 
     def test_unit_rdiv(self):
         x = self.U_("m")
@@ -214,6 +217,7 @@ class TestUnit(QuantityTestCase):
     def test_unit_pow(self, unit, power_ratio, expectation, expected_unit):
         with expectation:
             x = self.U_(unit)
+            assert_type(x**2, UnitRegistry.Unit)
             assert x**power_ratio == self.U_(expected_unit)
 
     def test_is_compatible_with(self):


### PR DESCRIPTION
`PlainUnit.__truediv__` is not annotated, so `ureg.meter / ureg.second` is inferred as `Unit | PlainQuantity[float] | Unknown` (pyright) or `Unknown` (ty), although the runtime returns a `Unit`.

`PlainUnit.__mul__` was typed in #2243, reverted in #2247, and typed again in #2373, but so far `PlainUnit.__truediv__` was omitted. This patch adds overloads for `__truediv__` mirroring `__mul__` and reuses `optype` like in `PlainQuantity.__truediv__`.

`PlainQuantity[float]` is used because `ureg.meter / 2` has a magnitude of `0.5`, and `__mul__`'s  `[T: Magnitude] -> PlainQuantity[T]` would make it an `int`. `__mul__`'s `str` overload was not copied, because unlike `Unit * "second"`, `Unit / "second"` raises `TypeError`.

`registry.Unit` gets the same overloads under `if TYPE_CHECKING` as `__mul__`, so that `/` also hands back a `Quantity` where `*` does. Without them `ureg.meter / 2` reads as `PlainQuantity[float]` while `ureg.meter * 2` reads as `Quantity[int]`.

`__pow__`, `__copy__` and `__deepcopy__` each build their result with `self.__class__(...)` but declare `PlainUnit`, so a subclass -- which is what every registry hands out -- is widened away to the plain base. `PlainQuantity.__copy__` and `__deepcopy__` already return `Self`.

---

- [x] Related issues/PRs:
  - #2302
  - #2303
  - #2404
  - #2243
  - #2247
  - #2373
- [x] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

---

This is what I did to get the typing errors in my codebase fixed and come up with a working upstreamable solution, but I'm otherwise very unfamiliar with this project, so I apologize if something in my PR breaks your customs.
