### PR TITLE
Fix UnitRegistry(system="imperial") returning US units

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Pint Changelog
 0.26.1 (unreleased)
 -----------------
 
-- No changes yet.
+- Fix `UnitRegistry(system="imperial")` returning US units instead of imperial ones for shared names like `gallon` or `pint` (#2408)
 
 
 0.26.0 (2026-09-10)

--- a/pint/facets/system/registry.py
+++ b/pint/facets/system/registry.py
@@ -113,6 +113,24 @@ class GenericSystemRegistry[QuantityT: Quantity, UnitT: Unit](
 
         self._default_system_name = name
 
+    def __getattr__(self, item: str) -> UnitT:
+        """Get a unit by name, considering the default system if set.
+
+        If a default system is set, try to get the system-specific variant
+        of the unit first (e.g., "imperial_gallon" if system is "imperial"
+        and item is "gallon"). Fall back to the parent implementation if
+        not found or if no default system is set.
+        """
+        # If a default system is set, try system-specific unit first
+        if self._default_system_name:
+            system_specific_name = f"{self._default_system_name}_{item}"
+            # Check if the system-specific unit exists in the registry
+            if system_specific_name in self._units:
+                return super().__getattr__(system_specific_name)
+
+        # Fall back to parent implementation
+        return super().__getattr__(item)
+
     def get_system(self, name: str, create_if_needed: bool = True) -> objects.System:
         """Return a Group.
 

--- a/pint/testsuite/test_systems.py
+++ b/pint/testsuite/test_systems.py
@@ -290,3 +290,55 @@ class TestSystem(QuantityTestCase):
         ureg = self.ureg
         for name in dir(ureg.sys):
             dir(getattr(ureg.sys, name))
+
+    def test_issue2048_imperial_system_units(self):
+        """Test that UnitRegistry(system="imperial") correctly returns imperial units.
+
+        When creating a registry with system="imperial", accessing units like
+        gallon or pint should return the imperial variants, not the US variants.
+        This test reproduces the bug reported in issue #2048.
+        """
+        # Create registries with different systems
+        imperial_reg = UnitRegistry(system="imperial")
+        us_reg = UnitRegistry(system="US")
+        plain_reg = UnitRegistry()
+
+        # Test that imperial_reg correctly identifies its system
+        assert imperial_reg.default_system == "imperial"
+        assert us_reg.default_system == "US"
+
+        # Test pint volumes
+        imp_reg_pint = 1 * imperial_reg.pint
+        us_reg_pint = 1 * us_reg.pint
+        plain_imp_pint = 1 * plain_reg.sys.imperial.pint
+        plain_us_pint = 1 * plain_reg.sys.US.pint
+
+        # Convert to a common unit (litre) to compare
+        imp_pint_litres = imp_reg_pint.to("litre").magnitude
+        us_pint_litres = us_reg_pint.to("litre").magnitude
+        plain_imp_pint_litres = plain_imp_pint.to("litre").magnitude
+        plain_us_pint_litres = plain_us_pint.to("litre").magnitude
+
+        # The imperial_reg.pint should match plain_reg.sys.imperial.pint
+        assert abs(imp_pint_litres - plain_imp_pint_litres) < 1e-8
+        assert abs(us_pint_litres - plain_us_pint_litres) < 1e-8
+        # And they should be different from each other
+        assert abs(imp_pint_litres - us_pint_litres) > 0.01
+
+        # Test gallon volumes
+        imp_reg_gallon = 1 * imperial_reg.gallon
+        us_reg_gallon = 1 * us_reg.gallon
+        plain_imp_gallon = 1 * plain_reg.sys.imperial.gallon
+        plain_us_gallon = 1 * plain_reg.sys.US.gallon
+
+        # Convert to a common unit (litre) to compare
+        imp_gallon_litres = imp_reg_gallon.to("litre").magnitude
+        us_gallon_litres = us_reg_gallon.to("litre").magnitude
+        plain_imp_gallon_litres = plain_imp_gallon.to("litre").magnitude
+        plain_us_gallon_litres = plain_us_gallon.to("litre").magnitude
+
+        # The imperial_reg.gallon should match plain_reg.sys.imperial.gallon
+        assert abs(imp_gallon_litres - plain_imp_gallon_litres) < 1e-8
+        assert abs(us_gallon_litres - plain_us_gallon_litres) < 1e-8
+        # And they should be different from each other
+        assert abs(imp_gallon_litres - us_gallon_litres) > 0.5


### PR DESCRIPTION
Fixes #2048.

When a registry is created with `system="imperial"`, accessing units like `gallon` or `pint` through it returns the US variant instead of the imperial one. `__getattr__` on `GenericSystemRegistry` wasn't considering the registry's default system when resolving a bare unit name.

This adds a check: if a default system is set, look for a `<system>_<unit>` variant first (e.g. `imperial_gallon`) before falling back to the plain name.

Added a regression test in `test_systems.py` comparing `UnitRegistry(system="imperial").gallon` against `UnitRegistry().sys.imperial.gallon` (and the same for `pint`/US), confirming they now match and differ from the US variants.