### PR TITLE
Fix `1 * unit` skipping auto_reduce_dimensions and autoconvert_to_preferred

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ Pint Changelog
 - Fix `Quantity.to_compact()` raising `OffsetUnitCalculusError` for offset units like `degree_Celsius` with magnitude below 1 (#2005)
 - Fix CI installing the numpy matrix pin outside the pixi env on Windows/macOS, so those legs ran the no-numpy test suite (#2402)
 - Fix `to_preferred` raising a spurious `DimensionalityError` for some preferred units (#2395)
+- Fix `1 * unit` skipping `auto_reduce_dimensions` and `autoconvert_to_preferred`, so it disagreed with every other magnitude (#2403)
 
 
 0.26.1 (2026-09-10)

--- a/pint/facets/plain/unit.py
+++ b/pint/facets/plain/unit.py
@@ -170,7 +170,16 @@ class PlainUnit(PrettyIPython, SharedRegistryObject):
                 return qself * other
 
         if isinstance(other, Number) and other == 1:
-            return self._REGISTRY.Quantity(other, self._units)
+            # Multiplying by 1 is shortcut here because non-multiplicative units
+            # (e.g. degC) cannot go through the multiplication below. Apply the
+            # conversions that `ireduce_dimensions` would have applied on that
+            # path, so that `1 * ureg.deg` and `2 * ureg.deg` agree.
+            qty = self._REGISTRY.Quantity(other, self._units)
+            if self._REGISTRY.autoconvert_to_preferred:
+                qty.ito_preferred()
+            if self._REGISTRY.auto_reduce_dimensions:
+                qty.ito_reduced_units()
+            return qty
 
         return self._REGISTRY.Quantity(1, self._units) * other
 

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1758,3 +1758,37 @@ def test_negative_magnitude_pretty_exponent_leaves_arrays_alone():
         formatted = f"{ureg.Quantity(np.array(values), 'meter'):P}"
         assert "×10" not in formatted
         assert formatted == f"{ureg.Quantity(np.array(values), 'meter'):}"
+
+
+def test_issue2403_unity_multiplication_reduces_dimensions():
+    # A magnitude of 1 is shortcut in PlainUnit.__mul__ because non-multiplicative
+    # units cannot go through the multiplication. That shortcut used to skip the
+    # reduction every other magnitude gets.
+    ureg = UnitRegistry(auto_reduce_dimensions=True)
+
+    assert (2 * ureg.deg).units == ureg.dimensionless
+    assert (1 * ureg.deg).units == ureg.dimensionless
+    assert (ureg.deg * 1).units == ureg.dimensionless
+    assert (1.0 * ureg.deg).units == ureg.dimensionless
+    assert (1 * ureg.deg).magnitude == pytest.approx(math.radians(1))
+
+    # Units that do not reduce keep their units, and the shortcut still carries
+    # non-multiplicative units, which cannot be multiplied at all.
+    assert (1 * ureg.foot).units == ureg.foot
+    assert (1 * ureg.degC).units == ureg.degC
+
+
+def test_issue2403_unity_multiplication_converts_to_preferred():
+    ureg = UnitRegistry(autoconvert_to_preferred=True)
+    ureg.default_preferred_units = [ureg.m, ureg.s]
+
+    assert (2 * ureg.km).units == ureg.m
+    assert (1 * ureg.km).units == ureg.m
+
+
+def test_issue2403_unity_multiplication_default_registry_unchanged():
+    ureg = UnitRegistry()
+
+    assert (1 * ureg.deg).units == ureg.deg
+    assert (2 * ureg.deg).units == ureg.deg
+    assert (1 * ureg.degC).units == ureg.degC


### PR DESCRIPTION
Closes #2403.

`PlainUnit.__mul__` shortcuts a magnitude of 1 and returns the Quantity directly, because non-multiplicative units such as `degC` cannot go through the multiplication below it (`2 * ureg.degC` raises `OffsetUnitCalculusError`). Every other magnitude goes through `PlainQuantity._mul_div`, which is wrapped in `ireduce_dimensions`, so the two disagreed:

```python
>>> u = pint.UnitRegistry(auto_reduce_dimensions=True)
>>> 1 * u.deg
<Quantity(1, 'degree')>
>>> 2 * u.deg
<Quantity(0.034906585, 'dimensionless')>
```

The same split applies to `autoconvert_to_preferred` (with preferred units `[m, s]`, `1 * u.km` stayed kilometre while `2 * u.km` became 2000 metre), and to the mirrored forms, since `__rmul__ = __mul__`:

| with `auto_reduce_dimensions=True` | before | after |
|---|---|---|
| `1 * u.deg`, `u.deg * 1`, `1.0 * u.deg` | degree | dimensionless |
| `2 * u.deg`, `u.deg * 2` | dimensionless | dimensionless |

This keeps the shortcut, which offset units still need, and applies the same two conversions `ireduce_dimensions` applies on the other path.

The shortcut dates from 2016 (aa0ca318) and `auto_reduce_dimensions` arrived in 2017 (fde78355), so the exemption looks accidental rather than intended. `test_nocoerce_creation` still passes: it asserts `(1 * ureg.foot).units == ureg.foot`, and `foot` does not reduce, so only genuinely dimensionless units like `degree` change.

### Testing

Added three tests in `pint/testsuite/test_issues.py`. Two of them fail on master and pass with the change; the third guards the default registry, where nothing should change. They also cover `u.deg * 1`, the float `1.0`, `1 * ureg.foot` (unchanged), and `1 * ureg.degC` (the offset unit the shortcut exists for).

Full suite on Python 3.14 with numpy 2.5.3: 2300 passed, 142 skipped, 11 xfailed, no failures. `ruff format` and `ruff check` are clean on the changed files. I could not run `pre-commit run --all-files` as the hooks shell out to `pixi`, which I do not have installed, so I ran ruff directly instead.

### Note, not addressed here

`__rtruediv__` returns `Quantity(other, 1 / self._units)` for any numeric, so `1 / u.deg` and `2 / u.deg` both stay `1 / degree` and never reduce, while `u.deg / 1` and `u.deg / 2` do. That looked like a separate decision from the reported issue, so I left it alone. Happy to extend this PR if you would like it fixed too.
