### PR TITLE
Fix np.sum/np.nansum not converting a Quantity initial value

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -63,6 +63,7 @@ Pint Changelog
 - Fix `Unit.__eq__` when comparing with strings using unit aliases (e.g. `Unit('metre') == 'meter'`) (#634)
 - Fix `@alias` raising a bare `KeyError` on prefixed unit targets (#1076, #1447)
 - Fix `parse_units` cache never being hit for symbol and prefixed spellings (e.g. `kg`, `kWh`, `ms`), making those very common lookups re-parse on every call (#2320)
+- Fix `numpy.sum`/`numpy.nansum` treating a Quantity `initial` as a bare magnitude instead of converting it to the input's units, unlike `numpy.max`/`numpy.min` which already convert it correctly (#2400)
 - Fix NumPy ufunc mul/div paths allowing offset units to bypass `OffsetUnitCalculusError` (#1335)
 
 

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Pint Changelog
 0.26.2 (unreleased)
 -------------------
 
-- No changes yet.
+- Fix `numpy.sum`/`numpy.nansum` not converting a Quantity `initial` value, unlike `numpy.max`/`numpy.min` (#2400)
 
 
 0.26.1 (2026-09-10)
@@ -76,7 +76,6 @@ Pint Changelog
 - Fix `Unit.__eq__` when comparing with strings using unit aliases (e.g. `Unit('metre') == 'meter'`) (#634)
 - Fix `@alias` raising a bare `KeyError` on prefixed unit targets (#1076, #1447)
 - Fix `parse_units` cache never being hit for symbol and prefixed spellings (e.g. `kg`, `kWh`, `ms`), making those very common lookups re-parse on every call (#2320)
-- Fix `numpy.sum`/`numpy.nansum` treating a Quantity `initial` as a bare magnitude instead of converting it to the input's units, unlike `numpy.max`/`numpy.min` which already convert it correctly (#2400)
 - Fix NumPy ufunc mul/div paths allowing offset units to bypass `OffsetUnitCalculusError` (#1335)
 
 

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -317,6 +317,13 @@ def implement_func(func_type, func_str, input_units=None, output_unit=None):
             )
 
         first_input_units = _get_first_input_units(args, kwargs)
+        if input_units is None and _is_quantity(kwargs.get("initial")):
+            # np.sum/np.nansum accept an `initial` value that gets added to the
+            # reduction; unlike amax/amin (handled elsewhere, see
+            # implement_consistent_units_by_argument), this path strips units
+            # without converting, so a Quantity `initial` would otherwise be
+            # added as a bare magnitude in whatever unit it happens to carry.
+            kwargs = {**kwargs, "initial": kwargs["initial"].m_as(first_input_units)}
         if input_units == "all_consistent":
             # Match all input args/kwargs to same units
             stripped_args, stripped_kwargs = convert_to_consistent_units(

--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -318,11 +318,7 @@ def implement_func(func_type, func_str, input_units=None, output_unit=None):
 
         first_input_units = _get_first_input_units(args, kwargs)
         if input_units is None and _is_quantity(kwargs.get("initial")):
-            # np.sum/np.nansum accept an `initial` value that gets added to the
-            # reduction; unlike amax/amin (handled elsewhere, see
-            # implement_consistent_units_by_argument), this path strips units
-            # without converting, so a Quantity `initial` would otherwise be
-            # added as a bare magnitude in whatever unit it happens to carry.
+            # Unlike amax/amin, this path doesn't convert a Quantity `initial`.
             kwargs = {**kwargs, "initial": kwargs["initial"].m_as(first_input_units)}
         if input_units == "all_consistent":
             # Match all input args/kwargs to same units

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -355,6 +355,16 @@ class TestNumpyMathematicalFunctions(TestNumpyMethods):
             np.nansum(self.q_nan, axis=0), [4, 2] * self.ureg.m
         )
 
+    def test_sum_with_initial_arg(self):
+        # a Quantity `initial` should be converted, not added as a bare magnitude
+        # (https://github.com/hgrecco/pint/issues/2400)
+        assert np.sum(self.q, initial=100 * self.ureg.cm) == 11 * self.ureg.m
+        with pytest.raises(DimensionalityError):
+            np.sum(self.q, initial=1 * self.ureg.s)
+
+    def test_nansum_with_initial_arg(self):
+        assert np.nansum(self.q_nan, initial=100 * self.ureg.cm) == 7 * self.ureg.m
+
     def test_cumprod(self):
         with pytest.raises(DimensionalityError):
             self.q.cumprod()


### PR DESCRIPTION
Closes #2400.

`np.max`/`np.min` (and `np.amax`/`np.amin`) already convert a Quantity `initial` argument to the input array's units before running the reduction, so `np.max(q, initial=100 * ureg.cm)` works correctly. `np.sum` and `np.nansum` go through a different registration path that strips units without converting anything, so the same call silently treats `initial` as a bare magnitude in whatever unit it happens to carry:

```python
q = [1, 2] * ureg.m
np.sum(q, initial=100 * ureg.cm)   # 103 meter, should be 4 meter
np.sum(q, initial=1 * ureg.s)      # 4 meter, should raise DimensionalityError
```

The fix converts a Quantity `initial` kwarg to the array's units right where `first_input_units` is already computed, mirroring what the max/min path does, and only touches this one narrow case (functions registered with `input_units=None`, gated on `initial` actually being a Quantity kwarg). Everything else that goes through the same generic dispatch keeps working exactly as before, verified by running the full test suite with and without the change.

As a smaller, known follow-up: the positional form mentioned in the issue (`np.sum(q, None, None, None, False, 100 * ureg.cm)`) isn't covered by this fix, since that would need binding the call against `numpy.sum`'s actual signature rather than a narrow kwarg check, which felt like more surface area than this fix needed. Happy to look at that separately if it's wanted.

Added two regression tests (`test_sum_with_initial_arg`, `test_nansum_with_initial_arg`) that fail on master and pass with the fix.