### PR TITLE
Give `UnitRegistry`'s magnitude parameter a default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Pint Changelog
 -----------------
 
 - Fix `UnitRegistry(system="imperial")` returning US units instead of imperial ones for shared names like `gallon` or `pint` (#2408)
+- Give `UnitRegistry`'s magnitude type parameter a default, so `ureg = UnitRegistry()` needs no annotation (#2245)
 
 
 0.26.0 (2026-09-10)
@@ -28,7 +29,6 @@ Pint Changelog
   initializing a `Quantity` with a `datetime.timedelta` value.  (#1978)
 - Improve type annotations for `Quantity` (#2302, #2303)
 - Improve type annotations for `Quantity`'s `__new__` and document support for arithmetic with `datetime.timedelta` introduced in #2348 at the typing level (#2373)
-- Give `UnitRegistry`'s magnitude type parameter a default, so `ureg = UnitRegistry()` needs no annotation (#2245)
 
 ### Formatting changes
 

--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,7 @@ Pint Changelog
   initializing a `Quantity` with a `datetime.timedelta` value.  (#1978)
 - Improve type annotations for `Quantity` (#2302, #2303)
 - Improve type annotations for `Quantity`'s `__new__` and document support for arithmetic with `datetime.timedelta` introduced in #2348 at the typing level (#2373)
+- Give `UnitRegistry`'s magnitude type parameter a default, so `ureg = UnitRegistry()` needs no annotation (#2245)
 
 ### Formatting changes
 

--- a/pint/registry.py
+++ b/pint/registry.py
@@ -55,6 +55,7 @@ else:
 MagnitudeT_co = TypeVar(
     "MagnitudeT_co", covariant=True, bound="Magnitude", default="Any"
 )
+MagnitudeT = TypeVar("MagnitudeT", bound="Magnitude", default="Any")
 
 
 class Quantity(
@@ -451,8 +452,8 @@ class GenericUnitRegistry[QuantityT: _Quantity, UnitT: _Unit](
     pass
 
 
-class UnitRegistry[MagnitudeT: Magnitude](
-    GenericUnitRegistry[Quantity[MagnitudeT], Unit]
+class UnitRegistry(
+    GenericUnitRegistry[Quantity[MagnitudeT], Unit], Generic[MagnitudeT]
 ):
     """The unit registry stores the definitions and relationships between units.
 


### PR DESCRIPTION
`ureg = UnitRegistry()` leaves `MagnitudeT` unsolved, so mypy asks for an annotation on the first line of the tutorial. The 0.25.1 revert cleared the second error of the #2245 reproducer, but not this one, which is still there on 0.25.3 and 0.26.0rc0.

`MagnitudeT_co` in the same file is already declared with `default="Any"`, so this patch spells the registry's parameter the same way. A PEP 696 default in the PEP 695 parameter list would need Python 3.13.

- [x] Closes #2245, relates to #2306
- [x] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
