### PR TITLE
Fix CI installing numpy matrix pin outside the pixi env on Windows/macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,7 @@ jobs:
           - test-py314
         numpy: [null, "numpy>=2.0.0,<2.1.0", "numpy>=2.4.0"]
         exclude:
-          # numpy 2.0.x has no cp313/cp314 wheels and doesn't support these
-          # Pythons, so pip would have to build it from sdist, which fails.
+          # numpy 2.0.x predates Python 3.13/3.14
           - environment: test-py313
             numpy: "numpy>=2.0.0,<2.1.0"
           - environment: test-py314

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,15 +99,25 @@ jobs:
           - test-py313
           - test-py314
         numpy: [null, "numpy>=2.0.0,<2.1.0", "numpy>=2.4.0"]
+        exclude:
+          # numpy 2.0.x has no cp313/cp314 wheels and doesn't support these
+          # Pythons, so pip would have to build it from sdist, which fails.
+          - environment: test-py313
+            numpy: "numpy>=2.0.0,<2.1.0"
+          - environment: test-py314
+            numpy: "numpy>=2.0.0,<2.1.0"
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
           environments: ${{ matrix.environment }}
+          activate-environment: true
           log-level: vvv
+      - name: Install pip
+        run: pixi add pip
       - name: Install numpy
         if: ${{ matrix.numpy != null }}
-        run: pip install "${{matrix.numpy}}"
+        run: pixi run -e ${{ matrix.environment }} pip install "${{matrix.numpy}}"
       - run: pixi run --environment ${{ matrix.environment }} test
 
   test-macos:
@@ -124,10 +134,13 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
           environments: ${{ matrix.environment }}
+          activate-environment: true
           log-level: vvv
+      - name: Install pip
+        run: pixi add pip
       - name: Install numpy
         if: ${{ matrix.numpy != null }}
-        run: pip install "${{matrix.numpy}}"
+        run: pixi run -e ${{ matrix.environment }} pip install "${{matrix.numpy}}"
       - run: pixi run --environment ${{ matrix.environment }} test
 
   publish:

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Pint Changelog
 
 - Fix `numpy.sum`/`numpy.nansum` not converting a Quantity `initial` value, unlike `numpy.max`/`numpy.min` (#2400)
 - Fix `Quantity.to_compact()` raising `OffsetUnitCalculusError` for offset units like `degree_Celsius` with magnitude below 1 (#2005)
+- Fix CI installing the numpy matrix pin outside the pixi env on Windows/macOS, so those legs ran the no-numpy test suite (#2402)
 
 
 0.26.1 (2026-09-10)


### PR DESCRIPTION
## Summary

- `test-windows` and `test-macos` installed the matrix numpy pin with a bare `pip install`, which targets the runner's system Python. pytest actually runs inside the pixi environment, so those environments never received numpy — every numpy-labeled Windows/macOS leg silently ran the exact no-numpy test suite (identical pass/skip counts to its no-numpy twin).
- #2304 already fixed this for `test-linux` by installing in-env (`pixi run -e ... pip install ...`), but never propagated the fix to `test-windows`/`test-macos`.
- This PR mirrors #2304's in-env install to `test-windows` and `test-macos`, and excludes `numpy>=2.0.0,<2.1.0` on Windows py313/py314, since numpy 2.0.x has no cp313/cp314 wheels and the sdist build crashes at `import numpy` (Windows fatal access violation) — that matrix combination was never actually testable.
- Also adds a CHANGES entry.

Fixes #2402

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses cleanly
- [ ] CI run on this PR should show the numpy suite actually executing on Windows/macOS (pass/skip counts matching the Linux numpy legs, not the no-numpy legs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)