### PR TITLE
Fix np.sum accepting bare numeric initial (#2401)

### DIFF
--- a/pint/facets/numpy/numpy_func.py
+++ b/pint/facets/numpy/numpy_func.py
@@ -317,9 +317,19 @@ def implement_func(func_type, func_str, input_units=None, output_unit=None):
             )
 
         first_input_units = _get_first_input_units(args, kwargs)
-        if input_units is None and _is_quantity(kwargs.get("initial")):
-            # Unlike amax/amin, this path doesn't convert a Quantity `initial`.
-            kwargs = {**kwargs, "initial": kwargs["initial"].m_as(first_input_units)}
+        if input_units is None and kwargs.get("initial") is not None:
+            initial = kwargs["initial"]
+            if _is_quantity(initial):
+                # Unlike amax/amin, this path doesn't convert via
+                # convert_to_consistent_units.
+                kwargs = {**kwargs, "initial": initial.m_as(first_input_units)}
+            elif not isinstance(initial, bool) and not zero_or_nan(
+                initial, True
+            ):
+                # Match amax/amin: a bare non-zero numeric is dimensionless and
+                # must raise when the array has dimensions (#2401).
+                if not first_input_units.dimensionless:
+                    raise DimensionalityError("dimensionless", first_input_units)
         if input_units == "all_consistent":
             # Match all input args/kwargs to same units
             stripped_args, stripped_kwargs = convert_to_consistent_units(

--- a/pint/testsuite/test_numpy.py
+++ b/pint/testsuite/test_numpy.py
@@ -361,9 +361,15 @@ class TestNumpyMathematicalFunctions(TestNumpyMethods):
         assert np.sum(self.q, initial=100 * self.ureg.cm) == 11 * self.ureg.m
         with pytest.raises(DimensionalityError):
             np.sum(self.q, initial=1 * self.ureg.s)
+        # bare non-zero numeric must raise like np.max (#2401); zero still ok
+        with pytest.raises(DimensionalityError):
+            np.sum(self.q, initial=100)
+        assert np.sum(self.q, initial=0) == 10 * self.ureg.m
 
     def test_nansum_with_initial_arg(self):
         assert np.nansum(self.q_nan, initial=100 * self.ureg.cm) == 7 * self.ureg.m
+        with pytest.raises(DimensionalityError):
+            np.nansum(self.q_nan, initial=100)
 
     def test_cumprod(self):
         with pytest.raises(DimensionalityError):


### PR DESCRIPTION
## Summary
- Make `np.sum` / `np.nansum` reject a bare non-zero numeric `initial` when the array has dimensions, matching `np.max` and quantity addition (#2401).
- Zero and Quantity `initial` values keep working as before (#2400 path unchanged).

## Test plan
- [x] `pytest pint/testsuite/test_numpy.py -k 'sum_with_initial or nansum_with_initial or max_with_initial'`
- [x] `pytest pint/testsuite/test_numpy.py pint/testsuite/test_numpy_func.py` (217 passed)

Closes #2401