### PR TITLE
Fix fathom to equal two international yards

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Pint Changelog
 0.26.2 (unreleased)
 -------------------
 
+- Fix `fathom` to equal two international yards; retain the survey-era value as `survey_fathom` and preserve `cables_length` (#2397)
 - Fix `numpy.sum`/`numpy.nansum` not converting a Quantity `initial` value, unlike `numpy.max`/`numpy.min` (#2400)
 - Fix `Quantity.to_compact()` raising `OffsetUnitCalculusError` for offset units like `degree_Celsius` with magnitude below 1 (#2005)
 - Fix CI installing the numpy matrix pin outside the pixi env on Windows/macOS, so those legs ran the no-numpy test suite (#2402)

--- a/pint/default_en.txt
+++ b/pint/default_en.txt
@@ -557,6 +557,9 @@ neper = 1 ; logbase: 2.71828182845904523536028747135266249775724709369995; logfa
     hand = 4 * inch
     foot = yard / 3 = ft = international_foot = feet = international_feet
     yard = 0.9144 * meter = yd = international_yard  # since Jul 1959
+    # Exactly 2 international yards (6 international feet). Survey-era
+    # fathoms remain available as survey_fathom.
+    fathom = 6 * foot
     mile = 1760 * yard = mi = international_mile
 
     circular_mil = π / 4 * mil_length ** 2 = cmil
@@ -573,11 +576,11 @@ neper = 1 ; logbase: 2.71828182845904523536028747135266249775724709369995; logfa
 @group USCSLengthSurvey
     link = 1e-2 * chain = li = survey_link
     survey_foot = 1200 / 3937 * meter = sft
-    fathom = 6 * survey_foot
+    survey_fathom = 6 * survey_foot
     rod = 16.5 * survey_foot = rd = pole = perch
     chain = 4 * rod
     furlong = 40 * rod = fur
-    cables_length = 120 * fathom
+    cables_length = 120 * survey_fathom
     survey_mile = 5280 * survey_foot = smi = us_statute_mile
     league = 3 * survey_mile
 

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1758,3 +1758,12 @@ def test_negative_magnitude_pretty_exponent_leaves_arrays_alone():
         formatted = f"{ureg.Quantity(np.array(values), 'meter'):P}"
         assert "×10" not in formatted
         assert formatted == f"{ureg.Quantity(np.array(values), 'meter'):}"
+
+
+def test_issue2397_fathom_is_exact_international_yards():
+    # fathom was defined as 6 * survey_foot, so 1 fathom.to(yard) was ~2.000004.
+    ureg = UnitRegistry(autoconvert_offset_to_baseunit=True)
+    assert (1 * ureg.fathom).to(ureg.yard).magnitude == 2
+    assert (1 * ureg.fathom).to(ureg.foot).magnitude == 6
+    # Survey-era length remains available explicitly.
+    assert (1 * ureg.survey_fathom).to(ureg.survey_foot).magnitude == 6

--- a/pint/testsuite/test_issues.py
+++ b/pint/testsuite/test_issues.py
@@ -1760,10 +1760,12 @@ def test_negative_magnitude_pretty_exponent_leaves_arrays_alone():
         assert formatted == f"{ureg.Quantity(np.array(values), 'meter'):}"
 
 
-def test_issue2397_fathom_is_exact_international_yards():
+def test_issue2397_fathom_is_exact_international_yards(sess_registry):
     # fathom was defined as 6 * survey_foot, so 1 fathom.to(yard) was ~2.000004.
-    ureg = UnitRegistry(autoconvert_offset_to_baseunit=True)
+    ureg = sess_registry
     assert (1 * ureg.fathom).to(ureg.yard).magnitude == 2
     assert (1 * ureg.fathom).to(ureg.foot).magnitude == 6
     # Survey-era length remains available explicitly.
     assert (1 * ureg.survey_fathom).to(ureg.survey_foot).magnitude == 6
+    # Changing the default fathom must not shorten the existing cable length.
+    assert (1 * ureg.cables_length).to(ureg.survey_foot).magnitude == 720


### PR DESCRIPTION
## Summary

Fixes #2397.

- Define `fathom` as six international feet (exactly two yards).
- Preserve the former survey definition as `survey_fathom` and keep `cables_length` numerically unchanged by expressing it in survey fathoms.
- Add regression coverage for international conversions and the preserved cable length, plus a CHANGES entry.

## Validation

An independent Astra High review inspected the change and completed the following checks in an isolated checkout (Python 3.12.3, NumPy 2.5.3):

```sh
python -m pytest pint/testsuite/test_issues.py pint/testsuite/test_systems.py pint/testsuite/test_unit.py pint/testsuite/test_quantity.py --benchmark-skip -ra
ruff check pint/testsuite/test_issues.py
ruff format --check pint/testsuite/test_issues.py
```

Result: **907 passed, 19 skipped, 5 xfailed**, with 6 existing NumPy deprecation warnings. The new regression also passed separately. Direct before/after checks preserve `cables_length` at 219.45643891287781 meters / 720 survey feet.

The optional dependency and Python-version matrix was not run locally. Full repository pre-commit/pixi was not run because those tools were unavailable; scoped Ruff and whitespace checks passed.

## Checklist

- [x] Closes #2397
- [ ] Executed `pre-commit run --all-files` or `pixi run lint --all-files` with no errors (not run; see above)
- [x] The change is covered by automated unit tests
- [x] Documentation addressed through the unit definitions and CHANGES; no separate docs page needed
- [x] Added an entry to the CHANGES file

AI-assisted contribution, separately reviewed and tested by an Astra High subagent.
