### PR TITLE
Run the two assertions in test_compat_upcast, one of which had gone stale

### DIFF
--- a/pint/testsuite/test_compat_upcast.py
+++ b/pint/testsuite/test_compat_upcast.py
@@ -38,7 +38,7 @@ def ds():
 def test_xarray_quantity_creation(module_registry, q_base):
     with pytest.raises(TypeError) as exc:
         module_registry.Quantity(xr.DataArray(np.arange(4)), "m")
-        assert "Quantity cannot wrap upcast type" in str(exc)
+    assert "Quantity cannot wrap upcast type" in str(exc.value)
     assert xr.DataArray(q_base).data is q_base
 
 
@@ -124,7 +124,7 @@ def test_dataarray_inequalities(da, module_registry):
     )
     with pytest.raises(ValueError) as exc:
         da > 2
-        assert "Cannot compare Quantity and <class 'int'>" in str(exc)
+    assert "Cannot compare PlainQuantity and <class 'int'>" in str(exc.value)
 
 
 def test_array_function_deferral(da, module_registry):


### PR DESCRIPTION
Two assertions in `test_compat_upcast.py` sit inside the `with pytest.raises(...)` block, after the statement that raises, so neither has ever run.

One of them had gone stale without anyone noticing. Once it executes it fails:

```
assert "Cannot compare Quantity and <class 'int'>" in "Cannot compare PlainQuantity and <class 'int'>"
```

The message in `pint/facets/plain/quantity.py:1750` is a literal `f"Cannot compare PlainQuantity and {type(other)}"`, so the expectation in the test has never matched it. Updated the test to the actual message rather than touching the message itself, since what a user should see there (`Quantity` or `PlainQuantity`) is your call, not a test fix. Happy to change the message instead if you prefer it to say `Quantity`.

Also switched `str(exc)` to `str(exc.value)`. `exc` is the `ExceptionInfo` wrapper, whose `str()` is `<ExceptionInfo ValueError(...) tblen=8>`; the substring checks happened to survive that because the repr embeds the message, but `exc.value` is what was meant.

`pint/testsuite/test_compat_upcast.py`: 21 passed. Both assertions are now live: replacing either expected string with wrong text fails the run, which it did not before this change. `ruff check` and `ruff format` clean.

I did not add a CHANGES entry, since this is test-only and that file is user-facing. Say the word and I will add one.

Found with an AST scan for assertions positioned after the raising statement inside a `pytest.raises` block.

This PR was written with AI assistance (Claude Code), including the scan and the verification above.
